### PR TITLE
[CDAP-17510] Disables checkbox for selecting column on table replication if primary key

### DIFF
--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -2510,6 +2510,11 @@ features:
     user: Business
     value: Value
 
+  Replication:
+    Create:
+      Content:
+        SelectColumns:
+          primaryKeyDescription: Must include primary key
   Reports:
     Customizer:
       clear: Clear Selection


### PR DESCRIPTION
Bugfix

Fixes [CDAP-17510](https://cdap.atlassian.net/browse/CDAP-17510).

Disables checkbox for selecting column on table replication if primary key. 

I have a couple of questions though:
- Should we only disable it if it is selected? Is it possible for a user to deselect it in another way?
- Should we notify the user why this checkbox is disabled? We can use tooltips as long as the tooltip is accessible?

<img width="751" alt="Screen Shot 2021-06-16 at 9 27 25 PM" src="https://user-images.githubusercontent.com/2054644/122331751-2dbd9380-ceea-11eb-90b3-ba8b0d3932a1.png">
