### PR TITLE
Hides side panel for GCS connections browse

### DIFF
--- a/app/cdap/components/Connections/Browser/SidePanel/index.tsx
+++ b/app/cdap/components/Connections/Browser/SidePanel/index.tsx
@@ -14,7 +14,7 @@
  * the License.
  */
 
-import * as React from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import Paper from '@material-ui/core/Paper';
 import makeStyles from '@material-ui/core/styles/makeStyles';
 import { Theme } from '@material-ui/core';
@@ -77,8 +77,8 @@ export function ConnectionsBrowserSidePanel({
   selectedConnection,
 }: IConnectionBrowserSidePanelProps) {
   const classes = useStyle();
-  const boundaryElement = React.useRef(null);
-  const [state, setState] = React.useState<IConnectionsBrowserSidePanelState>({
+  const boundaryElement = useRef(null);
+  const [state, setState] = useState<IConnectionsBrowserSidePanelState>({
     categorizedConnections: new Map(),
     connectorTypes: [],
   });
@@ -97,7 +97,7 @@ export function ConnectionsBrowserSidePanel({
       connectorTypes,
     });
   };
-  React.useEffect(() => {
+  useEffect(() => {
     initState();
   }, []);
   return (

--- a/app/cdap/components/Connections/ConnectionsContext/index.tsx
+++ b/app/cdap/components/Connections/ConnectionsContext/index.tsx
@@ -48,6 +48,7 @@ export interface IConnections {
   onEntitySelect?: (entitySpec) => void;
   initPath?: string;
   disabledTypes?: Record<string, boolean>;
+  hideSidePanel?: boolean;
 }
 export const ConnectionsContext = React.createContext<IConnections>({
   mode: IConnectionMode.ROUTED,

--- a/app/cdap/components/Connections/Home.tsx
+++ b/app/cdap/components/Connections/Home.tsx
@@ -14,7 +14,7 @@
  * the License.
  */
 
-import * as React from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { Theme } from '@material-ui/core';
 import { ConnectionsBrowserSidePanel } from 'components/Connections/Browser/SidePanel';
 import { ConnectionsBrowser } from 'components/Connections/Browser/index';
@@ -23,13 +23,13 @@ import { useParams } from 'react-router';
 import { ConnectionsContext } from 'components/Connections/ConnectionsContext';
 
 interface IConnectionsHomeStyleProps {
-  sidePanelCollapsed: boolean;
+  showSidePanel: boolean;
 }
 const useStyle = makeStyles<Theme, IConnectionsHomeStyleProps>((theme) => {
   return {
     root: {
       display: 'grid',
-      gridTemplateColumns: ({ sidePanelCollapsed }) => (sidePanelCollapsed ? '0 1fr' : '250px 1fr'),
+      gridTemplateColumns: ({ showSidePanel }) => (showSidePanel ? '0 1fr' : '250px 1fr'),
       gridTemplateRows: '100%',
       overflowY: 'hidden',
       height: '100%',
@@ -37,21 +37,23 @@ const useStyle = makeStyles<Theme, IConnectionsHomeStyleProps>((theme) => {
   };
 });
 
-export function ConnectionsHome() {
-  const { mode } = React.useContext(ConnectionsContext);
+export function ConnectionsHome({ hideSidePanel }: { hideSidePanel?: boolean }) {
+  const { mode } = useContext(ConnectionsContext);
   const params = useParams();
-  const [sidePanelCollapsed, setSidePanelCollapsed] = React.useState(false);
-  const [selectedConnection, setSelectedConnection] = React.useState(
+  const [sidePanelCollapsed, setSidePanelCollapsed] = useState(false);
+  const [selectedConnection, setSelectedConnection] = useState(
     (params as any).connectionid || null
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if ((params as any).connectionid !== selectedConnection) {
       setSelectedConnection((params as any).connectionid);
     }
   }, [params]);
 
-  const classes = useStyle({ sidePanelCollapsed });
+  const showSidePanel = hideSidePanel || sidePanelCollapsed;
+
+  const classes = useStyle({ showSidePanel });
   return (
     <div className={classes.root}>
       <ConnectionsBrowserSidePanel

--- a/app/cdap/components/Connections/Routes.tsx
+++ b/app/cdap/components/Connections/Routes.tsx
@@ -19,20 +19,20 @@ import { Route, Switch } from 'react-router-dom';
 import { CreateConnection } from 'components/Connections/Create';
 import { ConnectionsHome } from 'components/Connections/Home';
 
-export function ConnectionRoutes() {
+export function ConnectionRoutes({ hideSidePanel }: { hideSidePanel?: boolean }) {
   return (
     <Switch>
       <Route exact path="/ns/:namespace/connections/create">
         <CreateConnection />
       </Route>
       <Route path="/ns/:namespace/connections/:connectionid">
-        <ConnectionsHome />
+        <ConnectionsHome hideSidePanel={hideSidePanel} />
       </Route>
       <Route path="/ns/:namespace/connections">
-        <ConnectionsHome />
+        <ConnectionsHome hideSidePanel={hideSidePanel} />
       </Route>
       <Route path="/ns/:namespace/connection-upload">
-        <ConnectionsHome />
+        <ConnectionsHome hideSidePanel={hideSidePanel} />
       </Route>
     </Switch>
   );

--- a/app/cdap/components/Connections/index.tsx
+++ b/app/cdap/components/Connections/index.tsx
@@ -48,6 +48,7 @@ export default function Connections({
   onWorkspaceCreate,
   connectionId,
   onEntitySelect,
+  hideSidePanel,
   initPath,
 }: IConnections) {
   const [state, setState] = React.useState({
@@ -112,13 +113,13 @@ export default function Connections({
       <div className={classes.container}>
         <If condition={shouldUpdatePageTitle}>{pageTitle}</If>
         <If condition={mode === IConnectionMode.ROUTED}>
-          <ConnectionRoutes />
+          <ConnectionRoutes hideSidePanel={hideSidePanel} />
         </If>
         <If
           condition={mode === IConnectionMode.INMEMORY || mode === IConnectionMode.ROUTED_WORKSPACE}
         >
           <MemoryRouter initialEntries={[initialEntry]}>
-            <ConnectionRoutes />
+            <ConnectionRoutes hideSidePanel={hideSidePanel} />
           </MemoryRouter>
         </If>
       </div>

--- a/app/cdap/components/DataPrepConnections/PluginConnectionBrowser/index.tsx
+++ b/app/cdap/components/DataPrepConnections/PluginConnectionBrowser/index.tsx
@@ -121,6 +121,7 @@ class PluginConnectionBrowser extends React.PureComponent<
           modalBodyClassName={classes.modalBody}
         >
           <Connections
+            hideSidePanel={true}
             mode={IConnectionMode.ROUTED_WORKSPACE}
             connectionId={this.state.connectionName}
             onEntitySelect={this.handleEntitySelect}


### PR DESCRIPTION
### Bugfix

Jira: [CDAP-18150](https://cdap.atlassian.net/browse/CDAP-18150)

https://cdap.atlassian.net/browse/CDAP-18226

**Context** 
A number of bugs result from the side panel of the gcs -> browse -> connections side panel so disable the side panel if its from that pipeline modal. 


<img width="830" alt="Screen Shot 2021-07-16 at 2 59 38 PM" src="https://user-images.githubusercontent.com/2054644/126013896-6e9bb1c0-b5c3-4186-a563-7cc4ecc59ef2.png">
