### PR TITLE
[CDAP-18040] Type-specific formatting for connection browser table

### DIFF
--- a/app/cdap/components/Connections/Browser/GenericBrowser/BrowserTable.tsx
+++ b/app/cdap/components/Connections/Browser/GenericBrowser/BrowserTable.tsx
@@ -20,8 +20,6 @@ import TableHeader from 'components/Table/TableHeader';
 import TableRow from 'components/Table/TableRow';
 import TableCell from 'components/Table/TableCell';
 import TableBody from 'components/Table/TableBody';
-import { humanReadableDate, objectQuery } from 'services/helpers';
-import capitalize from 'lodash/capitalize';
 import If from 'components/If';
 import { getCurrentNamespace } from 'services/NamespaceStore';
 import makeStyle from '@material-ui/core/styles/makeStyles';
@@ -29,10 +27,16 @@ import FolderIcon from '@material-ui/icons/Folder';
 import DescriptionIcon from '@material-ui/icons/Description';
 import Heading, { HeadingTypes } from 'components/Heading';
 import LoadingSVG from 'components/LoadingSVG';
+import { format } from 'services/DataFormatter';
 
 const ICON_MAP = {
   directory: <FolderIcon />,
   file: <DescriptionIcon />,
+};
+
+const RIGHT_ALIGN_PROP_TYPES = {
+  NUMBER: true,
+  SIZE_BYTES: true,
 };
 
 const useStyle = makeStyle(() => {
@@ -79,14 +83,17 @@ export function BrowserTable({
   loading,
   selectedConnection,
   path,
+  propertyHeaders,
   entities,
   onExplore,
-  propertyHeaders,
 }: IBrowserTable) {
   const classes = useStyle();
 
   const getPath = (suffix) => (path === '/' ? `/${suffix}` : `${path}/${suffix}`);
   const columnTemplate = `repeat(${propertyHeaders.length + 2}, 1fr)`;
+
+  let headers = ['Name', 'Type'];
+  headers = [...headers, ...propertyHeaders];
 
   if (!loading && (!Array.isArray(entities) || (Array.isArray(entities) && !entities.length))) {
     return (
@@ -106,7 +113,7 @@ export function BrowserTable({
             <TableCell>Name</TableCell>
             <TableCell>Type</TableCell>
             {propertyHeaders.map((header) => {
-              return <TableCell key={header}>{capitalize(header)}</TableCell>;
+              return <TableCell key={header}>{header}</TableCell>;
             })}
           </TableRow>
         </TableHeader>
@@ -127,14 +134,14 @@ export function BrowserTable({
                   </div>
                 </TableCell>
                 <TableCell>{entity.type}</TableCell>
-                {propertyHeaders.map((prop) => {
-                  const property = entity.properties?.[prop];
-                  const type = property?.type;
-                  const value = property?.value;
-
+                {propertyHeaders.map((header) => {
+                  const prop = entity.properties[header];
                   return (
-                    <TableCell key={value}>
-                      {type === 'Timestamp' ? humanReadableDate(value) : value}
+                    <TableCell
+                      key={header}
+                      textAlign={prop && RIGHT_ALIGN_PROP_TYPES[prop.type] ? 'right' : 'left'}
+                    >
+                      {prop && format(prop.value, prop.type, { concise: true })}
                     </TableCell>
                   );
                 })}

--- a/app/cdap/components/Connections/Browser/GenericBrowser/index.tsx
+++ b/app/cdap/components/Connections/Browser/GenericBrowser/index.tsx
@@ -21,7 +21,6 @@ import {
   createWorkspace,
   getPluginSpec,
 } from 'components/Connections/Browser/GenericBrowser/apiHelpers';
-import capitalize from 'lodash/capitalize';
 import countBy from 'lodash/countBy';
 import debounce from 'lodash/debounce';
 import makeStyle from '@material-ui/core/styles/makeStyles';
@@ -37,7 +36,7 @@ import ErrorBanner from 'components/ErrorBanner';
 
 const PREFIX = 'features.DataPrep.DataPrepBrowser.GenericBrowser';
 import { Redirect } from 'react-router';
-import { ConnectionsContext, IConnectionMode } from 'components/Connections/ConnectionsContext';
+import { ConnectionsContext } from 'components/Connections/ConnectionsContext';
 import EntityCount from './EntityCount';
 
 const ENTITY_TRUNCATION_LIMIT = 1000;
@@ -71,6 +70,7 @@ export function GenericBrowser({ selectedConnection }) {
   const queryParams = new URLSearchParams(loc.search);
   const pathFromUrl = queryParams.get('path') || '/';
   const [entities, setEntities] = React.useState([]);
+  const [propertyHeaders, setPropertyHeaders] = React.useState([]);
   const [totalCount, setTotalCount] = React.useState(0);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState(null);
@@ -78,7 +78,6 @@ export function GenericBrowser({ selectedConnection }) {
   const [searchString, setSearchString] = React.useState('');
   const [searchStringDisplay, setSearchStringDisplay] = React.useState('');
   const [workspaceId, setWorkspaceId] = React.useState(null);
-  const [propertyHeaders, setPropertyHeaders] = React.useState([]);
   const classes = useStyle();
   const { onWorkspaceCreate, onEntitySelect } = React.useContext(ConnectionsContext);
 
@@ -227,11 +226,11 @@ export function GenericBrowser({ selectedConnection }) {
       <If condition={loading || (!isEmpty && !error)}>
         <BrowserTable
           entities={filteredEntities}
+          propertyHeaders={propertyHeaders}
           selectedConnection={selectedConnection}
           path={path}
           onExplore={onExplore}
           loading={loading}
-          propertyHeaders={propertyHeaders}
         />
       </If>
       <If condition={isEmpty && !loading}>

--- a/app/cdap/services/DataFormatter/__tests__/DataFormatter.test.ts
+++ b/app/cdap/services/DataFormatter/__tests__/DataFormatter.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { format, TYPES } from '../index';
+
+describe('DataFormatter', () => {
+  describe('string type', () => {
+    it('should format a string', () => {
+      expect(format('Hello world', TYPES.STRING)).toBe('Hello world');
+    });
+
+    it('should format a string in concise mode', () => {
+      expect(format('Hello world', TYPES.STRING, { concise: true })).toBe('Hello world');
+    });
+  });
+
+  describe('number type', () => {
+    it('should format a number', () => {
+      expect(format(8128437, TYPES.NUMBER)).toBe('8,128,437');
+    });
+
+    it('should format a number in concise mode', () => {
+      expect(format(8128437, TYPES.NUMBER, { concise: true })).toBe('8M');
+    });
+  });
+
+  // TODO The following tests will only work on machines in the Pacific timezone
+  describe.skip('timestamp_millis type', () => {
+    it('should format a timestamp', () => {
+      expect(format(1623104962602, TYPES.TIMESTAMP_MILLIS)).toBe('06-07-2021 3:29:22 PM');
+    });
+
+    it('should format a timestamp in concise mode', () => {
+      expect(format(1623104962602, TYPES.TIMESTAMP_MILLIS, { concise: true })).toBe(
+        '06-07-2021 3:29:22 PM'
+      );
+    });
+  });
+
+  describe('date_local_iso type', () => {
+    it('should format a date', () => {
+      expect(format('2021-06-07', TYPES.DATE_LOCAL_ISO)).toBe('06-07-2021');
+    });
+
+    it('should format a date in concise mode', () => {
+      expect(format('2021-06-07', TYPES.DATE_LOCAL_ISO, { concise: true })).toBe('06-07-2021');
+    });
+  });
+
+  describe('size_bytes type', () => {
+    it('should format a file size', () => {
+      expect(format('8128437', TYPES.SIZE_BYTES)).toBe('8.13MB');
+    });
+
+    it('should format a number in concise mode', () => {
+      expect(format('8128437', TYPES.SIZE_BYTES, { concise: true })).toBe('8.13MB');
+    });
+
+    it('should format 0 in concise mode', () => {
+      expect(format('0', TYPES.SIZE_BYTES, { concise: true })).toBe(0);
+    });
+  });
+
+  describe('unknown type', () => {
+    it('should use toString if available', () => {
+      const obj = { a: 'foo', toString: () => 'output of toString' };
+      expect(format(obj, 'UNKNOWN')).toBe('output of toString');
+    });
+  });
+});

--- a/app/cdap/services/DataFormatter/index.ts
+++ b/app/cdap/services/DataFormatter/index.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import moment from 'moment';
+import { convertBytesToHumanReadable, humanReadableNumber, truncateNumber } from 'services/helpers';
+
+export const TYPES = {
+  STRING: 'STRING',
+  NUMBER: 'NUMBER',
+  DATE_LOCAL_ISO: 'DATE_LOCAL_ISO',
+  TIMESTAMP_MILLIS: 'TIMESTAMP_MILLIS',
+  SIZE_BYTES: 'SIZE_BYTES',
+};
+
+const EMPTY_DATE = '--';
+
+// TODO Replace moment.format with Intl.DateTimeFormat
+function formatDate(momentInstance) {
+  return momentInstance.format('MM-DD-YYYY');
+}
+
+function formatDateTime(momentInstance) {
+  return momentInstance.format('MM-DD-YYYY hh:mm:ss A');
+}
+
+export function format(value, type, options: { concise?: boolean } = {}) {
+  switch (type) {
+    case TYPES.STRING:
+      return value;
+    case TYPES.NUMBER: {
+      const numVal = parseInt(value, 10);
+      if (options.concise) {
+        return truncateNumber(numVal);
+      }
+      return humanReadableNumber(numVal);
+    }
+    case TYPES.TIMESTAMP_MILLIS: {
+      if (!value) {
+        return EMPTY_DATE;
+      }
+      const timestampMoment = moment(parseInt(value, 10));
+      return formatDateTime(timestampMoment);
+    }
+    case TYPES.DATE_LOCAL_ISO: {
+      if (!value) {
+        return EMPTY_DATE;
+      }
+      const localMoment = moment(value);
+      return formatDate(localMoment);
+    }
+    case TYPES.SIZE_BYTES: {
+      const numVal = parseInt(value, 10);
+      return convertBytesToHumanReadable(numVal);
+    }
+    default:
+      return value.toString ? value.toString() : JSON.stringify(value);
+  }
+}


### PR DESCRIPTION
Adds `DataFormatter` which is intended to be extended for other data tables.

![image](https://user-images.githubusercontent.com/2728821/122826663-42a67800-d298-11eb-8e12-089f315d545a.png)
