### PR TITLE
[CDAP-18080] Improve errors for bad conn. names

### DIFF
--- a/app/cdap/components/Connections/Create/index.tsx
+++ b/app/cdap/components/Connections/Create/index.tsx
@@ -130,6 +130,14 @@ export function CreateConnection({
   const onConnectionCreate = async (connectionFormData) => {
     const { description, properties, name } = connectionFormData;
 
+    if (name.trim() === '') {
+      setError('Connection name must not be empty.');
+      return;
+    } else if (name.trim().match(/ /)) {
+      setError('Connection name must not contain spaces.');
+      return;
+    }
+
     if (!isEdit) {
       // validate existing connection name
       try {


### PR DESCRIPTION
https://cdap.atlassian.net/browse/CDAP-18080

Also rejects connection names with spaces since those don't appear to work, because without that check, this error occurs when attempting to use a connection name that has spaces:

    Exception occurred while handling request: Illegal character in path at index 115: http://localhost:50475/v3/namespaces/system/apps/pipeline/services/studio/methods/v1/contexts/default/connections/a b


![image](https://user-images.githubusercontent.com/550498/125673901-7233b8a6-f673-4702-9ca7-cb8c8573ca08.png)
