### PR TITLE
CDAP 18202 - Fix popover for connections so long names don't make them unusable

### DIFF
--- a/app/cdap/components/Connections/Browser/SidePanel/CategorizedConnections.tsx
+++ b/app/cdap/components/Connections/Browser/SidePanel/CategorizedConnections.tsx
@@ -79,14 +79,27 @@ const CustomAccordionDetails = withStyles((theme) => ({
   root: {
     padding: 0,
     gap: '10px',
-    display: 'grid',
-    gridAutoRows: `${theme.spacing(4)}px`,
+    display: 'flex',
+    flexDirection: 'column',
   },
 }))(AccordionDetails);
 
 const useStyle = makeStyles<Theme>(
   (theme): StyleRules => {
     return {
+      connectionGroup: {
+        '& a': {
+          maxWidth: `249px`,
+          overflowX: 'hidden',
+          '& .connection-name': {
+            overflowX: 'hidden',
+            textOverflow: 'ellipsis',
+          },
+        },
+        display: 'flex',
+        flexDirection: 'row',
+        minHeight: `${theme.spacing(4)}px`,
+      },
       connection: {
         color: 'black',
         paddingLeft: `${theme.spacing(4)}px`,
@@ -119,17 +132,23 @@ const useStyle = makeStyles<Theme>(
       },
       selectedConnection: {
         background: 'white',
-        color: theme.palette.primary.main,
         '&:hover': {
           color: theme.palette.primary.main,
           fontWeight: 'normal',
         },
+        '& a': {
+          color: theme.palette.primary.main,
+        },
       },
       actionPopover: {
-        marginLeft: 'auto',
-
+        // display table to vertically align popoover buttons in the middle
+        display: 'table',
         '&:hover': {
           fontWeight: 'normal',
+        },
+        '& [tag=span]': {
+          display: 'table-cell',
+          verticalAlign: 'middle',
         },
       },
       delete: {
@@ -341,27 +360,31 @@ export function CategorizedConnections({
                 ];
 
                 return (
-                  <Link
-                    to={`/ns/${getCurrentNamespace()}/connections/${connection.name}?path=/`}
-                    key={connection.name}
-                    onClick={() => onConnectionSelection(connection.name)}
-                    className={classnames(classes.connection, {
+                  <div
+                    className={classnames(classes.connectionGroup, {
                       [classes.selectedConnection]: localSelectedConnection === connection.name,
                     })}
                   >
-                    <If condition={localSelectedConnection === connection.name}>
-                      <strong>{connection.name}</strong>
-                    </If>
-                    <If condition={localSelectedConnection !== connection.name}>
-                      <span>{connection.name}</span>
-                    </If>
+                    <Link
+                      to={`/ns/${getCurrentNamespace()}/connections/${connection.name}?path=/`}
+                      key={connection.name}
+                      onClick={() => onConnectionSelection(connection.name)}
+                      className={classes.connection}
+                    >
+                      <If condition={localSelectedConnection === connection.name}>
+                        <strong className="connection-name">{connection.name}</strong>
+                      </If>
+                      <If condition={localSelectedConnection !== connection.name}>
+                        <span className="connection-name">{connection.name}</span>
+                      </If>
+                    </Link>
 
                     <ActionsPopover
                       className={classes.actionPopover}
                       actions={actions}
                       modifiers={popperModifiers}
                     />
-                  </Link>
+                  </div>
                 );
               })}
 


### PR DESCRIPTION
### Bugfix
# Context
[Jira](https://cdap.atlassian.net/browse/CDAP-18202)
Long names hides the action popover on the connections ui so they're unusable. 

**Before**
<img width="431" alt="Screen Shot 2021-07-12 at 3 20 34 PM" src="https://user-images.githubusercontent.com/2054644/125363285-38225000-e325-11eb-8de3-f36dc7406ed1.png">
**After**
<img width="310" alt="Screen Shot 2021-07-12 at 3 16 48 PM" src="https://user-images.githubusercontent.com/2054644/125363302-3fe1f480-e325-11eb-9c6d-098b2150aa45.png">

