### PR TITLE
[CDAP-17871] [CDAP-17875] Adds base connections listing + browsing capability with new Connections service

### DIFF
--- a/app/cdap/api/connections.ts
+++ b/app/cdap/api/connections.ts
@@ -33,7 +33,7 @@ const connectionWidgetJSONPath =
 const allConnectorWidgetJSONAndDocPath = '/namespaces/:namespace/artifactproperties';
 
 const pipelineV1AppBasePath =
-  '/namespaces/system/apps/pipeline/services/connection/methods/v1/contexts/:context';
+  '/namespaces/system/apps/pipeline/services/studio/methods/v1/contexts/:context';
 
 export const ConnectionsApi = {
   listConnectors: apiCreator(dataSrc, 'GET', 'REQUEST', connectionsTypePath),
@@ -55,5 +55,12 @@ export const ConnectionsApi = {
     'PUT',
     'REQUEST',
     `${pipelineV1AppBasePath}/connections/:connectionid`
+  ),
+  listConnections: apiCreator(dataSrc, 'GET', 'REQUEST', `${pipelineV1AppBasePath}/connections`),
+  exploreConnection: apiCreator(
+    dataSrc,
+    'GET',
+    'REQUEST',
+    `${pipelineV1AppBasePath}/connections/:connectionid/browse`
   ),
 };

--- a/app/cdap/components/Alert/index.js
+++ b/app/cdap/components/Alert/index.js
@@ -64,7 +64,10 @@ export default class Alert extends Component {
   }
 
   resetTimeout = () => {
-    if (this.state.type === ALERT_STATUS.Success || this.state.type === ALERT_STATUS.Info) {
+    if (
+      (this.state.type === ALERT_STATUS.Success || this.state.type === ALERT_STATUS.Info) &&
+      this.alertTimeout
+    ) {
       clearTimeout(this.alertTimeout);
       this.alertTimeout = setTimeout(this.onClose, CLOSE_TIMEOUT);
     }

--- a/app/cdap/components/ConfigurationGroup/utilities/DynamicPluginFilters.ts
+++ b/app/cdap/components/ConfigurationGroup/utilities/DynamicPluginFilters.ts
@@ -35,7 +35,7 @@ import jexl from 'jexl';
 import difference from 'lodash/difference';
 import flatten from 'lodash/flatten';
 import isPlainObject from 'lodash/isPlainObject';
-import { isMacro, objectQuery, removeEmptyJsonValues } from 'services/helpers';
+import { isMacro, objectQuery } from 'services/helpers';
 
 export interface IFilteredWidgetProperty extends IWidgetProperty {
   show?: boolean;
@@ -220,10 +220,12 @@ export function filterByCondition(
                     }))
                 );
             }
-            return {
-              property: showConfig.name,
-              filterName: f.name,
-            };
+            return [
+              {
+                property: showConfig.name,
+                filterName: f.name,
+              },
+            ];
           })
         );
       };

--- a/app/cdap/components/Connections/Browser/GenericBrowser/apiHelpers.ts
+++ b/app/cdap/components/Connections/Browser/GenericBrowser/apiHelpers.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { ConnectionsApi } from 'api/connections';
+import { getCurrentNamespace } from 'services/NamespaceStore';
+
+export function exploreConnection({ connectionid, path = '/' }) {
+  return ConnectionsApi.exploreConnection({
+    context: getCurrentNamespace(),
+    connectionid,
+    path,
+  }).toPromise();
+}

--- a/app/cdap/components/Connections/Browser/GenericBrowser/index.tsx
+++ b/app/cdap/components/Connections/Browser/GenericBrowser/index.tsx
@@ -1,0 +1,160 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import LoadingSVG from 'components/LoadingSVG';
+import { humanReadableDate, isNilOrEmptyString, objectQuery } from 'services/helpers';
+import { exploreConnection } from 'components/Connections/Browser/GenericBrowser/apiHelpers';
+import * as React from 'react';
+import capitalize from 'lodash/capitalize';
+import If from 'components/If';
+import FolderIcon from '@material-ui/icons/Folder';
+import DescriptionIcon from '@material-ui/icons/Description';
+import makeStyle from '@material-ui/core/styles/makeStyles';
+import Table from 'components/Table';
+import TableHeader from 'components/Table/TableHeader';
+import TableRow from 'components/Table/TableRow';
+import TableCell from 'components/Table/TableCell';
+import TableBody from 'components/Table/TableBody';
+import { getCurrentNamespace } from 'services/NamespaceStore';
+import { useLocation } from 'react-router-dom';
+
+const useStyle = makeStyle(() => {
+  return {
+    nameWrapper: {
+      display: 'flex',
+      gap: '5px',
+    },
+    grid: {
+      height: '100%',
+      marginTop: '15px',
+    },
+    loadingContainer: {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      height: '100%',
+    },
+  };
+});
+
+const ICON_MAP = {
+  directory: <FolderIcon />,
+  file: <DescriptionIcon />,
+};
+
+export function GenericBrowser({ selectedConnection }) {
+  const loc = useLocation();
+  const queryParams = new URLSearchParams(loc.search);
+  const pathFromUrl = queryParams.get('path') || '/';
+  const [entities, setEntities] = React.useState([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState(null);
+  const [path, setPath] = React.useState(pathFromUrl);
+  const classes = useStyle();
+
+  const fetchEntities = async () => {
+    try {
+      const res = await exploreConnection({
+        connectionid: selectedConnection,
+        path,
+      });
+      setEntities(res.entities);
+    } catch (e) {
+      setError(`Failed to explore connection : "${e.message}"`);
+    } finally {
+      setLoading(false);
+    }
+  };
+  const onExplore = (entityName) => {
+    if (path === '/') {
+      setPath(`/${entityName}`);
+    } else {
+      setPath(`${path}/${entityName}`);
+    }
+    setLoading(true);
+  };
+  React.useEffect(() => {
+    if (isNilOrEmptyString(selectedConnection)) {
+      return setLoading(false);
+    }
+    fetchEntities();
+  }, [selectedConnection, path]);
+
+  React.useEffect(() => {
+    const query = new URLSearchParams(loc.search);
+    const urlPath = query.get('path') || '/';
+    if (path !== urlPath) {
+      setPath(urlPath);
+    }
+  }, [loc]);
+  if (loading) {
+    return (
+      <div className={classes.loadingContainer}>
+        <LoadingSVG />
+      </div>
+    );
+  }
+
+  if (error) {
+    throw error;
+  }
+  if (!Array.isArray(entities) || (Array.isArray(entities) && !entities.length)) {
+    return <div>No entities available</div>;
+  }
+  let headers = ['Name', 'Type'];
+  const properties = objectQuery(entities, 0, 'properties') || [];
+  headers = [...headers, ...properties.map((prop) => capitalize(prop.key))];
+  const columnTemplate = headers.map(() => '1fr').join(' ');
+  const getPath = (suffix) => (path === '/' ? `/${suffix}` : `${path}/${suffix}`);
+  return (
+    <Table columnTemplate={columnTemplate} classes={{ grid: classes.grid }}>
+      <TableHeader>
+        <TableRow>
+          {headers.map((header) => {
+            return <TableCell key={header}>{header}</TableCell>;
+          })}
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {entities.map((entity, i) => {
+          return (
+            <TableRow
+              key={i}
+              to={`/ns/${getCurrentNamespace()}/connections/${selectedConnection}?path=${getPath(
+                entity.name
+              )}`}
+              onClick={() => onExplore(entity.name)}
+            >
+              <TableCell>
+                <div className={classes.nameWrapper}>
+                  <If condition={ICON_MAP[entity.type]}>{ICON_MAP[entity.type]}</If>
+                  <div>{entity.name}</div>
+                </div>
+              </TableCell>
+              <TableCell>{entity.type}</TableCell>
+              {entity.properties.map((prop) => {
+                if (prop.type === 'Timestamp') {
+                  return <TableCell key={prop.value}>{humanReadableDate(prop.value)}</TableCell>;
+                }
+                return <TableCell key={prop.value}>{prop.value}</TableCell>;
+              })}
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+}

--- a/app/cdap/components/Connections/Browser/SidePanel/CategorizedConnections.tsx
+++ b/app/cdap/components/Connections/Browser/SidePanel/CategorizedConnections.tsx
@@ -1,0 +1,199 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import MuiAccordion from '@material-ui/core/Accordion';
+import AccordionSummary from '@material-ui/core/AccordionSummary';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import { makeStyles, StyleRules, Theme, withStyles } from '@material-ui/core/styles';
+import { Link } from 'react-router-dom';
+import { getCurrentNamespace } from 'services/NamespaceStore';
+import If from 'components/If';
+import classnames from 'classnames';
+
+interface ICategorizedConnectionsProps {
+  categorizedConnections: Map<string, any[]>;
+  categories: string[];
+  onConnectionSelection: (conn: string) => void;
+  selectedConnection: string;
+}
+const Accordion = withStyles({
+  root: {
+    border: '1px solid rgba(0, 0, 0, .125)',
+    boxShadow: 'none',
+    background: 'transparent',
+    borderRight: 0,
+    '&:not(:last-child)': {
+      borderBottom: 0,
+      borderRight: 0,
+    },
+    '&:before': {
+      display: 'none',
+    },
+    '&$expanded': {
+      margin: 'auto',
+    },
+  },
+  expanded: {},
+})(MuiAccordion);
+
+const CustomAccordionSummary = withStyles((theme) => ({
+  root: {
+    minHeight: `${theme.spacing(4)}px`,
+    '&$expanded': {
+      minHeight: `${theme.spacing(4)}px`,
+    },
+  },
+  content: {
+    '&$expanded': {
+      margin: `${theme.spacing(1.25)}px 0`,
+    },
+  },
+  expanded: {},
+}))(AccordionSummary);
+
+const CustomAccordionDetails = withStyles({
+  root: {
+    padding: 0,
+    gap: '10px',
+    display: 'grid',
+    gridAutoRows: '30px',
+    paddingBottom: '10px',
+  },
+})(AccordionDetails);
+
+const useStyle = makeStyles<Theme>(
+  (theme): StyleRules => {
+    return {
+      connection: {
+        color: 'black',
+        paddingLeft: `${theme.spacing(4)}px`,
+        display: 'flex',
+        alignItems: 'center',
+        '&:hover': {
+          color: 'black',
+          textDecoration: 'none',
+          fontWeight: 600,
+        },
+      },
+      selectedConnection: {
+        background: 'white',
+        color: theme.palette.primary.main,
+        '&:hover': {
+          color: theme.palette.primary.main,
+          fontWeight: 'normal',
+        },
+      },
+    };
+  }
+);
+function getActiveCategory(selectedConnection: string, categorizedConnections: Map<string, any[]>) {
+  const entries = Array.from(categorizedConnections.entries());
+  if (!entries || (Array.isArray(entries) && !entries.length)) {
+    return null;
+  }
+  for (const [category, connectors] of entries) {
+    const isActive = connectors.find((connector) => connector.name === selectedConnection);
+    if (isActive) {
+      return category;
+    }
+  }
+  return null;
+}
+
+export function CategorizedConnections({
+  categorizedConnections = new Map(),
+  categories = [],
+  onConnectionSelection,
+  selectedConnection,
+}: ICategorizedConnectionsProps) {
+  const classes = useStyle();
+  const activeCategory = selectedConnection
+    ? getActiveCategory(selectedConnection, categorizedConnections)
+    : null;
+  const [currentActiveAccordion, setCurrentActiveAccordion] = React.useState(activeCategory);
+  const [localSelectedConnection, setLocalSelectedConnection] = React.useState(selectedConnection);
+
+  const combinedCategorizedConnections = new Map();
+  for (const category of categories) {
+    const connectionExistsInThisCategory = categorizedConnections.has(category);
+    if (connectionExistsInThisCategory) {
+      combinedCategorizedConnections.set(category, categorizedConnections.get(category));
+    } else {
+      combinedCategorizedConnections.set(category, []);
+    }
+  }
+
+  React.useEffect(() => {
+    const currentCategory = selectedConnection
+      ? getActiveCategory(selectedConnection, categorizedConnections)
+      : null;
+    setCurrentActiveAccordion(currentCategory);
+  }, [categorizedConnections]);
+
+  React.useEffect(() => {
+    setLocalSelectedConnection(selectedConnection);
+  }, [selectedConnection]);
+
+  const handleChange = (tabName) => {
+    if (currentActiveAccordion === tabName) {
+      setCurrentActiveAccordion('');
+    } else {
+      setCurrentActiveAccordion(tabName);
+    }
+  };
+
+  return (
+    <div>
+      {Array.from(combinedCategorizedConnections.entries()).map(([key, connections]) => {
+        return (
+          <Accordion
+            square
+            expanded={currentActiveAccordion === key}
+            onChange={() => handleChange(key)}
+            key={key}
+          >
+            <CustomAccordionSummary expandIcon={<ExpandMoreIcon />}>
+              {key}({connections.length})
+            </CustomAccordionSummary>
+            <CustomAccordionDetails>
+              {connections.map((connection) => {
+                return (
+                  <Link
+                    to={`/ns/${getCurrentNamespace()}/connections/${connection.name}?path=/`}
+                    key={connection.name}
+                    onClick={() => onConnectionSelection(connection.name)}
+                    className={classnames(classes.connection, {
+                      [classes.selectedConnection]: localSelectedConnection === connection.name,
+                    })}
+                  >
+                    <If condition={localSelectedConnection === connection.name}>
+                      <strong>{connection.name}</strong>
+                    </If>
+                    <If condition={localSelectedConnection !== connection.name}>
+                      {connection.name}
+                    </If>
+                  </Link>
+                );
+              })}
+            </CustomAccordionDetails>
+          </Accordion>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/cdap/components/Connections/Browser/SidePanel/apiHelpers.ts
+++ b/app/cdap/components/Connections/Browser/SidePanel/apiHelpers.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { ConnectionsApi } from 'api/connections';
+import { getCurrentNamespace } from 'services/NamespaceStore';
+
+function getConnections() {
+  return ConnectionsApi.listConnections({
+    context: getCurrentNamespace(),
+  }).toPromise();
+}
+
+export async function getCategorizedConnections() {
+  let connections;
+  const categorizedConnectionsMap = new Map();
+  try {
+    connections = await getConnections();
+    for (const connection of connections) {
+      const { category } = connection.plugin;
+      let existingConnections = categorizedConnectionsMap.get(category);
+      if (!existingConnections) {
+        existingConnections = [];
+      }
+      categorizedConnectionsMap.set(category, existingConnections.concat(connection));
+    }
+  } catch (e) {
+    // tslint:disable-next-line: no-console
+    console.log('Unable to fetch connections');
+    throw new Error(`Connections fetch failed: ${e.message}`);
+  }
+  return categorizedConnectionsMap;
+}

--- a/app/cdap/components/Connections/Browser/SidePanel/index.tsx
+++ b/app/cdap/components/Connections/Browser/SidePanel/index.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import Paper from '@material-ui/core/Paper';
+import makeStyles from '@material-ui/core/styles/makeStyles';
+import { Theme } from '@material-ui/core';
+import { getCategorizedConnections } from 'components/Connections/Browser/SidePanel/apiHelpers';
+import { CategorizedConnections } from 'components/Connections/Browser/SidePanel/CategorizedConnections';
+import {
+  getCategoriesToConnectorsMap,
+  fetchConnectors,
+} from 'components/Connections/Create/reducer';
+import { CreateConnectionBtn } from 'components/Connections/CreateConnectionBtn';
+import ArrowBackIosIcon from '@material-ui/icons/ArrowBackIos';
+import IconButton from '@material-ui/core/IconButton';
+import { getCurrentNamespace } from 'services/NamespaceStore';
+
+const useStyle = makeStyles<Theme>((theme) => {
+  return {
+    root: {
+      display: 'grid',
+      gridTemplateColumns: '100%',
+      gridTemplateRows: '50px 1fr auto',
+      backgroundColor: theme.palette.grey[600],
+      paddingBottom: `${theme.spacing(1)}px`,
+      overflowY: 'auto',
+    },
+    toggleContainer: {
+      padding: `${theme.spacing(2)}px ${theme.spacing(1)}px`,
+      fontWeight: 'bold',
+      cursor: 'pointer',
+    },
+  };
+});
+
+interface IConnectionsBrowserSidePanelState {
+  categorizedConnections: Map<string, any[]>;
+  categories: string[];
+}
+
+interface IConnectionBrowserSidePanelProps {
+  enableRouting?: boolean;
+  onSidePanelToggle: () => void;
+  onConnectionSelection: (conn: string) => void;
+  selectedConnection: string;
+}
+
+export function ConnectionsBrowserSidePanel({
+  enableRouting,
+  onSidePanelToggle,
+  onConnectionSelection,
+  selectedConnection,
+}: IConnectionBrowserSidePanelProps) {
+  const classes = useStyle();
+  const [state, setState] = React.useState<IConnectionsBrowserSidePanelState>({
+    categorizedConnections: new Map(),
+    categories: [],
+  });
+  const initState = async () => {
+    const categorizedConnections = await getCategorizedConnections();
+    const connectors = await fetchConnectors();
+    const categories = getCategoriesToConnectorsMap(connectors);
+    setState({
+      categorizedConnections,
+      categories: Array.from(categories.keys()),
+    });
+  };
+  React.useEffect(() => {
+    initState();
+  }, []);
+  return (
+    <Paper className={classes.root}>
+      <div className={classes.toggleContainer} onClick={onSidePanelToggle}>
+        <IconButton size="small">
+          <ArrowBackIosIcon fontSize="inherit" />
+        </IconButton>
+        <span> Connections in "{getCurrentNamespace()}" </span>
+      </div>
+      <CategorizedConnections
+        categories={state.categories}
+        categorizedConnections={state.categorizedConnections}
+        onConnectionSelection={onConnectionSelection}
+        selectedConnection={selectedConnection}
+      />
+      <CreateConnectionBtn enableRouting={true} />
+    </Paper>
+  );
+}

--- a/app/cdap/components/Connections/Browser/index.tsx
+++ b/app/cdap/components/Connections/Browser/index.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import Paper from '@material-ui/core/Paper';
+import makeStyles from '@material-ui/core/styles/makeStyles';
+import ArrowForwardIosIcon from '@material-ui/icons/ArrowForwardIos';
+import IconButton from '@material-ui/core/IconButton';
+import { GenericBrowser } from 'components/Connections/Browser/GenericBrowser';
+
+import If from 'components/If';
+import Heading, { HeadingTypes } from 'components/Heading';
+
+const useStyle = makeStyles((theme) => {
+  return {
+    root: {
+      padding: 0,
+      display: 'grid',
+      gridTemplateRows: '50px 1fr',
+      gridTemplateColumns: '100%',
+    },
+    header: {
+      padding: `${theme.spacing(2)}px ${theme.spacing(1)}px`,
+      backgroundColor: theme.palette.grey[600],
+      display: 'flex',
+      alignItems: 'center',
+      gap: `${theme.spacing(1)}px`,
+    },
+    heading: {
+      fontWeight: 'bold',
+      paddingLeft: `${theme.spacing(1)}px`,
+    },
+    browserContainer: {
+      borderTop: '1px solid rgba(0, 0, 0, .125)',
+    },
+  };
+});
+
+export function ConnectionsBrowser({ enableRouting, expanded, onCollapse, selectedConnection }) {
+  const classes = useStyle();
+  return (
+    <Paper className={classes.root}>
+      <div className={classes.header}>
+        <If condition={expanded}>
+          <IconButton onClick={expanded ? onCollapse : undefined} size="small">
+            <ArrowForwardIosIcon fontSize="inherit" />
+          </IconButton>
+        </If>
+        <Heading type={HeadingTypes.h5} label="Select Data" className={classes.heading} />
+      </div>
+      <div className={classes.browserContainer}>
+        <GenericBrowser selectedConnection={selectedConnection} />
+      </div>
+    </Paper>
+  );
+}

--- a/app/cdap/components/Connections/Create/ConnectionConfiguration/ConnectionConfigForm.tsx
+++ b/app/cdap/components/Connections/Create/ConnectionConfiguration/ConnectionConfigForm.tsx
@@ -39,6 +39,7 @@ export function ConnectionConfigForm({
   const [name, setName] = React.useState('');
   const [description, setDescription] = React.useState('');
   const classes = useStyle();
+
   return (
     <div>
       <div>

--- a/app/cdap/components/Connections/Create/index.tsx
+++ b/app/cdap/components/Connections/Create/index.tsx
@@ -29,7 +29,6 @@ import {
   IConnectorDetails,
   fetchConnectionDetails,
   createConnection,
-  ICreateConnectionState,
 } from 'components/Connections/Create/reducer';
 import If from 'components/If';
 import LoadingSVGCentered from 'components/LoadingSVGCentered';
@@ -49,7 +48,7 @@ const useStyle = makeStyle(() => {
     },
   };
 });
-export function CreateConnection({ enableRouting, onRender, onUnmount }) {
+export function CreateConnection({ enableRouting }) {
   const classes = useStyle();
   const [loading, setLoading] = React.useState(true);
   const [state, dispatch] = React.useReducer(reducer, initialState);
@@ -60,7 +59,6 @@ export function CreateConnection({ enableRouting, onRender, onUnmount }) {
     connectorDoc: null,
   });
   const init = async () => {
-    onRender();
     try {
       await initStore(dispatch);
       setLoading(false);
@@ -70,9 +68,6 @@ export function CreateConnection({ enableRouting, onRender, onUnmount }) {
   };
   React.useEffect(() => {
     init();
-    return () => {
-      onUnmount();
-    };
   }, []);
 
   if (state.activeStep === ICreateConnectionSteps.CONNECTOR_LIST) {
@@ -94,6 +89,7 @@ export function CreateConnection({ enableRouting, onRender, onUnmount }) {
     const { selectedConnector } = state;
     const connectionConfiguration = {
       description,
+      category: state.selectedConnector.category,
       plugin: {
         ...selectedConnector,
         properties,
@@ -103,6 +99,7 @@ export function CreateConnection({ enableRouting, onRender, onUnmount }) {
       await createConnection(name, connectionConfiguration);
       navigateToConnectionList(dispatch);
     } catch (e) {
+      // tslint:disable-next-line: no-console
       console.log('TODO: surface error: ', e);
     }
   };

--- a/app/cdap/components/Connections/Create/reducer.ts
+++ b/app/cdap/components/Connections/Create/reducer.ts
@@ -165,7 +165,7 @@ export function fetchAllConnectorPluginProperties(connectors) {
   ).toPromise();
 }
 
-export function getCategoriesToConnectionsMap(connectionTypes = []) {
+export function getCategoriesToConnectorsMap(connectionTypes = []) {
   const categoryToConnectionsMap = new Map();
   if (!connectionTypes.length) {
     return categoryToConnectionsMap;
@@ -196,7 +196,7 @@ export async function fetchConnectionDetails({
   };
   const {
     name: artifactname = 'google-cloud',
-    version: artifactversion = '0.17.0-SNAPSHOT',
+    version: artifactversion = '0.18.0-SNAPSHOT',
     scope: artifactscope = 'SYSTEM',
   } = artifactObj || {};
   const cdapVersion = VersionStore.getState().version;
@@ -237,6 +237,7 @@ export async function fetchConnectionDetails({
     connDetails.connectorWidgetJSON = JSON.parse(connectionWidgetJSON[widgetJSONKey]);
     connDetails.connectorDoc = connectionDoc[docKey];
   } catch (e) {
+    // tslint:disable-next-line: no-console
     console.log('Error fetching widget json or parsing: ', e);
   }
   return connDetails;
@@ -273,7 +274,7 @@ export async function initStore(dispatch: Dispatch<IAction<ICreateConnectionActi
     const mapOfConnectorPluginProperties = getMapOfConnectorToPluginProperties(
       allConnectorsPluginProperties
     );
-    const categoriesToConnectorsMap = getCategoriesToConnectionsMap(connectors as any);
+    const categoriesToConnectorsMap = getCategoriesToConnectorsMap(connectors as any);
     const categories = Array.from(new Set(connectors.map((conn) => conn.category)));
     dispatch({
       type: ICreateConnectionActions.INIT,

--- a/app/cdap/components/Connections/CreateConnectionBtn/index.tsx
+++ b/app/cdap/components/Connections/CreateConnectionBtn/index.tsx
@@ -18,6 +18,7 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { Button } from '@material-ui/core';
 import makeStyle from '@material-ui/core/styles/makeStyles';
+import { getCurrentNamespace } from 'services/NamespaceStore';
 
 const useStyle = makeStyle(() => {
   return {
@@ -26,7 +27,7 @@ const useStyle = makeStyle(() => {
       display: 'flex',
       justifyContent: 'center',
       alignContent: 'center',
-      padding: '5px',
+      padding: '10px',
     },
     link: {
       width: '100%',
@@ -38,7 +39,7 @@ const useStyle = makeStyle(() => {
       },
     },
     button: {
-      width: '80%',
+      width: '100%',
     },
   };
 });
@@ -47,7 +48,7 @@ export function CreateConnectionBtn({ enableRouting }) {
   if (enableRouting) {
     return (
       <div className={classes.root}>
-        <Link to="create" className={classes.link}>
+        <Link to={`/ns/${getCurrentNamespace()}/connections/create`} className={classes.link}>
           <Button className={classes.button} variant="contained">
             Add Connection
           </Button>

--- a/app/cdap/components/Connections/Home.tsx
+++ b/app/cdap/components/Connections/Home.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import { Theme } from '@material-ui/core';
+import { ConnectionsBrowserSidePanel } from 'components/Connections/Browser/SidePanel';
+import { ConnectionsBrowser } from 'components/Connections/Browser/index';
+import makeStyles from '@material-ui/core/styles/makeStyles';
+import { useParams } from 'react-router';
+
+interface IConnectionsHomeStyleProps {
+  sidePanelCollapsed: boolean;
+}
+const useStyle = makeStyles<Theme, IConnectionsHomeStyleProps>((theme) => {
+  return {
+    root: {
+      display: 'grid',
+      gridTemplateColumns: ({ sidePanelCollapsed }) => (sidePanelCollapsed ? '0 1fr' : '250px 1fr'),
+      gridTemplateRows: '100%',
+      overflowY: 'hidden',
+      height: '100%',
+    },
+  };
+});
+
+export function ConnectionsHome({ enableRouting }) {
+  const params = useParams();
+  const [sidePanelCollapsed, setSidePanelCollapsed] = React.useState(false);
+  const [selectedConnection, setSelectedConnection] = React.useState(
+    (params as any).connectionid || null
+  );
+
+  React.useEffect(() => {
+    if ((params as any).connectionid !== selectedConnection) {
+      setSelectedConnection((params as any).connectionid);
+    }
+  }, [params]);
+
+  const classes = useStyle({ sidePanelCollapsed });
+  return (
+    <div className={classes.root}>
+      <ConnectionsBrowserSidePanel
+        enableRouting={enableRouting}
+        onSidePanelToggle={() => setSidePanelCollapsed(true)}
+        onConnectionSelection={(conn) => setSelectedConnection(conn)}
+        selectedConnection={selectedConnection}
+      />
+      <ConnectionsBrowser
+        selectedConnection={selectedConnection}
+        enableRouting={enableRouting}
+        expanded={sidePanelCollapsed}
+        onCollapse={() => setSidePanelCollapsed(false)}
+      />
+    </div>
+  );
+}

--- a/app/cdap/components/Connections/Routes.tsx
+++ b/app/cdap/components/Connections/Routes.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import { Route, Switch } from 'react-router-dom';
+import { CreateConnection } from 'components/Connections/Create';
+import { ConnectionsHome } from 'components/Connections/Home';
+
+export function ConnectionRoutes({ enableRouting }) {
+  return (
+    <Switch>
+      <Route exact path="/ns/:namespace/connections/create">
+        <CreateConnection enableRouting={enableRouting} />
+      </Route>
+      <Route path="/ns/:namespace/connections/:connectionid">
+        <ConnectionsHome enableRouting={enableRouting} />
+      </Route>
+      <Route path="/ns/:namespace/connections">
+        <ConnectionsHome enableRouting={enableRouting} />
+      </Route>
+    </Switch>
+  );
+}

--- a/app/cdap/components/Connections/index.tsx
+++ b/app/cdap/components/Connections/index.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import If from 'components/If';
+import Helmet from 'react-helmet';
+import T from 'i18n-react';
+import { Theme } from 'services/ThemeHelper';
+import { ConnectionRoutes } from 'components/Connections/Routes';
+import { MemoryRouter } from 'react-router';
+import { getCurrentNamespace } from 'services/NamespaceStore';
+const PREFIX = 'features.DataPrepConnections';
+const DATAPREP_I18N_PREFIX = 'features.DataPrep.pageTitle';
+
+export default function Connections({ enableRouting = true, singleWorkspaceMode }) {
+  const featureName = Theme.featureNames.dataPrep;
+  const pageTitle = (
+    <Helmet
+      title={T.translate(DATAPREP_I18N_PREFIX, {
+        productName: Theme.productName,
+        featureName,
+      })}
+    />
+  );
+  return (
+    <React.Fragment>
+      <If condition={singleWorkspaceMode || enableRouting}>{pageTitle}</If>
+      <If condition={enableRouting}>
+        <ConnectionRoutes enableRouting={enableRouting} />
+      </If>
+      <If condition={!enableRouting}>
+        <MemoryRouter initialEntries={[`/ns/${getCurrentNamespace()}/connections`]}>
+          <ConnectionRoutes enableRouting={enableRouting} />
+        </MemoryRouter>
+      </If>
+    </React.Fragment>
+  );
+}

--- a/app/cdap/components/DataPrepConnections/PluginConnectionBrowser/index.tsx
+++ b/app/cdap/components/DataPrepConnections/PluginConnectionBrowser/index.tsx
@@ -30,6 +30,8 @@ import ThemeWrapper from 'components/ThemeWrapper';
 import ee from 'event-emitter';
 import { getCurrentNamespace } from 'services/NamespaceStore';
 import { objectQuery } from 'services/helpers';
+import Connections from 'components/Connections';
+import { ConnectionsApi } from 'api/connections';
 
 const styles = (theme) => {
   return {
@@ -73,7 +75,7 @@ class PluginConnectionBrowser extends React.PureComponent<
   public state = {
     showBrowserModal: false,
     error: null,
-    loading: true,
+    loading: false,
     defaultConnectionId: null,
     defaultConnectionType: null,
   };
@@ -83,7 +85,7 @@ class PluginConnectionBrowser extends React.PureComponent<
   public async openDefaultConnection() {
     let connections;
     try {
-      connections = await MyDataPrepApi.listConnections({
+      connections = await ConnectionsApi.listConnections({
         context: getCurrentNamespace(),
       }).toPromise();
     } catch (e) {
@@ -344,15 +346,7 @@ class PluginConnectionBrowser extends React.PureComponent<
           </div>
           <ModalBody>
             <If condition={!this.state.loading}>
-              <DataPrepConnection
-                enableRouting={false}
-                singleWorkspaceMode={true}
-                sidePanelExpanded={true}
-                scope="plugin-browser-source"
-                onWorkspaceCreate={this.onWorkspaceCreate}
-                defaultConnectionId={this.state.defaultConnectionId}
-                defaultConnectionType={this.state.defaultConnectionType}
-              />
+              <Connections enableRouting={false} singleWorkspaceMode={true} />
             </If>
             <If condition={this.state.loading}>
               <LoadingSVGCentered />

--- a/app/cdap/components/DataPrepConnections/index.js
+++ b/app/cdap/components/DataPrepConnections/index.js
@@ -36,7 +36,7 @@ import T from 'i18n-react';
 import MyDataPrepApi from 'api/dataprep';
 import DataPrepServiceControl from 'components/DataPrep/DataPrepServiceControl';
 import ConnectionsUpload from 'components/DataPrepConnections/UploadFile';
-import { CreateConnectionBtn } from 'components/DataPrepConnections/CreateConnectionBtn';
+import { CreateConnectionBtn } from 'components/Connections/CreateConnectionBtn';
 import { CreateConnection } from 'components/Connections/Create';
 import isNil from 'lodash/isNil';
 import ExpandableMenu from 'components/UncontrolledComponents/ExpandableMenu';

--- a/app/cdap/components/Home/index.js
+++ b/app/cdap/components/Home/index.js
@@ -32,9 +32,8 @@ const EntityListView = Loadable({
   loader: () => import(/* webpackChunkName: "EntityListView" */ 'components/EntityListView'),
   loading: LoadingSVGCentered,
 });
-const DataPrepConnections = Loadable({
-  loader: () =>
-    import(/* webpackChunkName: "DataPrepConnections" */ 'components/DataPrepConnections'),
+const Connections = Loadable({
+  loader: () => import(/* webpackChunkName: "Connections" */ 'components/Connections'),
   loading: LoadingSVGCentered,
 });
 const DataPrepHome = Loadable({
@@ -152,7 +151,7 @@ export default class Home extends Component {
           <Route exact path="/ns/:namespace/rulesengine" component={RulesEngineHome} />
           <Route exact path="/ns/:namespace/wrangler" component={DataPrepHome} />
           <Route exact path="/ns/:namespace/wrangler/:workspaceId" component={DataPrepHome} />
-          <Route path="/ns/:namespace/connections" component={DataPrepConnections} />
+          <Route path="/ns/:namespace/connections" component={Connections} />
           <Route path="/ns/:namespace/experiments" component={Experiments} />
           <Route exact path="/ns/:namespace/operations" component={Operations} />
           <Route exact path="/ns/:namespace/details" component={NamespaceDetails} />

--- a/app/cdap/components/Table/TableCell.tsx
+++ b/app/cdap/components/Table/TableCell.tsx
@@ -36,16 +36,14 @@ interface ITableCellProps extends WithStyles<typeof styles> {
   textAlign?: TextAlignProperty;
 }
 
-const TableCellView: React.FC<React.PropsWithChildren<ITableCellProps>> = ({
-  classes,
-  children,
-  textAlign = 'left',
-}) => {
+const TableCellView: React.FC<React.PropsWithChildren<
+  ITableCellProps & React.HTMLAttributes<HTMLDivElement>
+>> = ({ classes, children, textAlign = 'left', ...rest }) => {
   const style: React.CSSProperties = {
     textAlign,
   };
   return (
-    <div className={classes.gridCell} style={style}>
+    <div className={classes.gridCell} style={style} {...rest}>
       {children}
     </div>
   );

--- a/app/cdap/components/Table/TableRow.tsx
+++ b/app/cdap/components/Table/TableRow.tsx
@@ -51,7 +51,9 @@ interface ITableRowProps extends WithStyles<typeof styles> {
   nativeLink?: boolean;
 }
 
-const TableRowView: React.FC<React.PropsWithChildren<ITableRowProps>> = ({
+const TableRowView: React.FC<React.PropsWithChildren<
+  ITableRowProps & React.HTMLAttributes<HTMLDivElement>
+>> = ({
   classes,
   children,
   columnTemplate,
@@ -59,6 +61,7 @@ const TableRowView: React.FC<React.PropsWithChildren<ITableRowProps>> = ({
   hover = true,
   to,
   nativeLink = false,
+  ...rest
 }) => {
   const style = {
     gridTemplateColumns: columnTemplate,
@@ -69,14 +72,24 @@ const TableRowView: React.FC<React.PropsWithChildren<ITableRowProps>> = ({
 
   if (to) {
     return (
-      <NavLinkWrapper to={to} isNativeLink={nativeLink} className={linkClassName} style={style}>
+      <NavLinkWrapper
+        to={to}
+        isNativeLink={nativeLink}
+        className={linkClassName}
+        style={style}
+        {...rest}
+      >
         {children}
       </NavLinkWrapper>
     );
   }
 
   return (
-    <div className={classnames(classes.gridRow, { [classes.hover]: hover })} style={style}>
+    <div
+      className={classnames(classes.gridRow, { [classes.hover]: hover })}
+      style={style}
+      {...rest}
+    >
       {children}
     </div>
   );

--- a/app/cdap/main.js
+++ b/app/cdap/main.js
@@ -203,6 +203,7 @@ class CDAP extends Component {
       });
     });
     if (!VersionStore.getState().version) {
+      this.setState({ loading: true });
       MyCDAPVersionApi.get().subscribe((res) => {
         VersionStore.dispatch({
           type: VersionActions.updateVersion,
@@ -210,6 +211,7 @@ class CDAP extends Component {
             version: res.version,
           },
         });
+        this.setState({ loading: false });
       });
     }
   };

--- a/app/common/cask-shared-components.js
+++ b/app/common/cask-shared-components.js
@@ -131,6 +131,7 @@ var ALERT_STATUS = require('../cdap/services/AlertStatus').ALERT_STATUS;
 var Comment = require('../cdap/components/AbstractWidget/Comment').default;
 var PipelineCommentsActionBtn = require('../cdap/components/PipelineCanvasActions/PipelineCommentsActionBtn')
   .default;
+var Connections = require('../cdap/components/Connections').default;
 export {
   Store,
   NameSpaceStoreActions,
@@ -234,4 +235,5 @@ export {
   ALERT_STATUS,
   Comment,
   PipelineCommentsActionBtn,
+  Connections,
 };

--- a/app/directives/plugin-functions/plugin-functions-factory.js
+++ b/app/directives/plugin-functions/plugin-functions-factory.js
@@ -43,11 +43,12 @@ angular.module(PKG.name + '.commons')
         },
       },
       'connection-browser': {
-        element: '<connection-browser></connection-browser>',
+        element: '<connections-browser></connections-browser>',
         attributes: {
           'node': 'node',
           'on-browse-complete': 'onComplete',
           'fn-config': 'fnConfig',
+          'enable-routing': '"false"',
         }
       }
     };

--- a/app/directives/react-components/index.js
+++ b/app/directives/react-components/index.js
@@ -100,9 +100,6 @@ angular
   .directive('multipleValuesWidget', function(reactDirective) {
     return reactDirective(window.CaskCommon.MultipleValuesWidget);
   })
-  .directive('connectionBrowser', function(reactDirective) {
-    return reactDirective(window.CaskCommon.PluginConnectionBrowser);
-  })
   .directive('functionDropdownAliasWidget', function(reactDirective) {
     return reactDirective(window.CaskCommon.FunctionDropdownAlias);
   })
@@ -183,4 +180,7 @@ angular
   })
   .directive('pipelineCommentsActionBtn', function(reactDirective) {
     return reactDirective(window.CaskCommon.PipelineCommentsActionBtn);
+  })
+  .directive('connectionsBrowser', function (reactDirective) {
+    return reactDirective(window.CaskCommon.Connections);
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "sourceMap": true,
     "importHelpers": false,
     "allowSyntheticDefaultImports": true,
+    "downlevelIteration": true,
     "lib": [
       "es2015",
       "dom",

--- a/webpack.config.cdap.dev.js
+++ b/webpack.config.cdap.dev.js
@@ -75,6 +75,7 @@ var plugins = [
     shorthands: true,
     collections: true,
     caching: true,
+    flattening: true,
   }),
   new CopyWebpackPlugin(
     [

--- a/webpack.config.cdap.js
+++ b/webpack.config.cdap.js
@@ -76,6 +76,7 @@ var plugins = [
     shorthands: true,
     collections: true,
     caching: true,
+    flattening: true,
   }),
   new CopyWebpackPlugin(
     [

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -34,6 +34,7 @@ var plugins = [
     shorthands: true,
     collections: true,
     caching: true,
+    flattening: true,
   }),
   new CleanWebpackPlugin(cleanOptions),
   new CaseSensitivePathsPlugin(),

--- a/webpack.config.login.js
+++ b/webpack.config.login.js
@@ -48,6 +48,7 @@ var plugins = [
     shorthands: true,
     collections: true,
     caching: true,
+    flattening: true,
   }),
   new CleanWebpackPlugin(cleanOptions),
   new CaseSensitivePathsPlugin(),


### PR DESCRIPTION
JIRA 
- https://cdap.atlassian.net/browse/CDAP-17871
- https://cdap.atlassian.net/browse/CDAP-17875

Changes
- Adds `GenericBrowser` to handle browsing any connections
- Adds initial POC to use `MemoryRouter` from `react-router-dom` to use same code base for both React and Angular
- Adds explore and list connections API

Auxillary changes
- Changes `main.js` to load CDAPVersion before loading children
- Fixes `Alert` to not setState when unmounted.
- Adds `tsconfig.json` config `downlevelIteration` to support using `Map`s in `for..of` loop 

TODO
- Addresses only happy path for connections browsing.
- Still missing,
  - Breadcrumbs
  - Search/Filter/Sorting in connections browser
  - Actual working connections from pipelines Browse button