### PR TITLE
Bugfix/cdap 18267 Removes duplicate getworkspace call during re-render

### DIFF
--- a/app/cdap/components/DataPrep/index.js
+++ b/app/cdap/components/DataPrep/index.js
@@ -98,7 +98,7 @@ export default class DataPrep extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.state.currentWorkspace !== nextProps.workspaceId) {
+    if (this.props.workspaceId !== nextProps.workspaceId || this.props.mode !== nextProps.mode) {
       this.init(nextProps);
     }
   }


### PR DESCRIPTION
Avoids the duplicate getworkspace() call during component re-render.