### PR TITLE
CDAP 18245 - right aligns the popover buttons for connections in wrangler

### DIFF
--- a/app/cdap/components/Connections/Browser/SidePanel/CategorizedConnections.tsx
+++ b/app/cdap/components/Connections/Browser/SidePanel/CategorizedConnections.tsx
@@ -89,7 +89,7 @@ const useStyle = makeStyles<Theme>(
     return {
       connectionGroup: {
         '& a': {
-          maxWidth: `249px`,
+          width: '249px',
           overflowX: 'hidden',
           '& .connection-name': {
             overflowX: 'hidden',


### PR DESCRIPTION
### bugfix

https://cdap.atlassian.net/browse/CDAP-18245

<img width="284" alt="Screen Shot 2021-07-16 at 5 29 30 PM" src="https://user-images.githubusercontent.com/2054644/126019953-6cc939e9-034a-470b-ba6c-5e2039878c75.png">


