### PR TITLE
 [CDAP-18040] Type-specific formatting for connection browser table

### DIFF
--- a/app/cdap/components/Connections/Browser/GenericBrowser/BrowserTable.tsx
+++ b/app/cdap/components/Connections/Browser/GenericBrowser/BrowserTable.tsx
@@ -29,6 +29,7 @@ import FolderIcon from '@material-ui/icons/Folder';
 import DescriptionIcon from '@material-ui/icons/Description';
 import Heading, { HeadingTypes } from 'components/Heading';
 import LoadingSVG from 'components/LoadingSVG';
+import { format } from 'services/DataFormatter';
 
 const ICON_MAP = {
   directory: <FolderIcon />,
@@ -123,7 +124,7 @@ export function BrowserTable({
                 {entity.properties.map((prop) => {
                   return (
                     <TableCell key={prop.value}>
-                      {prop.type === 'Timestamp' ? humanReadableDate(prop.value) : prop.value}
+                      {format(prop.value, prop.type, { concise: true })}
                     </TableCell>
                   );
                 })}

--- a/app/cdap/services/DataFormatter/__tests__/DataFormatter.test.ts
+++ b/app/cdap/services/DataFormatter/__tests__/DataFormatter.test.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { format, TYPES } from '../index';
+
+describe('DataFormatter', () => {
+  describe('string type', () => {
+    it('should format a string', () => {
+      expect(format('Hello world', TYPES.STRING)).toBe('Hello world');
+    });
+
+    it('should format a string in concise mode', () => {
+      expect(format('Hello world', TYPES.STRING, { concise: true })).toBe('Hello world');
+    });
+  });
+
+  describe('number type', () => {
+    it('should format a number', () => {
+      expect(format(8128437, TYPES.NUMBER)).toBe('8,128,437');
+    });
+
+    it('should format a number in concise mode', () => {
+      expect(format(8128437, TYPES.NUMBER, { concise: true })).toBe('8.1M');
+    });
+  });
+
+  // TODO The following tests will only work on machines in the Pacific timezone
+  describe.skip('timestamp_millis type', () => {
+    it('should format a timestamp', () => {
+      expect(format(1623104962602, TYPES.TIMESTAMP_MILLIS)).toBe('June 7, 2021 at 3:29:22 PM');
+    });
+
+    it('should format a timestamp in concise mode', () => {
+      expect(format(1623104962602, TYPES.TIMESTAMP_MILLIS, { concise: true })).toBe('6/7/21, 3:29:22 PM');
+    });
+  });
+
+  describe('date_local_iso type', () => {
+    it('should format a date', () => {
+      expect(format('2021-06-07', TYPES.DATE_ISO_LOCAL)).toBe('June 7, 2021');
+    });
+
+    it('should format a date in concise mode', () => {
+      expect(format('2021-06-07', TYPES.DATE_ISO_LOCAL, { concise: true })).toBe('6/7/2021');
+    });
+  });
+
+  describe('file_size type', () => {
+    it('should format a file size', () => {
+      expect(format(8128437, TYPES.FILE_SIZE)).toBe('8,128,437 byte');
+    });
+
+    it('should format a number in concise mode', () => {
+      expect(format(8128437, TYPES.FILE_SIZE, { concise: true })).toBe('7.8 MB');
+    });
+  });
+
+  describe('unknown type', () => {
+    it('should use toString if available', () => {
+      const obj = { a: 'foo', toString: () => 'output of toString' };
+      expect(format(obj, 'UNKNOWN')).toBe('output of toString');
+    });
+  });
+});

--- a/app/cdap/services/DataFormatter/index.ts
+++ b/app/cdap/services/DataFormatter/index.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import moment from 'moment';
+
+export const TYPES = {
+  STRING: 'string',
+  NUMBER: 'number',
+  DATE_ISO_LOCAL: 'date_iso_local',
+  TIMESTAMP_MILLIS: 'timestamp_millis',
+  FILE_SIZE: 'file_size',
+};
+
+// TODO format options here need TS 4.1+
+
+const numberFormatter = Intl.NumberFormat();
+const conciseNumberFormatter = Intl.NumberFormat(undefined, {
+  // @ts-ignore
+  notation: 'compact',
+});
+
+const dateFormatter = Intl.DateTimeFormat(undefined, {
+  // @ts-ignore
+  dateStyle: 'long',
+});
+const conciseDateFormatter = Intl.DateTimeFormat(undefined, {
+  // @ts-ignore
+  dateTyle: 'short',
+});
+
+const dateTimeFormatter = Intl.DateTimeFormat(undefined, {
+  // @ts-ignore
+  dateStyle: 'long',
+  timeStyle: 'medium',
+});
+const conciseDateTimeFormatter = Intl.DateTimeFormat(undefined, {
+  // @ts-ignore
+  dateStyle: 'short',
+  timeStyle: 'medium',
+});
+
+const byteFormatter = Intl.NumberFormat(undefined, {
+  style: 'unit',
+  // @ts-ignore
+  unit: 'byte',
+});
+
+const byteSizeUnits = ['byte', 'kilobyte', 'megabyte', 'gigabyte', 'terabyte', 'petabyte'];
+const conciseByteSizeFormatters = byteSizeUnits.map((unit) =>
+  Intl.NumberFormat(undefined, {
+    // @ts-ignore
+    notation: 'compact',
+    style: 'unit',
+    unit,
+  })
+);
+
+function formatConciseByteSize(value) {
+  const exponent = Math.min(Math.floor(Math.log(value) / Math.log(1024)), 5);
+  const decimal = value / Math.pow(1024, exponent);
+  return conciseByteSizeFormatters[exponent].format(decimal);
+}
+
+export function format(value, type, options) {
+  switch (type) {
+    case TYPES.STRING:
+      return value;
+    case TYPES.NUMBER:
+      if (options.concise) {
+        return conciseNumberFormatter.format(value);
+      }
+      return numberFormatter.format(value);
+    case TYPES.TIMESTAMP_MILLIS:
+      const timestampDate = new Date(value);
+      if (options.concise) {
+        return conciseDateTimeFormatter.format(timestampDate);
+      }
+      return dateTimeFormatter.format(timestampDate);
+    case TYPES.DATE_ISO_LOCAL:
+      const localDate = moment(value).toDate();
+      if (options.concise) {
+        return conciseDateFormatter.format(localDate);
+      }
+      return dateFormatter.format(localDate);
+    case TYPES.FILE_SIZE:
+      if (options.concise) {
+        return formatConciseByteSize(value);
+      }
+      return byteFormatter.format(value);
+    default:
+      return value.toString ? value.toString() : JSON.stringify(value);
+  }
+}

--- a/app/cdap/services/DataFormatter/index.ts
+++ b/app/cdap/services/DataFormatter/index.ts
@@ -24,7 +24,7 @@ export const TYPES = {
   FILE_SIZE: 'file_size',
 };
 
-// TODO format options here need TS 4.1+
+// TODO some format options here need TS 4.1+
 
 const numberFormatter = Intl.NumberFormat();
 const conciseNumberFormatter = Intl.NumberFormat(undefined, {
@@ -74,7 +74,7 @@ function formatConciseByteSize(value) {
   return conciseByteSizeFormatters[exponent].format(decimal);
 }
 
-export function format(value, type, options) {
+export function format(value, type, options: { concise?: boolean } = {}) {
   switch (type) {
     case TYPES.STRING:
       return value;


### PR DESCRIPTION
This adds DataFormatter, which I'm proposing to use for all data fields that are returned from the back end. We should also review the formats used to display values.

Jira: https://cdap.atlassian.net/browse/CDAP-18040