### PR TITLE
[CDAP-17870]Partially rewrite ConfigurableTab for ts&css-in-js migration

### DIFF
--- a/app/cdap/components/ConfigurableTab/TabIcon.tsx
+++ b/app/cdap/components/ConfigurableTab/TabIcon.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 import { objectQuery } from 'services/helpers';
 import IconSVG from 'components/IconSVG';
 
-interface IIcon {
+export interface IIcon {
   type: 'font-icon' | 'link' | 'inline';
   arguments: {
     data?: string;

--- a/app/cdap/components/ConfigurableTab/index.tsx
+++ b/app/cdap/components/ConfigurableTab/index.tsx
@@ -13,49 +13,61 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Tabs from '../Tabs';
 import TabHeaders from 'components/Tabs/TabHeaders';
 import TabHead from 'components/Tabs/TabHead';
 import TabGroup from 'components/Tabs/TabGroup';
 import classnames from 'classnames';
-import TabIcon from 'components/ConfigurableTab/TabIcon';
+import TabIcon, { IIcon } from 'components/ConfigurableTab/TabIcon';
 
 require('./ConfigurableTab.scss');
-const TabConfig = PropTypes.shape({
-  name: PropTypes.string,
-  content: PropTypes.node,
-  contentClassName: PropTypes.string,
-  paneClassName: PropTypes.string,
-});
 
-export default class ConfigurableTab extends Component {
-  static propTypes = {
-    onTabClick: PropTypes.func,
-    activeTab: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    tabConfig: PropTypes.shape({
-      tabs: PropTypes.arrayOf(TabConfig),
-      layout: PropTypes.string,
-      defaultTab: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    }),
-  };
+export enum TabLayoutEnum {
+  VERTICAL = 'vertical',
+  HORIZONTAL = 'horizontal',
+}
 
-  componentWillReceiveProps(nextProps) {
-    const newState = { tabs: nextProps.tabConfig.tabs };
+export interface ITabConfig {
+  id?: string | number;
+  name: string;
+  content: React.ReactNode;
+  contentClassName?: string;
+  paneClassName?: string;
+  type?: string;
+  icon?: IIcon;
+  subtabs?: ITabConfig[];
+}
+
+export interface ITabConfigObj {
+  tabs: ITabConfig[];
+  layout: TabLayoutEnum;
+  defaultTab: string | number;
+}
+
+interface IConfigurableTabProps {
+  onTabClick?: (tabId: string) => void;
+  activeTab?: string | number;
+  tabConfig: ITabConfigObj;
+  tabClassName?: string;
+  className?: string;
+}
+export default class ConfigurableTab extends Component<IConfigurableTabProps> {
+  public componentWillReceiveProps(nextProps) {
+    const newState = { tabs: nextProps.tabConfig.tabs, activeTab: this.state.activeTab };
     if (nextProps.activeTab && nextProps.activeTab !== this.state.activeTab) {
       newState.activeTab = nextProps.activeTab;
     }
     this.setState(newState);
   }
 
-  state = {
+  public state = {
     tabs: this.props.tabConfig.tabs,
     layout: this.props.tabConfig.layout,
     activeTab: this.props.activeTab || this.props.tabConfig.defaultTab,
   };
 
-  setTab = (tabId) => {
+  public setTab = (tabId) => {
     this.setState({ activeTab: tabId });
     document.querySelector('.tab-content').scrollTop = 0;
 
@@ -64,11 +76,11 @@ export default class ConfigurableTab extends Component {
     }
   };
 
-  isActiveTab = (tabId) => {
+  public isActiveTab = (tabId) => {
     return this.state.activeTab === tabId;
   };
 
-  render() {
+  public render() {
     let tabs = [];
     this.state.tabs.forEach((tab) => {
       if (tab.type === 'tab-group') {
@@ -77,10 +89,10 @@ export default class ConfigurableTab extends Component {
       }
       tabs.push(tab);
     });
-    let activeTab = tabs.find((tab) => this.state.activeTab === tab.id);
+    const activeTab = tabs.find((tab) => this.state.activeTab === tab.id);
     return (
-      <div className="cask-configurable-tab">
-        <Tabs layout={this.state.layout}>
+      <div className={classnames('cask-configurable-tab', this.props.className)}>
+        <Tabs layout={this.state.layout} className={this.props.tabClassName}>
           <TabHeaders>
             {this.state.tabs.map((tab, index) => {
               if (tab.type === 'tab-group') {
@@ -117,7 +129,6 @@ export default class ConfigurableTab extends Component {
               className={`tab-pane active ${
                 activeTab.paneClassName ? activeTab.paneClassName : ''
               }`}
-              tabid={activeTab.id}
             >
               {activeTab.content}
             </div>

--- a/app/cdap/components/Market/index.js
+++ b/app/cdap/components/Market/index.js
@@ -15,7 +15,7 @@
  */
 
 import React, { Component } from 'react';
-import ConfigurableTab from '../ConfigurableTab';
+import ConfigurableTab from 'components/ConfigurableTab';
 import { MyMarketApi } from 'api/market';
 import MarketAction from './action/market-action.js';
 import find from 'lodash/find';

--- a/app/cdap/components/PluginSchemaEditor/index.tsx
+++ b/app/cdap/components/PluginSchemaEditor/index.tsx
@@ -26,7 +26,11 @@ import LoadingSVG from 'components/LoadingSVG';
 import If from 'components/If';
 import Textbox from 'components/AbstractWidget/FormInputs/TextBox';
 import { RefreshableSchemaEditor } from 'components/PluginSchemaEditor/RefreshableSchemaEditor';
-import ConfigurableTab from 'components/ConfigurableTab';
+import ConfigurableTab, {
+  ITabConfig,
+  ITabConfigObj,
+  TabLayoutEnum,
+} from 'components/ConfigurableTab';
 import classnames from 'classnames';
 import { objectQuery, isNilOrEmptyString } from 'services/helpers';
 import Alert from 'components/Alert';
@@ -481,21 +485,23 @@ class PluginSchemaEditorBase extends React.PureComponent<
       if (typeof s.schema === 'string') {
         content = s.schema;
       }
-      return {
+      const tab: ITabConfig = {
         id: i,
         name: s.name,
         content,
         contentClassName: this.props.classes.tabContent,
         paneClassName: this.props.classes.tabContent,
       };
+      return tab;
     });
+    const tabConfig: ITabConfigObj = {
+      tabs,
+      layout: TabLayoutEnum.HORIZONTAL,
+      defaultTab: 0,
+    };
     const tabProps = {
       activeTab: 0,
-      tabConfig: {
-        tabs,
-        layout: 'horizontal',
-        defaultTab: 0,
-      },
+      tabConfig,
     };
     return <ConfigurableTab activeTab={tabProps.activeTab} tabConfig={tabProps.tabConfig} />;
   };

--- a/app/cdap/components/Tabs/Tabs.scss
+++ b/app/cdap/components/Tabs/Tabs.scss
@@ -35,6 +35,14 @@
       width: calc(100% - 140px);
       display: flex;
     }
+    &.size1-5x {
+      > div {
+        &:first-child {
+          width: 210px;
+        }
+        width: calc(100% - 210px);
+      }
+    }
   }
   &.horizontal {
     > div {

--- a/app/cdap/components/Tabs/index.js
+++ b/app/cdap/components/Tabs/index.js
@@ -21,10 +21,11 @@ var classnames = require('classnames');
 
 require('./Tabs.scss');
 
-export default function Tabs({ layout, children }) {
-  return <div className={classnames('cask-tabs', layout)}>{children}</div>;
+export default function Tabs({ layout, children, className }) {
+  return <div className={classnames('cask-tabs', layout, className)}>{children}</div>;
 }
 Tabs.propTypes = {
   layout: PropTypes.string,
   children: PropTypes.node.isRequired,
+  className: PropTypes.string,
 };


### PR DESCRIPTION
- Transitions js -> tsx
- Adds types for props and state for ConfigurableTab component

**Note:**
- Not doing transition of styles as the `.cask-confiurable-tab` is being used in way more places. The usage of the css class is also complex enough that it warrants a separate change. 
- Since this causes too much of scope creep I am not doing all those in this PR.
- Not migrating Tab and children components for Tab either. We should ideally use Tab from material-ui and customize it in ways we need.
- We don't achieve consistency with this change but this is one step closer towards that.