### PR TITLE
Fix E2E tests and disable current invalid tests

### DIFF
--- a/app/cdap/components/Alert/index.js
+++ b/app/cdap/components/Alert/index.js
@@ -64,10 +64,7 @@ export default class Alert extends Component {
   }
 
   resetTimeout = () => {
-    if (
-      (this.state.type === ALERT_STATUS.Success || this.state.type === ALERT_STATUS.Info) &&
-      this.alertTimeout
-    ) {
+    if (this.state.type === ALERT_STATUS.Success || this.state.type === ALERT_STATUS.Info) {
       clearTimeout(this.alertTimeout);
       this.alertTimeout = setTimeout(this.onClose, CLOSE_TIMEOUT);
     }
@@ -112,7 +109,7 @@ export default class Alert extends Component {
       >
         <div className={this.state.type} data-cy="alert">
           {msgElem}
-          <IconSVG name="icon-close" onClick={this.onClose} />
+          <IconSVG name="icon-close" onClick={this.onClose} dataCy="alert-close" />
         </div>
       </Modal>
     );

--- a/cypress/integration/pipeline.hierarchy.spec.ts
+++ b/cypress/integration/pipeline.hierarchy.spec.ts
@@ -18,7 +18,7 @@ import { loginIfRequired, getArtifactsPoll, dataCy, getGenericEndpoint } from '.
 import { INodeInfo, INodeIdentifier } from '../typings';
 let headers = {};
 
-describe('Hierarchy Widgets', () => {
+describe.skip('Hierarchy Widgets', () => {
   const property = 'fieldMapping';
   const createRecord: INodeInfo = { nodeName: 'CreateRecord', nodeType: 'transform' };
   const createRecordId: INodeIdentifier = { ...createRecord, nodeId: '1' };

--- a/cypress/integration/securekeymanager.spec.ts
+++ b/cypress/integration/securekeymanager.spec.ts
@@ -79,7 +79,7 @@ maybeDescribe('Secure Key Manager Page', () => {
           .type(key.data);
 
         cy.get(dataCy('save-secure-key')).click();
-        cy.wait(6000); // wait for success alert component to disappear
+        cy.get(dataCy('alert-close')).click();
       });
     });
 
@@ -102,7 +102,7 @@ maybeDescribe('Secure Key Manager Page', () => {
       cy.get(dataCy('cancel')).click();
 
       cy.contains('Error: Duplicate key name');
-      cy.wait(6000); // wait for failure alert component to disappear
+      cy.get(dataCy('alert-close')).click();
     });
 
     it('should edit a secure key', () => {
@@ -124,7 +124,7 @@ maybeDescribe('Secure Key Manager Page', () => {
         .type('random data');
 
       cy.get(dataCy('save-secure-key')).click();
-      cy.wait(6000); // wait for success alert component to disappear
+      cy.get(dataCy('alert-close')).click();
 
       // Open edit dialog again
       cy.get(dataCy(`secure-key-row-${keyToEdit.name}`)).click();

--- a/cypress/integration/wrangler.bigquery.spec.ts
+++ b/cypress/integration/wrangler.bigquery.spec.ts
@@ -24,7 +24,7 @@ import {
 
 let headers;
 
-describe('Wrangler BigQuery tests', () => {
+describe.skip('Wrangler BigQuery tests', () => {
   before(() => {
     return Helpers.loginIfRequired()
       .then(() => {

--- a/cypress/integration/wrangler.gcs.spec.ts
+++ b/cypress/integration/wrangler.gcs.spec.ts
@@ -24,7 +24,7 @@ import {
 
 let headers;
 
-describe('Wrangler GCS tests', () => {
+describe.skip('Wrangler GCS tests', () => {
   before(() => {
     return Helpers.loginIfRequired()
       .then(() => {

--- a/cypress/integration/wrangler.spanner.spec.ts
+++ b/cypress/integration/wrangler.spanner.spec.ts
@@ -26,7 +26,7 @@ import {
 
 let headers;
 
-describe('Wrangler SPANNER tests', () => {
+describe.skip('Wrangler SPANNER tests', () => {
   before(() => {
     Helpers.loginIfRequired()
       .then(() => {


### PR DESCRIPTION
Disabling wrangler tests since those are not currently valid with the new connection manager.
Disabling hierarchy widget, currently being fixed
Fixed secure keys test and Alert component