### PR TITLE
E2E: Use 6.5 branch of the CDAP sandbox build (6.5 branch)

### DIFF
--- a/sandboxjs/bamboo_plan_info.json
+++ b/sandboxjs/bamboo_plan_info.json
@@ -1,4 +1,4 @@
 {
-  "planName": "CDAP-BUT",
+  "planName": "CDAP-BUT893",
   "version": "6.5.0-SNAPSHOT"
 }


### PR DESCRIPTION
This is only in the `release/6.5` branch - it should not be brought to `develop`