### PR TITLE
[CDAP-17988] Breadcrumb for new generic browser

### DIFF
--- a/app/cdap/components/Connections/Browser/GenericBrowser/Breadcrumb.tsx
+++ b/app/cdap/components/Connections/Browser/GenericBrowser/Breadcrumb.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import Typography from '@material-ui/core/Typography';
+import Breadcrumbs from '@material-ui/core/Breadcrumbs';
+import Link from '@material-ui/core/Link';
+import makeStyle from '@material-ui/core/styles/makeStyles';
+import { Link as RouterLink } from 'react-router-dom';
+import * as React from 'react';
+
+const ROOT_ELEMENT = 'Root';
+
+const useStyle = makeStyle(() => {
+  return {
+    crumb: {
+      color: 'black',
+      fontSize: '1.0rem',
+    },
+    lastCrumb: {
+      color: 'black',
+      fontWeight: 'bold',
+      fontSize: '1.0rem',
+    },
+  };
+});
+
+export default function Breadcrumb({ path, baseLinkPath }) {
+  // Filter to handle '/' as first or last character
+  const pathElements = path.split('/').filter((pathElement) => pathElement.length > 0);
+  const classes = useStyle();
+
+  function createCrumb(title, path, isLast) {
+    return isLast ? (
+      <Typography key={path} className={classes.lastCrumb}>
+        {title}
+      </Typography>
+    ) : (
+      <Link to={`${baseLinkPath}${path}`} key={path} component={RouterLink}>
+        <Typography className={classes.crumb}>{title}</Typography>
+      </Link>
+    );
+  }
+
+  return (
+    <Breadcrumbs maxItems={3} itemsAfterCollapse={2} itemsBeforeCollapse={0}>
+      {createCrumb(ROOT_ELEMENT, '/', pathElements.length === 0)}
+      {pathElements.map((pathEntry, i) => {
+        const fullPath = `/${pathElements.slice(0, i + 1).join('/')}`;
+        return createCrumb(pathEntry, fullPath, i === pathElements.length - 1);
+      })}
+    </Breadcrumbs>
+  );
+}

--- a/app/cdap/components/Connections/Browser/GenericBrowser/index.tsx
+++ b/app/cdap/components/Connections/Browser/GenericBrowser/index.tsx
@@ -30,6 +30,7 @@ import TableCell from 'components/Table/TableCell';
 import TableBody from 'components/Table/TableBody';
 import { getCurrentNamespace } from 'services/NamespaceStore';
 import { useLocation } from 'react-router-dom';
+import Breadcrumb from './Breadcrumb';
 
 const useStyle = makeStyle(() => {
   return {
@@ -39,13 +40,15 @@ const useStyle = makeStyle(() => {
     },
     grid: {
       height: '100%',
-      marginTop: '15px',
     },
     loadingContainer: {
       display: 'flex',
       justifyContent: 'center',
       alignItems: 'center',
       height: '100%',
+    },
+    topBar: {
+      margin: '8px 0 8px 10px',
     },
   };
 });
@@ -120,41 +123,49 @@ export function GenericBrowser({ selectedConnection }) {
   const columnTemplate = headers.map(() => '1fr').join(' ');
   const getPath = (suffix) => (path === '/' ? `/${suffix}` : `${path}/${suffix}`);
   return (
-    <Table columnTemplate={columnTemplate} classes={{ grid: classes.grid }}>
-      <TableHeader>
-        <TableRow>
-          {headers.map((header) => {
-            return <TableCell key={header}>{header}</TableCell>;
+    <React.Fragment>
+      <div className={classes.topBar}>
+        <Breadcrumb
+          path={path}
+          baseLinkPath={`/ns/${getCurrentNamespace()}/connections/${selectedConnection}?path=`}
+        />
+      </div>
+      <Table columnTemplate={columnTemplate} classes={{ grid: classes.grid }}>
+        <TableHeader>
+          <TableRow>
+            {headers.map((header) => {
+              return <TableCell key={header}>{header}</TableCell>;
+            })}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {entities.map((entity, i) => {
+            return (
+              <TableRow
+                key={i}
+                to={`/ns/${getCurrentNamespace()}/connections/${selectedConnection}?path=${getPath(
+                  entity.name
+                )}`}
+                onClick={() => onExplore(entity.name)}
+              >
+                <TableCell>
+                  <div className={classes.nameWrapper}>
+                    <If condition={ICON_MAP[entity.type]}>{ICON_MAP[entity.type]}</If>
+                    <div>{entity.name}</div>
+                  </div>
+                </TableCell>
+                <TableCell>{entity.type}</TableCell>
+                {entity.properties.map((prop) => {
+                  if (prop.type === 'Timestamp') {
+                    return <TableCell key={prop.value}>{humanReadableDate(prop.value)}</TableCell>;
+                  }
+                  return <TableCell key={prop.value}>{prop.value}</TableCell>;
+                })}
+              </TableRow>
+            );
           })}
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {entities.map((entity, i) => {
-          return (
-            <TableRow
-              key={i}
-              to={`/ns/${getCurrentNamespace()}/connections/${selectedConnection}?path=${getPath(
-                entity.name
-              )}`}
-              onClick={() => onExplore(entity.name)}
-            >
-              <TableCell>
-                <div className={classes.nameWrapper}>
-                  <If condition={ICON_MAP[entity.type]}>{ICON_MAP[entity.type]}</If>
-                  <div>{entity.name}</div>
-                </div>
-              </TableCell>
-              <TableCell>{entity.type}</TableCell>
-              {entity.properties.map((prop) => {
-                if (prop.type === 'Timestamp') {
-                  return <TableCell key={prop.value}>{humanReadableDate(prop.value)}</TableCell>;
-                }
-                return <TableCell key={prop.value}>{prop.value}</TableCell>;
-              })}
-            </TableRow>
-          );
-        })}
-      </TableBody>
-    </Table>
+        </TableBody>
+      </Table>
+    </React.Fragment>
   );
 }


### PR DESCRIPTION
Jira: https://cdap.atlassian.net/browse/CDAP-17988

This uses material-ui's Breadcrumbs to add a breadcrumb for the generic browser. It uses react-router to change locations and has the look and feel of the current breadcrumb, with the exception of the collapsed state.

Base state:
![image](https://user-images.githubusercontent.com/2728821/118328981-5271b600-b4bb-11eb-9eaf-b4743af4836c.png)

A couple levels in:
![image](https://user-images.githubusercontent.com/2728821/118329027-61f0ff00-b4bb-11eb-8532-3326567e32ad.png)

Collapsed with > 3 levels:
![image](https://user-images.githubusercontent.com/2728821/118329068-703f1b00-b4bb-11eb-8b51-b64349e2f311.png)

Note the different style. I don't know if the appearance can be overridden. Also, clicking it will expand the directories in-place rather than showing a menu. If this is too big a change, we'll need to create our own bread crumb.
