### PR TITLE
[CDAP-18173] Fix unmount bug in ConfigurationGroup

### DIFF
--- a/app/cdap/components/ConfigurationGroup/index.tsx
+++ b/app/cdap/components/ConfigurationGroup/index.tsx
@@ -19,7 +19,7 @@ import PropTypes from 'prop-types';
 import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
 import { IWidgetJson, PluginProperties } from './types';
 import { processConfigurationGroups, removeFilteredProperties } from './utilities';
-import { objectQuery } from 'services/helpers';
+import { objectQuery, useOnUnmount } from 'services/helpers';
 import defaults from 'lodash/defaults';
 import If from 'components/If';
 import PropertyRow from './PropertyRow';
@@ -149,18 +149,6 @@ const ConfigurationGroupView: React.FC<IConfigurationGroupProps> = ({
     updateFilteredConfigurationGroup(configurationGroups, values);
   }, [values]);
 
-  // This onUnMount is to make sure we clear out all properties that are hidden.
-  React.useEffect(() => {
-    return () => {
-      const newValues = referenceValueForUnMount.current.values;
-      const configGroups = referenceValueForUnMount.current.configurationGroups;
-      const updatedFilteredValues = removeFilteredProperties(newValues, configGroups);
-      changeParentHandler(updatedFilteredValues);
-    };
-  }, []);
-
-  React.useEffect(getOrphanedErrors, [errors]);
-
   function changeParentHandler(updatedValues) {
     if (!onChange || typeof onChange !== 'function') {
       return;
@@ -168,6 +156,16 @@ const ConfigurationGroupView: React.FC<IConfigurationGroupProps> = ({
 
     onChange(updatedValues);
   }
+
+  // This onUnMount is to make sure we clear out all properties that are hidden.
+  useOnUnmount(() => {
+    const newValues = referenceValueForUnMount.current.values;
+    const configGroups = referenceValueForUnMount.current.configurationGroups;
+    const updatedFilteredValues = removeFilteredProperties(newValues, configGroups);
+    changeParentHandler(updatedFilteredValues);
+  });
+
+  React.useEffect(getOrphanedErrors, [errors]);
 
   const extraConfig = {
     namespace: getCurrentNamespace(),

--- a/app/cdap/services/helpers.js
+++ b/app/cdap/services/helpers.js
@@ -723,6 +723,19 @@ function santizeStringForHTMLID(str) {
   return str.replace(/[ \/]/g, '-');
 }
 
+/**
+ * Wrapper for useEffect that ensures the latest version of the callback will be used, unlike useEffect
+ */
+function useOnUnmount(unmountHandler) {
+  const unmountRef = React.useRef(unmountHandler);
+  unmountRef.current = unmountHandler;
+  React.useEffect(() => {
+    return () => {
+      unmountRef.current();
+    };
+  }, [unmountRef]);
+}
+
 const PIPELINE_ARTIFACTS = [
   'cdap-data-pipeline',
   'cdap-data-streams',
@@ -781,5 +794,6 @@ export {
   isAuthSetToProxyMode,
   isAuthSetToManagedMode,
   santizeStringForHTMLID,
+  useOnUnmount,
   PIPELINE_ARTIFACTS,
 };


### PR DESCRIPTION
This was causing the PushdownConfig settings to get partially reset when closing the settings modal.

Questions for reviewer:
- I considered refactoring ConfigurationGroup to not use its existing ref workaround, but decided that the possibility of unexpected dependence on the current ref behavior meant I should leave it as is. Does that seem like the right move to you as well?
- Even without changing the existing ref workaround, this has a slight possibility of having unexpected effects on ConfigurationGroup, if a widget that uses ConfigurationGroup has behavior that depends on the current only-set-up-once behavior of onChange. Do you think that risk warrants only using a ref workaround in PushdownConfig rather than generalizing it to all ConfigurationGroup instances the way I've done here?