### PR TITLE
[CDAP-18038] Empty and error messaging to match app standard

### DIFF
--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -463,6 +463,11 @@ features:
             truncatedContentsTooltip: The GCS account you are viewing contains more directories and files we can currently display.
             truncatedLabel: "{dirsCount} directories and {fileCount} files of many"
           selectData: Select data
+      GenericBrowser:
+        EmptyMessageContainer:
+          title: No entities available
+          suggestion1: your search
+          suggestion2: Browse to another location
       KafkaBrowser:
         EmptyMessage:
           clearLabel: Clear


### PR DESCRIPTION
Switched to use EmptyMessageContainer and ErrorBanner

Jira: https://cdap.atlassian.net/browse/CDAP-18038

Empty state:
![image](https://user-images.githubusercontent.com/2728821/120401107-1aa8a200-c2f4-11eb-80b2-a8d6d81d8b3b.png)

Error state:
![image](https://user-images.githubusercontent.com/2728821/120535104-75470a00-c397-11eb-962f-730c8766a5af.png)
