### PR TITLE
[CDAP-18152] Tweak styles for pushdown (cherry pick version)

### DIFF
--- a/app/cdap/components/PipelineConfigurations/ConfigurationsContent/PushdownTabContent.tsx
+++ b/app/cdap/components/PipelineConfigurations/ConfigurationsContent/PushdownTabContent.tsx
@@ -18,7 +18,6 @@ import React, { useCallback, useMemo } from 'react';
 import { useDispatch, useSelector, shallowEquals } from 'react-redux';
 import { ACTIONS as PipelineConfigurationsActions } from 'components/PipelineConfigurations/Store';
 
-import PipelineConfigurationsStore from 'components/PipelineConfigurations/Store';
 import PushdownConfig from 'components/PushdownConfig';
 
 export default function PushdownTabContent({}) {

--- a/app/cdap/components/PipelineConfigurations/index.js
+++ b/app/cdap/components/PipelineConfigurations/index.js
@@ -61,24 +61,24 @@ const TABS = {
     contentClassName: 'pipeline-configurations-body',
     paneClassName: 'configuration-content',
   },
-  resources: {
+  pushdown: {
     id: 4,
+    name: T.translate(`${PREFIX}.Pushdown.title`),
+    content: <PushdownTabContent />,
+    contentClassName: 'pipeline-configurations-body',
+    paneClassName: 'configuration-content',
+  },
+  resources: {
+    id: 5,
     name: T.translate(`${PREFIX}.Resources.title`),
     content: <ResourcesTabContent />,
     contentClassName: 'pipeline-configurations-body',
     paneClassName: 'configuration-content',
   },
   alerts: {
-    id: 5,
+    id: 6,
     name: T.translate(`${PREFIX}.Alerts.title`),
     content: <AlertsTabContent />,
-    contentClassName: 'pipeline-configurations-body',
-    paneClassName: 'configuration-content',
-  },
-  pushdown: {
-    id: 6,
-    name: T.translate(`${PREFIX}.Pushdown.title`),
-    content: <PushdownTabContent />,
     contentClassName: 'pipeline-configurations-body',
     paneClassName: 'configuration-content',
   },
@@ -183,9 +183,9 @@ export default class PipelineConfigurations extends Component {
         TABS.computeConfig,
         TABS.pipelineConfig,
         TABS.engineConfig,
+        TABS.pushdown,
         TABS.resources,
         TABS.alerts,
-        TABS.pushdown,
       ];
     } else if (this.props.pipelineType === GLOBALS.etlDataStreams) {
       tabs = [

--- a/app/cdap/components/PushdownConfig/index.tsx
+++ b/app/cdap/components/PushdownConfig/index.tsx
@@ -26,8 +26,14 @@ import ToggleSwitch from 'components/ToggleSwitch';
 import LoadingSVG from 'components/LoadingSVG';
 import VersionStore from 'services/VersionStore';
 import { catchError } from 'rxjs/operators';
+import Checkbox from '@material-ui/core/Checkbox';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 
 const useStyles = makeStyles({
+  toggleRow: {
+    marginTop: '20px',
+    marginBottom: '20px',
+  },
   container: {
     left: 0,
     maxWidth: '100%',
@@ -41,6 +47,10 @@ const useStyles = makeStyles({
   inner: {
     overflowY: 'scroll',
     overflowX: 'hidden',
+  },
+  blockShown: {},
+  blockHidden: {
+    display: 'none',
   },
 });
 
@@ -180,20 +190,26 @@ export default function PushdownConfig({ value, onValueChange, cloudArtifact }: 
   return (
     <div className={classes.container}>
       <div className={classes.inner}>
-        ELT Pushdown lets you push transformations to an SQL-compatible engine, enabling an ELT
-        pattern.
-        <div className="label-with-toggle row">
-          <span className="toggle-label col-xs-4">Enable ELT Pushdown</span>
-          <div className="col-xs-7 toggle-container">
-            <ToggleSwitch isOn={pushdownEnabled} onToggle={toggleEnabled} />
-          </div>
+        <strong>
+          Transformation Pushdown lets you push down compatible transformations to BigQuery. It
+          currently only supports Join transformations.
+        </strong>
+        <div className={classes.toggleRow}>
+          <FormControlLabel
+            control={
+              <Checkbox checked={pushdownEnabled} onChange={toggleEnabled} color="primary" />
+            }
+            label="Enable Transformation Pushdown"
+          />
         </div>
-        <ConfigurationGroup
-          widgetJson={pluginWidget}
-          pluginProperties={pluginProperties}
-          values={valueProperties}
-          onChange={onChange}
-        />
+        <div className={pushdownEnabled ? classes.blockShown : classes.blockHidden}>
+          <ConfigurationGroup
+            widgetJson={pluginWidget}
+            pluginProperties={pluginProperties}
+            values={valueProperties}
+            onChange={onChange}
+          />
+        </div>
       </div>
     </div>
   );

--- a/app/cdap/components/Tabs/TabHead/TabHead.scss
+++ b/app/cdap/components/Tabs/TabHead/TabHead.scss
@@ -23,8 +23,6 @@
   color: #333333;
   font-size: 14px;
 
-  &.vertical { white-space: nowrap; }
-
   &.active-tab {
     &.horizontal {
       transition: border-bottom 0.2s ease;

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -2091,7 +2091,7 @@ features:
       contentHeading: Set alerts for your batch pipeline
       title: Pipeline alert
     Pushdown:
-      title: ELT Pushdown
+      title: Transformation Pushdown
     ComputeConfig:
       title: Compute config
     EngineConfig:


### PR DESCRIPTION
- tab name changed
- description changed
- description made bold (\<strong/>)
- toggle label changed
- toggle changed to material-ui Checkbox
- hide configgroup with display: none when not enabled
- move pushdown tab before resources

JIRA subtasks not in this commit: change placeholder for dataset. see
https://github.com/data-integrations/google-cloud/pull/704
and https://github.com/data-integrations/google-cloud/pull/705 for that
change.