### PR TITLE
CDAP-18193 - Adds optional prop to errorBanner and Alert components to make page interactable when used as a toast.

### DIFF
--- a/app/cdap/components/Alert/Alert.scss
+++ b/app/cdap/components/Alert/Alert.scss
@@ -15,6 +15,9 @@
  */
 @import "../../styles/variables.scss";
 $close-btn-size: 13px;
+.modal.can-edit-page-while-open {
+  height: auto;
+}
 
 .global-alert {
   &.modal-dialog {

--- a/app/cdap/components/Alert/index.js
+++ b/app/cdap/components/Alert/index.js
@@ -38,6 +38,7 @@ export default class Alert extends Component {
     element: PropTypes.node,
     onClose: PropTypes.func,
     type: PropTypes.oneOf(['success', 'error', 'info']),
+    canEditPageWhileOpen: PropTypes.bool,
   };
 
   alertTimeout = null;
@@ -103,7 +104,15 @@ export default class Alert extends Component {
       );
     }
     return (
+      /**
+       * TODO: This should be a toast, not a modal at least in some scenarios
+       * - In some scenarios (eg cdap/components/ErrorBanner) this is being used as a toast, which means
+       * its an error message at the top of the page. This makes the rest of the page uninteractable, which
+       * is not intended. To fix this bug https://cdap.atlassian.net/browse/CDAP-18193 I had to disable
+       * the height: 100% overlay with the canEditPageWhileOpen prop. The long term fix should be using a toast.
+       */
       <Modal
+        modalClassName={this.props.canEditPageWhileOpen ? 'can-edit-page-while-open' : ''}
         isOpen={this.state.showAlert}
         toggle={() => {}}
         backdrop={false}

--- a/app/cdap/components/Connections/Browser/GenericBrowser/index.tsx
+++ b/app/cdap/components/Connections/Browser/GenericBrowser/index.tsx
@@ -254,7 +254,7 @@ export function GenericBrowser({ selectedConnection }) {
         </EmptyMessageContainer>
       </If>
       <If condition={error && !loading}>
-        <ErrorBanner error={error} />
+        <ErrorBanner error={error} canEditPageWhileOpen={true} />
       </If>
     </React.Fragment>
   );

--- a/app/cdap/components/ErrorBanner/index.tsx
+++ b/app/cdap/components/ErrorBanner/index.tsx
@@ -21,9 +21,10 @@ import Alert from 'components/Alert';
 interface IErrorProps {
   error: object | string | null;
   onClose?: () => void;
+  canEditPageWhileOpen?: boolean;
 }
 
-const ErrorBanner: React.SFC<IErrorProps> = ({ error, onClose }) => {
+const ErrorBanner: React.SFC<IErrorProps> = ({ error, onClose, canEditPageWhileOpen }) => {
   if (!error) {
     return null;
   }
@@ -31,7 +32,15 @@ const ErrorBanner: React.SFC<IErrorProps> = ({ error, onClose }) => {
   const errorMessage: string =
     objectQuery(error, 'response', 'message') || objectQuery(error, 'response') || error;
 
-  return <Alert message={errorMessage} type="error" showAlert={true} onClose={onClose} />;
+  return (
+    <Alert
+      message={errorMessage}
+      type="error"
+      showAlert={true}
+      onClose={onClose}
+      canEditPageWhileOpen={canEditPageWhileOpen}
+    />
+  );
 };
 
 export default ErrorBanner;


### PR DESCRIPTION
### Bugfix
[jira ticket](https://cdap.atlassian.net/browse/CDAP-18193)

**Code changes**
This adds an optional prop to `Alert` and `Error Banner` components so that the page is interactable when an error message shows up. 

**Context**
This is a short term fix. Modals are normally components that take away all focus from the rest of the page, going into a different mode. We're currently using the reactstrap/modal component instead of a toast, so you can't interact with the page while the error message is there. If we want the error message to be a toast (like this scenario) we should use the toast component that reactstrap has in it or make another toast component that fits our needs. 