### PR TITLE
[CDAP-18078] [CDAP-18077]  Connection browser: icons, widths, non-sample entities for 6.5

### DIFF
--- a/app/cdap/components/Connections/Browser/GenericBrowser/index.tsx
+++ b/app/cdap/components/Connections/Browser/GenericBrowser/index.tsx
@@ -89,7 +89,10 @@ export function GenericBrowser({ selectedConnection }) {
         path,
       });
 
-      setEntities(res.entities);
+      const newEntities = [...res.entities];
+      newEntities.sort((a, b) => a.name.localeCompare(b.name));
+
+      setEntities(newEntities);
       setTotalCount(res.totalCount);
       setPropertyHeaders(res.propertyHeaders || []);
       setError(null);

--- a/app/cdap/components/Table/TableCell.tsx
+++ b/app/cdap/components/Table/TableCell.tsx
@@ -25,7 +25,7 @@ const styles = (): StyleRules => {
       borderBottom: 0,
       padding: '5px 7px',
       maxWidth: '100%',
-      overfllow: 'hidden',
+      overflow: 'hidden',
       wordBreak: 'inherit',
       textOverflow: 'ellipsis',
     },


### PR DESCRIPTION
Cherry-pick of #64 

[CDAP-18078] Add icons for all entity types
[CDAP-18077] Disable exploring entities that can't be explored
Tweak column widths - show ellipsis for truncated names, fix numeric width, display '--' for missing property values

Show ellipsis for long entry names. Make name column wider than the others.

Fix issue when only name and type shown. Also, add S3 bucket icon

Add more icons. Tweak column widths. Display '--' for all missing property values

[CDAP-18078]: https://cdap.atlassian.net/browse/CDAP-18078
[CDAP-18077]: https://cdap.atlassian.net/browse/CDAP-18077