### PR TITLE
[CDAP-18069] Test connection improvements: messaging and field-level errors

### DIFF
--- a/app/cdap/components/Connections/Create/ConnectionConfiguration/ConnectionConfigForm.tsx
+++ b/app/cdap/components/Connections/Create/ConnectionConfiguration/ConnectionConfigForm.tsx
@@ -21,6 +21,7 @@ import makeStyle from '@material-ui/core/styles/makeStyles';
 import PropertyRow from 'components/ConfigurationGroup/PropertyRow';
 import If from 'components/If';
 import LoadingSVG from 'components/LoadingSVG';
+import Alert from '@material-ui/lab/Alert';
 
 const useStyle = makeStyle((theme) => {
   return {
@@ -31,14 +32,11 @@ const useStyle = makeStyle((theme) => {
     },
     connectionTestMessage: {
       display: 'flex',
-      height: '2rem',
       padding: '0 10px',
+      marginBottom: '1rem',
     },
-    connectionTestSuccess: {
-      color: theme.palette.green[500],
-    },
-    connectionTestFailure: {
-      color: theme.palette.red[200],
+    alert: {
+      fontSize: 'inherit',
     },
   };
 });
@@ -109,6 +107,7 @@ export function ConnectionConfigForm({
         pluginProperties={connectorProperties}
         values={values}
         onChange={setValues}
+        errors={testResults.configurationErrors}
       />
       <div className={classes.connectionTestMessage}>
         <If condition={testResults.inProgress}>
@@ -116,14 +115,16 @@ export function ConnectionConfigForm({
         </If>
 
         <If condition={testResults.succeeded}>
-          <div className={classes.connectionTestSuccess}>Successfuly connected.</div>
+          <Alert severity="success" className={classes.alert}>
+            Successfuly connected.
+          </Alert>
         </If>
         {!testResults.succeeded &&
           testResults.messages &&
           testResults.messages.map((message, i) => (
-            <div key={i} className={classes.connectionTestFailure}>
+            <Alert severity="error" key={i} className={classes.alert}>
               {message.message} {message.correctiveAction}
-            </div>
+            </Alert>
           ))}
       </div>
       <div className={classes.formStyles}>

--- a/app/cdap/components/Connections/Create/ConnectionConfiguration/index.tsx
+++ b/app/cdap/components/Connections/Create/ConnectionConfiguration/index.tsx
@@ -47,6 +47,7 @@ interface IConnectionConfigurationProps extends IConnectorDetails {
     succeeded: boolean;
     inProgress: boolean;
     messages?: any;
+    configurationErrors?: any;
   };
   isEdit: boolean;
 }

--- a/app/cdap/components/Connections/Create/index.tsx
+++ b/app/cdap/components/Connections/Create/index.tsx
@@ -40,6 +40,7 @@ import { ConnectionConfiguration } from 'components/Connections/Create/Connectio
 import { extractErrorMessage, objectQuery } from 'services/helpers';
 import Alert from 'components/Alert';
 import { ConnectionsContext, IConnectionMode } from 'components/Connections/ConnectionsContext';
+import { constructErrors } from 'components/ConfigurationGroup/utilities';
 
 const useStyle = makeStyle(() => {
   return {
@@ -72,6 +73,7 @@ export function CreateConnection({
   });
   const [initValues, setInitValues] = React.useState({});
   const [error, setError] = React.useState(null);
+  const [configurationErrors, setConfigurationErrors] = React.useState(null);
   const [testSucceeded, setTestSucceeded] = React.useState(false);
   const [testInProgress, setTestInProgress] = React.useState(false);
   const [testResponseMessages, setTestResponseMessages] = React.useState(undefined);
@@ -119,6 +121,10 @@ export function CreateConnection({
     const connDetails = await fetchConnectionDetails(selectedConnector);
     setConnectionDetails(connDetails);
     setLoading(false);
+    setTestResponseMessages(undefined);
+    setTestSucceeded(false);
+    setError(null);
+    setConfigurationErrors(null);
   };
 
   const onConnectionCreate = async (connectionFormData) => {
@@ -179,12 +185,20 @@ export function CreateConnection({
     setTestResponseMessages(undefined);
     setTestSucceeded(false);
     setError(null);
+    setConfigurationErrors(null);
     setTestInProgress(true);
 
     try {
       const testResult = await testConnection(connectionConfiguration);
       setTestResponseMessages(testResult);
       setTestSucceeded(!testResult);
+
+      if (testResult) {
+        const configErrors = constructErrors(testResult);
+        setConfigurationErrors(configErrors.propertyErrors);
+      } else {
+        setConfigurationErrors(null);
+      }
     } catch (e) {
       const errorMsg = extractErrorMessage(e);
       setError(errorMsg);
@@ -244,6 +258,7 @@ export function CreateConnection({
             succeeded: testSucceeded,
             messages: testResponseMessages,
             inProgress: testInProgress,
+            configurationErrors,
           }}
         />
       </If>


### PR DESCRIPTION
Jira: https://cdap.atlassian.net/browse/CDAP-18069

Use new material-ui Alert for test connection messaging
Handle field-level error information in test connection - note that there's no connecter sending this information yet

Test success:
![image](https://user-images.githubusercontent.com/2728821/123874345-e1f8ea00-d8ec-11eb-8cf4-dbbe3d563889.png)

Test failure:
![image](https://user-images.githubusercontent.com/2728821/123874401-f89f4100-d8ec-11eb-93e5-5a7042ed7acf.png)

