### PR TITLE
[CDAP-17915] Adds schema name to table name for search filtering

### DIFF
--- a/app/cdap/components/Replicator/Create/Content/SelectTables/index.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectTables/index.tsx
@@ -204,7 +204,8 @@ class SelectTablesView extends React.PureComponent<ISelectTablesProps, ISelectTa
     let filteredTables = tables;
     if (search && search.length > 0) {
       filteredTables = filteredTables.filter((row) => {
-        const normalizedTable = row.table.toLowerCase();
+        const tableName = getTableDisplayName(row);
+        const normalizedTable = tableName.toLowerCase();
         const normalizedSearch = search.toLowerCase();
 
         return normalizedTable.indexOf(normalizedSearch) !== -1;

--- a/app/cdap/components/Replicator/Create/Content/Summary/TableList/index.tsx
+++ b/app/cdap/components/Replicator/Create/Content/Summary/TableList/index.tsx
@@ -73,7 +73,8 @@ const TableListView: React.FC<ICreateContext & WithStyles<typeof styles>> = ({
     }
 
     const filteredList = tables.toList().filter((row) => {
-      const normalizedTable = row.get('table').toLowerCase();
+      const tableName = getTableDisplayName(row);
+      const normalizedTable = tableName.toLowerCase();
       const normalizedSearch = search.toLowerCase();
 
       return normalizedTable.indexOf(normalizedSearch) !== -1;

--- a/app/cdap/components/Replicator/Detail/Overview/TablesList/index.tsx
+++ b/app/cdap/components/Replicator/Detail/Overview/TablesList/index.tsx
@@ -119,7 +119,8 @@ const TablesListView: React.FC<WithStyles<typeof styles>> = ({ classes }) => {
 
     const filteredList = tables
       .filter((row) => {
-        const normalizedTable = row.get('table').toLowerCase();
+        const tableName = getTableDisplayName(row);
+        const normalizedTable = tableName.toLowerCase();
         const normalizedSearch = search.toLowerCase();
 
         return normalizedTable.indexOf(normalizedSearch) !== -1;


### PR DESCRIPTION
Bugfix

Fixes [CDAP-17915](https://cdap.atlassian.net/browse/CDAP-17915).

Reused getTableDisplayName to use as the search term for the table row filtering. 