### PR TITLE
[CDAP-17878] Integrates Wrangler UI with V2 wrangler API

### DIFF
--- a/app/cdap/api/connections.ts
+++ b/app/cdap/api/connections.ts
@@ -25,7 +25,7 @@ const connectionsTypePath =
 
 // The assumption is UI will get all its connection types from a single plugin.
 const connectionsTypePropertiesPath =
-  '/namespaces/:namespace/artifacts/cdap-data-pipeline/versions/:datapipelineArtifactVersion/extensions/batchsource';
+  '/namespaces/:namespace/artifacts/cdap-data-pipeline/versions/:datapipelineArtifactVersion/extensions/connector';
 
 const connectionWidgetJSONPath =
   '/namespaces/:namespace/artifacts/:artifactname/versions/:artifactversion/properties';

--- a/app/cdap/api/dataprep.js
+++ b/app/cdap/api/dataprep.js
@@ -22,20 +22,25 @@ let dataSrc = DataSourceConfigurer.getInstance();
 const appPath = '/namespaces/system/apps/dataprep';
 const baseServicePath = `${appPath}/services/service`;
 const contextPath = `${baseServicePath}/methods/contexts/:context`;
+const contextPathV2 = `${baseServicePath}/methods/v2/contexts/:context`;
 const basepath = `${contextPath}/workspaces/:workspaceId`;
+const basepathV2 = `${contextPathV2}/workspaces/:workspaceId`;
 const connectionsPath = `${contextPath}/connections`;
 const connectionTypesPath = `${baseServicePath}/methods/connectionTypes`;
 const datamodelsPath = `${contextPath}/datamodels/schemas`;
 
 const MyDataPrepApi = {
-  delete: apiCreator(dataSrc, 'DELETE', 'REQUEST', basepath),
-  execute: apiCreator(dataSrc, 'POST', 'REQUEST', `${basepath}/execute`),
+  createWorkspace: apiCreator(dataSrc, 'POST', 'REQUEST', `${contextPathV2}/workspaces`),
+
+  delete: apiCreator(dataSrc, 'DELETE', 'REQUEST', basepathV2),
+  execute: apiCreator(dataSrc, 'POST', 'REQUEST', `${basepathV2}/execute`),
   summary: apiCreator(dataSrc, 'POST', 'REQUEST', `${basepath}/summary`),
   getSchema: apiCreator(dataSrc, 'POST', 'REQUEST', `${basepath}/schema`),
+  getSpecification: apiCreator(dataSrc, 'GET', 'REQUEST', `${basepathV2}/specification`),
   getUsage: apiCreator(dataSrc, 'GET', 'REQUEST', `${contextPath}/usage`),
   getInfo: apiCreator(dataSrc, 'GET', 'REQUEST', `${baseServicePath}/methods/info`),
-  getWorkspace: apiCreator(dataSrc, 'GET', 'REQUEST', `${basepath}`),
-  getWorkspaceList: apiCreator(dataSrc, 'GET', 'REQUEST', `${contextPath}/workspaces`),
+  getWorkspace: apiCreator(dataSrc, 'GET', 'REQUEST', `${basepathV2}`),
+  getWorkspaceList: apiCreator(dataSrc, 'GET', 'REQUEST', `${contextPathV2}/workspaces`),
 
   // Wrangler Data Model
   attachDataModel: apiCreator(dataSrc, 'POST', 'REQUEST', `${basepath}/datamodels`),
@@ -63,12 +68,6 @@ const MyDataPrepApi = {
   // File System Browser
   explorer: apiCreator(dataSrc, 'GET', 'REQUEST', `${contextPath}/explorer/fs`),
   readFile: apiCreator(dataSrc, 'GET', 'REQUEST', `${contextPath}/explorer/fs/read`),
-  getSpecification: apiCreator(
-    dataSrc,
-    'GET',
-    'REQUEST',
-    `${contextPath}/explorer/fs/specification`
-  ),
 
   // Database Browser
   listTables: apiCreator(dataSrc, 'GET', 'REQUEST', `${connectionsPath}/:connectionId/tables`),

--- a/app/cdap/components/AbstractWidget/WranglerEditor/index.tsx
+++ b/app/cdap/components/AbstractWidget/WranglerEditor/index.tsx
@@ -186,11 +186,10 @@ class WranglerEditor extends React.PureComponent<IWranglerEditorProps, IWrangler
             </div>
             <ModalBody>
               <DataPrepHome
-                singleWorkspaceMode={true}
                 workspaceId={properties.workspaceId}
                 onSubmit={this.updateDirectivesAndCloseModal}
-                enableRouting={false}
                 disabled={disabled}
+                mode="ROUTED_WORKSPACE"
               />
             </ModalBody>
           </Modal>

--- a/app/cdap/components/Connections/Browser/GenericBrowser/BrowserTable.tsx
+++ b/app/cdap/components/Connections/Browser/GenericBrowser/BrowserTable.tsx
@@ -59,11 +59,18 @@ const useStyle = makeStyle(() => {
     },
   };
 });
+interface IBrowseEntity {
+  canBrowse: boolean;
+  canSample: boolean;
+  name: string;
+  type: string;
+  path: string;
+}
 interface IBrowserTable {
   selectedConnection: string;
   path: string;
   entities: any;
-  onExplore: (entityName: string) => void;
+  onExplore: (entityName: IBrowseEntity) => void;
   loading: boolean;
 }
 
@@ -111,7 +118,7 @@ export function BrowserTable({
                 to={`/ns/${getCurrentNamespace()}/connections/${selectedConnection}?path=${getPath(
                   entity.name
                 )}`}
-                onClick={() => onExplore(entity.name)}
+                onClick={() => onExplore(entity)}
               >
                 <TableCell>
                   <div className={classes.nameWrapper}>

--- a/app/cdap/components/Connections/Browser/GenericBrowser/apiHelpers.ts
+++ b/app/cdap/components/Connections/Browser/GenericBrowser/apiHelpers.ts
@@ -15,6 +15,7 @@
  */
 
 import { ConnectionsApi } from 'api/connections';
+import DataprepApi from 'api/dataprep';
 import { getCurrentNamespace } from 'services/NamespaceStore';
 
 export function exploreConnection({ connectionid, path = '/' }) {
@@ -27,6 +28,24 @@ export function exploreConnection({ connectionid, path = '/' }) {
     {
       context: getCurrentNamespace(),
       connectionid,
+    },
+    body
+  ).toPromise();
+}
+
+export function createWorkspace({ entity, connection, limit = 1000 }) {
+  const { path } = entity;
+  const body = {
+    connection,
+    sampleRequest: {
+      path,
+      properties: {}, // For 6.5 this will always be empty. Once we add support to set file encoding and other properties this will get dynamic.
+      limit,
+    },
+  };
+  return DataprepApi.createWorkspace(
+    {
+      context: getCurrentNamespace(),
     },
     body
   ).toPromise();

--- a/app/cdap/components/Connections/Browser/SidePanel/apiHelpers.ts
+++ b/app/cdap/components/Connections/Browser/SidePanel/apiHelpers.ts
@@ -29,7 +29,10 @@ export async function getCategorizedConnections() {
   try {
     connections = await getConnections();
     for (const connection of connections) {
-      const { category } = connection.plugin;
+      let { category } = connection.plugin;
+      if (!category) {
+        category = connection.plugin.artifact.name;
+      }
       let existingConnections = categorizedConnectionsMap.get(category);
       if (!existingConnections) {
         existingConnections = [];

--- a/app/cdap/components/Connections/Browser/SidePanel/index.tsx
+++ b/app/cdap/components/Connections/Browser/SidePanel/index.tsx
@@ -53,14 +53,12 @@ interface IConnectionsBrowserSidePanelState {
 }
 
 interface IConnectionBrowserSidePanelProps {
-  enableRouting?: boolean;
   onSidePanelToggle: () => void;
   onConnectionSelection: (conn: string) => void;
   selectedConnection: string;
 }
 
 export function ConnectionsBrowserSidePanel({
-  enableRouting,
   onSidePanelToggle,
   onConnectionSelection,
   selectedConnection,
@@ -96,7 +94,7 @@ export function ConnectionsBrowserSidePanel({
         onConnectionSelection={onConnectionSelection}
         selectedConnection={selectedConnection}
       />
-      <CreateConnectionBtn enableRouting={true} />
+      <CreateConnectionBtn />
     </Paper>
   );
 }

--- a/app/cdap/components/Connections/Browser/index.tsx
+++ b/app/cdap/components/Connections/Browser/index.tsx
@@ -20,7 +20,6 @@ import makeStyles from '@material-ui/core/styles/makeStyles';
 import ArrowForwardIosIcon from '@material-ui/icons/ArrowForwardIos';
 import IconButton from '@material-ui/core/IconButton';
 import { GenericBrowser } from 'components/Connections/Browser/GenericBrowser';
-
 import If from 'components/If';
 import Heading, { HeadingTypes } from 'components/Heading';
 
@@ -55,7 +54,16 @@ const useStyle = makeStyles((theme) => {
   };
 });
 
-export function ConnectionsBrowser({ enableRouting, expanded, onCollapse, selectedConnection }) {
+interface IConnectionsBrowser {
+  expanded: boolean;
+  onCollapse: () => void;
+  selectedConnection: string;
+}
+export function ConnectionsBrowser({
+  expanded,
+  onCollapse,
+  selectedConnection,
+}: IConnectionsBrowser) {
   const classes = useStyle();
   return (
     <Paper className={classes.root}>

--- a/app/cdap/components/Connections/ConnectionsContext/index.tsx
+++ b/app/cdap/components/Connections/ConnectionsContext/index.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+
+/**
+ * The Connection Mode represents how the connections will be integrated across the UI.
+ *
+ * 1. Routed - Regular use of Connections under the /connections route. This is entirely in React
+ * so we can use regular react-router and navigation can take place just normal
+ *
+ * 2. Routed Workspace - Meaning routing only happens while navigating to the workspace. This is the
+ * case when user is in dataprep table and clicks on the left arrow to browse through connections.
+ * The user is already in a specific workspace (/wrangler/:workspaceid) and we don't want to change
+ * the url based on the activity in the connection
+ *
+ * 3. In Memory - The entire routing happens in memory. This will be the case when the user clicks on the
+ * "Browse" button in wrangler sources or clicks on the "Wrangle" button in wrangler transform. Since we are in
+ * studio (completely in angular world) we do not want to do any navigation here. Everything happens in memory,
+ * including browsing through connections, going to a wrangler workspace, and finally applying the wrangler properties
+ * to wrangler transform.
+ */
+export enum IConnectionMode {
+  'ROUTED' = 'ROUTED',
+  'ROUTED_WORKSPACE' = 'ROUTED_WORKSPACE',
+  'INMEMORY' = 'INMEMORY',
+}
+export interface IConnections {
+  mode: IConnectionMode;
+  path?: string;
+  // Ideally connections should not require workspaceId. Path should be sufficient but because of old usage this is still here.
+  workspaceId?: string;
+  onWorkspaceCreate?: (workspaceId: string) => void;
+}
+export const ConnectionsContext = React.createContext<IConnections>({
+  mode: IConnectionMode.ROUTED,
+});

--- a/app/cdap/components/Connections/Create/index.tsx
+++ b/app/cdap/components/Connections/Create/index.tsx
@@ -37,8 +37,8 @@ import { Redirect } from 'react-router';
 import { getCurrentNamespace } from 'services/NamespaceStore';
 import { ConnectionConfiguration } from 'components/Connections/Create/ConnectionConfiguration';
 import { extractErrorMessage, objectQuery } from 'services/helpers';
-import { ConnectionsApi } from 'api/connections';
 import Alert from 'components/Alert';
+import { ConnectionsContext, IConnectionMode } from 'components/Connections/ConnectionsContext';
 
 const useStyle = makeStyle(() => {
   return {
@@ -53,12 +53,12 @@ const useStyle = makeStyle(() => {
   };
 });
 export function CreateConnection({
-  enableRouting,
   onToggle = null,
   initialConfig = {},
   onCreate = null,
   isEdit = false,
 }) {
+  const { mode } = React.useContext(ConnectionsContext);
   const classes = useStyle();
   const [loading, setLoading] = React.useState(true);
   const [state, dispatch] = React.useReducer(reducer, initialState);
@@ -100,7 +100,10 @@ export function CreateConnection({
     }
   }, []);
 
-  if (enableRouting && state.activeStep === ICreateConnectionSteps.CONNECTOR_LIST) {
+  if (
+    mode === IConnectionMode.ROUTED &&
+    state.activeStep === ICreateConnectionSteps.CONNECTOR_LIST
+  ) {
     return <Redirect to={`/ns/${getCurrentNamespace()}/connections`} />;
   }
 
@@ -142,7 +145,7 @@ export function CreateConnection({
         onCreate();
       }
 
-      if (enableRouting) {
+      if (mode === IConnectionMode.ROUTED) {
         navigateToConnectionList(dispatch);
       }
 
@@ -156,7 +159,7 @@ export function CreateConnection({
   };
 
   function onClose() {
-    if (enableRouting) {
+    if (mode === IConnectionMode.ROUTED) {
       navigateToConnectionList(dispatch);
       return;
     }

--- a/app/cdap/components/Connections/Create/reducer.ts
+++ b/app/cdap/components/Connections/Create/reducer.ts
@@ -172,7 +172,10 @@ export function getCategoriesToConnectorsMap(connectionTypes = []) {
     return categoryToConnectionsMap;
   }
   for (const connectionType of connectionTypes) {
-    const { category } = connectionType;
+    let { category } = connectionType;
+    if (!category) {
+      category = connectionType.artifact.name;
+    }
     if (!categoryToConnectionsMap.has(category)) {
       categoryToConnectionsMap.set(category, [connectionType]);
       continue;

--- a/app/cdap/components/Connections/CreateConnectionBtn/index.tsx
+++ b/app/cdap/components/Connections/CreateConnectionBtn/index.tsx
@@ -19,6 +19,7 @@ import { Link } from 'react-router-dom';
 import { Button } from '@material-ui/core';
 import makeStyle from '@material-ui/core/styles/makeStyles';
 import { getCurrentNamespace } from 'services/NamespaceStore';
+import { ConnectionsContext, IConnectionMode } from 'components/Connections/ConnectionsContext';
 
 const useStyle = makeStyle(() => {
   return {
@@ -43,9 +44,10 @@ const useStyle = makeStyle(() => {
     },
   };
 });
-export function CreateConnectionBtn({ enableRouting }) {
+export function CreateConnectionBtn() {
+  const { mode } = React.useContext(ConnectionsContext);
   const classes = useStyle();
-  if (enableRouting) {
+  if (mode === IConnectionMode.ROUTED) {
     return (
       <div className={classes.root}>
         <Link to={`/ns/${getCurrentNamespace()}/connections/create`} className={classes.link}>

--- a/app/cdap/components/Connections/CreateConnectionModal/index.tsx
+++ b/app/cdap/components/Connections/CreateConnectionModal/index.tsx
@@ -64,7 +64,6 @@ export default function CreateConnectionModal({
     <div className={classes.root}>
       <If condition={isOpen}>
         <CreateConnection
-          enableRouting={false}
           onToggle={onToggle}
           initialConfig={initialConfig}
           onCreate={onCreate}

--- a/app/cdap/components/Connections/Home.tsx
+++ b/app/cdap/components/Connections/Home.tsx
@@ -20,6 +20,7 @@ import { ConnectionsBrowserSidePanel } from 'components/Connections/Browser/Side
 import { ConnectionsBrowser } from 'components/Connections/Browser/index';
 import makeStyles from '@material-ui/core/styles/makeStyles';
 import { useParams } from 'react-router';
+import { ConnectionsContext } from 'components/Connections/ConnectionsContext';
 
 interface IConnectionsHomeStyleProps {
   sidePanelCollapsed: boolean;
@@ -36,7 +37,8 @@ const useStyle = makeStyles<Theme, IConnectionsHomeStyleProps>((theme) => {
   };
 });
 
-export function ConnectionsHome({ enableRouting }) {
+export function ConnectionsHome() {
+  const { mode } = React.useContext(ConnectionsContext);
   const params = useParams();
   const [sidePanelCollapsed, setSidePanelCollapsed] = React.useState(false);
   const [selectedConnection, setSelectedConnection] = React.useState(
@@ -53,14 +55,12 @@ export function ConnectionsHome({ enableRouting }) {
   return (
     <div className={classes.root}>
       <ConnectionsBrowserSidePanel
-        enableRouting={enableRouting}
         onSidePanelToggle={() => setSidePanelCollapsed(true)}
         onConnectionSelection={(conn) => setSelectedConnection(conn)}
         selectedConnection={selectedConnection}
       />
       <ConnectionsBrowser
         selectedConnection={selectedConnection}
-        enableRouting={enableRouting}
         expanded={sidePanelCollapsed}
         onCollapse={() => setSidePanelCollapsed(false)}
       />

--- a/app/cdap/components/Connections/Routes.tsx
+++ b/app/cdap/components/Connections/Routes.tsx
@@ -19,17 +19,17 @@ import { Route, Switch } from 'react-router-dom';
 import { CreateConnection } from 'components/Connections/Create';
 import { ConnectionsHome } from 'components/Connections/Home';
 
-export function ConnectionRoutes({ enableRouting }) {
+export function ConnectionRoutes() {
   return (
     <Switch>
       <Route exact path="/ns/:namespace/connections/create">
-        <CreateConnection enableRouting={enableRouting} />
+        <CreateConnection />
       </Route>
       <Route path="/ns/:namespace/connections/:connectionid">
-        <ConnectionsHome enableRouting={enableRouting} />
+        <ConnectionsHome />
       </Route>
       <Route path="/ns/:namespace/connections">
-        <ConnectionsHome enableRouting={enableRouting} />
+        <ConnectionsHome />
       </Route>
     </Switch>
   );

--- a/app/cdap/components/DataPrep/DataPrepTable/index.js
+++ b/app/cdap/components/DataPrep/DataPrepTable/index.js
@@ -52,8 +52,8 @@ export default class DataPrepTable extends Component {
     let storeState = DataPrepStore.getState();
     let workspaceId = storeState.dataprep.workspaceId;
     let currentWorkspace =
-      storeState.workspaces.list.find((workspace) => workspace.id === workspaceId) || {};
-    let currentWorkspaceName = currentWorkspace.name;
+      storeState.workspaces.list.find((workspace) => workspace.workspaceId === workspaceId) || {};
+    let currentWorkspaceName = currentWorkspace.workspaceName;
     this.state = {
       headers: storeState.dataprep.headers.map((header) => ({ name: header, edit: false })),
       data: storeState.dataprep.data.map((d, i) =>

--- a/app/cdap/components/DataPrep/Directives/DropColumn/index.js
+++ b/app/cdap/components/DataPrep/Directives/DropColumn/index.js
@@ -30,8 +30,11 @@ export default class DropColumnDirective extends Component {
   }
 
   applyDirective() {
-    let column = this.props.column.toString();
-    let directive = `drop :${column}`;
+    let column = `:${this.props.column.toString()}`;
+    if (Array.isArray(this.props.column) && this.props.column.length > 1) {
+      column = this.props.column.map(c => `:${c}`).join(',');
+    }
+    let directive = `drop ${column}`;
 
     execute([directive]).subscribe(
       () => {

--- a/app/cdap/components/DataPrep/WorkspaceTabs/WorkspaceTab/index.js
+++ b/app/cdap/components/DataPrep/WorkspaceTabs/WorkspaceTab/index.js
@@ -37,7 +37,7 @@ export default class WorkspaceTab extends Component {
   }
 
   componentDidUpdate() {
-    let workspaceElem = document.getElementById(this.props.workspace.id);
+    let workspaceElem = document.getElementById(this.props.workspace.workspaceId);
     if (!workspaceElem) {
       return;
     }
@@ -55,11 +55,11 @@ export default class WorkspaceTab extends Component {
   }
 
   renderName() {
-    return <span className="original-name">{this.props.workspace.name}</span>;
+    return <span className="original-name">{this.props.workspace.workspaceName}</span>;
   }
 
   renderOverflow() {
-    let name = this.props.workspace.name;
+    let name = this.props.workspace.workspaceName;
 
     return (
       <span className="display-name">
@@ -74,7 +74,11 @@ export default class WorkspaceTab extends Component {
     let workspace = this.props.workspace;
 
     return (
-      <div id={workspace.id} className="workspace-tab active clearfix" title={workspace.name}>
+      <div
+        id={workspace.id}
+        className="workspace-tab active clearfix"
+        title={workspace.workspaceName}
+      >
         <span className="display-name-container float-left">
           {this.state.overflow ? this.renderOverflow() : this.renderName()}
         </span>
@@ -90,9 +94,9 @@ export default class WorkspaceTab extends Component {
     let workspace = this.props.workspace;
 
     return (
-      <div id={workspace.id} className="workspace-tab clearfix" title={workspace.name}>
+      <div id={workspace.id} className="workspace-tab clearfix" title={workspace.workspaceName}>
         <span className="display-name-container float-left">
-          <Link to={`/ns/${this.namespace}/wrangler/${workspace.id}`}>
+          <Link to={`/ns/${this.namespace}/wrangler/${workspace.workspaceId}`}>
             {this.state.overflow ? this.renderOverflow() : this.renderName()}
           </Link>
         </span>

--- a/app/cdap/components/DataPrep/WorkspaceTabs/index.js
+++ b/app/cdap/components/DataPrep/WorkspaceTabs/index.js
@@ -82,7 +82,7 @@ export default class WorkspaceTabs extends Component {
     this.calculateMaxTabs();
     MouseTrap.bind('enter', () => {
       if (this.state.deleteWorkspace) {
-        this.handleDeleteWorkspace(this.state.deleteWorkspace.id);
+        this.handleDeleteWorkspace(this.state.deleteWorkspace.workspaceId);
       }
     });
 
@@ -193,14 +193,14 @@ export default class WorkspaceTabs extends Component {
         <UncontrolledPopover popperClassName="workspace-list-popover">
           {list.map((workspace) => {
             return (
-              <div key={workspace.id} className="workspace-list-dropdown-item">
+              <div key={workspace.workspaceId} className="workspace-list-dropdown-item">
                 <Link
-                  to={`/ns/${this.namespace}/wrangler/${workspace.id}`}
+                  to={`/ns/${this.namespace}/wrangler/${workspace.workspaceId}`}
                   className={classnames('workspace-link', {
-                    active: this.state.activeWorkspace === workspace.id,
+                    active: this.state.activeWorkspace === workspace.workspaceId,
                   })}
                 >
-                  {workspace.name}
+                  {workspace.workspaceName}
                 </Link>
 
                 <span
@@ -226,9 +226,9 @@ export default class WorkspaceTabs extends Component {
           return (
             <WorkspaceTab
               workspace={workspace}
-              active={this.state.activeWorkspace === workspace.id}
+              active={this.state.activeWorkspace === workspace.workspaceId}
               onDelete={this.toggleDeleteWorkspace.bind(this, workspace)}
-              key={workspace.id}
+              key={workspace.workspaceId}
             />
           );
         })}
@@ -246,7 +246,7 @@ export default class WorkspaceTabs extends Component {
       <React.Fragment>
         <h5>
           {T.translate(`${PREFIX}.DeleteModal.mainMessage`, {
-            workspace: this.state.deleteWorkspace.name,
+            workspace: this.state.deleteWorkspace.workspaceName,
           })}
         </h5>
         <div>{T.translate(`${PREFIX}.DeleteModal.helperMessage`)}</div>
@@ -258,7 +258,7 @@ export default class WorkspaceTabs extends Component {
         confirmationElem={ConfirmationElement}
         confirmButtonText={T.translate(`${PREFIX}.DeleteModal.confirmButton`)}
         cancelButtonText={T.translate(`${PREFIX}.DeleteModal.cancelButton`)}
-        confirmFn={this.handleDeleteWorkspace.bind(this, this.state.deleteWorkspace.id)}
+        confirmFn={this.handleDeleteWorkspace.bind(this, this.state.deleteWorkspace.workspaceId)}
         cancelFn={this.toggleDeleteWorkspace.bind(this, null)}
         isOpen={true}
         headerTitle={T.translate(`${PREFIX}.DeleteModal.header`)}

--- a/app/cdap/components/DataPrep/helper.js
+++ b/app/cdap/components/DataPrep/helper.js
@@ -22,22 +22,10 @@ import Version from 'services/VersionRange/Version';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import NamespaceStore from 'services/NamespaceStore';
 
-export function directiveRequestBodyCreator(directivesArray, wsId) {
-  let workspaceId = wsId || DataPrepStore.getState().dataprep.workspaceId;
-
+export function directiveRequestBodyCreator(directivesArray) {
   return {
-    version: 1.0,
-    workspace: {
-      name: workspaceId,
-      results: 1000,
-    },
-    recipe: {
-      directives: directivesArray,
-    },
-    sampling: {
-      method: 'FIRST',
-      limit: 1000,
-    },
+    directives: directivesArray,
+    limit: 1000,
   };
 }
 

--- a/app/cdap/components/DataPrep/index.js
+++ b/app/cdap/components/DataPrep/index.js
@@ -31,7 +31,7 @@ import WorkspaceTabs from 'components/DataPrep/WorkspaceTabs';
 import IconSVG from 'components/IconSVG';
 import classnames from 'classnames';
 import { checkDataPrepHigherVersion } from 'components/DataPrep/helper';
-import { isNilOrEmpty } from 'services/helpers';
+import { isNilOrEmpty, isNilOrEmptyString } from 'services/helpers';
 import LoadingSVGCentered from 'components/LoadingSVGCentered';
 import T from 'i18n-react';
 import isEmpty from 'lodash/isEmpty';
@@ -144,7 +144,7 @@ export default class DataPrep extends Component {
   checkBackendUp() {
     // On single workspace mode (within pipeline), the service management is
     // handled from the wrapper component (DataPrepHome)
-    if (!this.props.singleWorkspaceMode) {
+    if (!this.props.mode === 'ROUTED_WORKSPACE') {
       this.init(this.props);
       return;
     }
@@ -166,7 +166,7 @@ export default class DataPrep extends Component {
   init(props) {
     const workspaceId = props.workspaceId;
 
-    if (props.singleWorkspaceMode) {
+    if (props.mode === 'ROUTED_WORKSPACE') {
       DataPrepStore.dispatch({
         type: DataPrepActions.setWorkspaceMode,
         payload: {
@@ -181,6 +181,9 @@ export default class DataPrep extends Component {
   }
 
   setCurrentWorkspace(workspaceId) {
+    if (isNilOrEmptyString(workspaceId)) {
+      return;
+    }
     setWorkspace(workspaceId).subscribe(
       () => {
         let { properties } = DataPrepStore.getState().dataprep;
@@ -238,7 +241,7 @@ export default class DataPrep extends Component {
   }
 
   renderTabs() {
-    if (this.props.singleWorkspaceMode) {
+    if (this.props.mode === 'ROUTED_WORKSPACE') {
       return null;
     }
 
@@ -301,10 +304,10 @@ export default class DataPrep extends Component {
     return (
       <div
         className={classnames('dataprep-container', {
-          'single-workspace': this.props.singleWorkspaceMode,
+          'single-workspace': this.props.mode === 'ROUTED_WORKSPACE',
         })}
       >
-        {this.props.singleWorkspaceMode ? null : (
+        {this.props.mode === 'ROUTED_WORKSPACE' ? null : (
           <Helmet
             title={T.translate(`${DATAPREP_I18N_PREFIX}.pageTitle`, {
               workspaceUri: !isNilOrEmpty(this.state.workspaceName)
@@ -323,7 +326,7 @@ export default class DataPrep extends Component {
           <div className="top-section-content float-left">
             {this.renderTabs()}
             <DataPrepTopPanel
-              singleWorkspaceMode={this.props.singleWorkspaceMode}
+              mode={this.props.mode}
               onSubmit={this.onSubmitToListener.bind(this)}
               disabled={this.props.disabled}
             />
@@ -342,7 +345,7 @@ export default class DataPrep extends Component {
   }
 }
 DataPrep.propTypes = {
-  singleWorkspaceMode: PropTypes.bool,
+  mode: PropTypes.oneOf(['ROUTED', 'ROUTED_WORKSPACE', 'INMEMORY']),
   workspaceId: PropTypes.string,
   onSubmit: PropTypes.func,
   onConnectionsToggle: PropTypes.func.isRequired,

--- a/app/cdap/components/DataPrepConnections/PluginConnectionBrowser/index.tsx
+++ b/app/cdap/components/DataPrepConnections/PluginConnectionBrowser/index.tsx
@@ -19,7 +19,6 @@ import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
 
 import Button from '@material-ui/core/Button';
 import { ConnectionType } from 'components/DataPrepConnections/ConnectionType';
-import DataPrepConnection from 'components/DataPrepConnections';
 import ErrorBanner from 'components/ErrorBanner';
 import { IWidgetProps } from 'components/AbstractWidget';
 import If from 'components/If';
@@ -31,6 +30,7 @@ import ee from 'event-emitter';
 import { getCurrentNamespace } from 'services/NamespaceStore';
 import { objectQuery } from 'services/helpers';
 import Connections from 'components/Connections';
+import { IConnectionMode } from 'components/Connections/ConnectionsContext';
 import { ConnectionsApi } from 'api/connections';
 
 const styles = (theme) => {
@@ -346,7 +346,7 @@ class PluginConnectionBrowser extends React.PureComponent<
           </div>
           <ModalBody>
             <If condition={!this.state.loading}>
-              <Connections enableRouting={false} singleWorkspaceMode={true} />
+              <Connections mode={IConnectionMode.ROUTED_WORKSPACE} />
             </If>
             <If condition={this.state.loading}>
               <LoadingSVGCentered />

--- a/app/cdap/components/DataPrepHome/DataPrepHome.scss
+++ b/app/cdap/components/DataPrepHome/DataPrepHome.scss
@@ -14,20 +14,16 @@
  * the License.
 */
 
+.dataprep-home-container {
+  height: inherit;
+  overflow-y: hidden;
+}
 .dataprephome-wrapper {
-  display: flex;
+  display: grid;
+  grid-template-columns: 100%;
   height: 100%;
-  > div {
-    &:only-child {
-      flex: 1;
-    }
-    &:not(:only-child) {
-      &:first-child {
-        flex: 0.5;
-      }
-      &:nth-child(2) {
-        flex: 0.5;
-      }
-    }
+
+  &.connections-toggle {
+    grid-template-columns: 50% 50%;
   }
 }

--- a/app/cdap/components/PipelineContextMenu/WranglerConnection/index.tsx
+++ b/app/cdap/components/PipelineContextMenu/WranglerConnection/index.tsx
@@ -122,7 +122,7 @@ function WranglerConnection({
       </div>
       <div className="modal-body">
         <If condition={showModal}>
-          <DataPrepHome singleWorkspaceMode={true} onSubmit={onWranglerConnectionSubmit} />
+          <DataPrepHome mode="ROUTED_WORKSPACE" onSubmit={onWranglerConnectionSubmit} />
         </If>
       </div>
     </Modal>


### PR DESCRIPTION
JIRA - https://cdap.atlassian.net/browse/CDAP-17878

**Functional change**
- From a user perspective nothing changes. They will still see valid connections/wrangler workspace/ apply directives.
- Behind the scenes
  - The PR primarily addresses the integration of wrangler UI with v2 wrangler API.
  - This should enable a working solution of wrangler from wrangler/connections side. User should be able to navigate from connection to wrangler and apply directives.
  - This also fixes the "Wrangle" button in the wrangler transform which does the same thing.
  - Fixes DataprepActionCreator based on changes in response from v2 API

**Code Improvements**
- Cleans up `Connections`. Removes `enableRouting` and `singleWorkspaceMode` and consolidates them to `mode`.
- Introduces Context to be shared between Connection and children of Connection component.

**TODO**
- The 'Browse' functionality is still not addressed in this PR. The specification API from backend is available and we should be able to add it as a separate PR
- `DataPrepHome`, `DataPrep` modules can be converted to tsx. I have not done that in this PR as that conversion introduces like 100+ errors which increases the scope of this PR. Once we do this we should be able to remove the hardcoding `ROUTED_WORKSPACE` and `INMEMORY`