### PR TITLE
Set node back to 10.16 to avoid issues with dependencies

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.17]
+        node-version: [10.16]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/package.json
+++ b/package.json
@@ -252,7 +252,7 @@
     "yml-loader": "2.1.0"
   },
   "engines": {
-    "node": ">= 12.11.0"
+    "node": ">= 10.12.2"
   },
   "resolutions": {
     "**/cypress": "5.6.0"

--- a/pom.xml
+++ b/pom.xml
@@ -218,8 +218,8 @@
                   <goal>install-node-and-yarn</goal>
                 </goals>
                 <configuration>
-                  <nodeVersion>v14.17.1</nodeVersion>
-                  <yarnVersion>v1.22.5</yarnVersion>
+                  <nodeVersion>v10.16.2</nodeVersion>
+                  <yarnVersion>v1.7.0</yarnVersion>
                 </configuration>
               </execution>
               <execution>
@@ -335,8 +335,8 @@
                   <goal>install-node-and-yarn</goal>
                 </goals>
                 <configuration>
-                  <nodeVersion>v14.17.1</nodeVersion>
-                  <yarnVersion>v1.22.5</yarnVersion>
+                  <nodeVersion>v10.16.2</nodeVersion>
+                  <yarnVersion>v1.7.0</yarnVersion>
                 </configuration>
               </execution>
               <execution>


### PR DESCRIPTION
Node 14 requires Python 3, which is breaking our build.