### PR TITLE
[CDAP-18243] Allow selection connection during browse if no connection specified

### DIFF
--- a/app/cdap/components/Connections/Browser/SidePanel/CategorizedConnections.tsx
+++ b/app/cdap/components/Connections/Browser/SidePanel/CategorizedConnections.tsx
@@ -39,6 +39,7 @@ interface ICategorizedConnectionsProps {
   selectedConnection: string;
   boundaryElement: any;
   fetchConnections: () => void;
+  hideAddConnection?: boolean;
 }
 const Accordion = withStyles({
   root: {
@@ -189,6 +190,7 @@ export function CategorizedConnections({
   selectedConnection,
   boundaryElement,
   fetchConnections,
+  hideAddConnection,
 }: ICategorizedConnectionsProps) {
   const classes = useStyle();
   const activeCategory = selectedConnection
@@ -306,14 +308,16 @@ export function CategorizedConnections({
 
   return (
     <div>
-      <Link
-        to={`/ns/${getCurrentNamespace()}/connection-upload`}
-        className={classnames(classes.upload, {
-          [classes.selectedConnection]: !localSelectedConnection,
-        })}
-      >
-        Upload
-      </Link>
+      <If condition={!hideAddConnection}>
+        <Link
+          to={`/ns/${getCurrentNamespace()}/connection-upload`}
+          className={classnames(classes.upload, {
+            [classes.selectedConnection]: !localSelectedConnection,
+          })}
+        >
+          Upload
+        </Link>
+      </If>
       {connectorTypes.map((connectorType) => {
         const key = connectorType.name;
         const connections = categorizedConnections.get(key) || [];
@@ -382,11 +386,13 @@ export function CategorizedConnections({
                       </If>
                     </Link>
 
-                    <ActionsPopover
-                      className={classes.actionPopover}
-                      actions={actions}
-                      modifiers={popperModifiers}
-                    />
+                    <If condition={!hideAddConnection}>
+                      <ActionsPopover
+                        className={classes.actionPopover}
+                        actions={actions}
+                        modifiers={popperModifiers}
+                      />
+                    </If>
                   </div>
                 );
               })}

--- a/app/cdap/components/Connections/Browser/SidePanel/index.tsx
+++ b/app/cdap/components/Connections/Browser/SidePanel/index.tsx
@@ -30,6 +30,7 @@ import { sortedUniqBy } from 'lodash';
 import { ConnectionsContext, IConnectionMode } from 'components/Connections/ConnectionsContext';
 import AddConnectionBtnModal from 'components/Connections/AddConnectionBtnModal';
 import CreateConnectionModal from 'components/Connections/CreateConnectionModal';
+import If from 'components/If';
 
 const useStyle = makeStyles<Theme>((theme) => {
   return {
@@ -82,12 +83,16 @@ interface IConnectionBrowserSidePanelProps {
   onSidePanelToggle: () => void;
   onConnectionSelection: (conn: string) => void;
   selectedConnection: string;
+  selectedConnectorType?: string;
+  hideAddConnection?: boolean;
 }
 
 export function ConnectionsBrowserSidePanel({
   onSidePanelToggle,
   onConnectionSelection,
   selectedConnection,
+  selectedConnectorType,
+  hideAddConnection,
 }: IConnectionBrowserSidePanelProps) {
   const { mode } = useContext(ConnectionsContext);
 
@@ -106,6 +111,15 @@ export function ConnectionsBrowserSidePanel({
     connectorTypes = connectorTypes.filter((conn) => {
       return !disabledTypes[conn.name];
     });
+    if (selectedConnectorType) {
+      const connectionTypeLower = selectedConnectorType.toLowerCase();
+      const filteredConnectorTypes = connectorTypes.filter((conn) => {
+        return connectionTypeLower === conn.name.toLowerCase();
+      });
+      if (filteredConnectorTypes.length > 0) {
+        connectorTypes = filteredConnectorTypes;
+      }
+    }
     connectorTypes = orderBy(connectorTypes, ['name'], ['asc']);
     connectorTypes = sortedUniqBy(connectorTypes, (ct) => ct.name);
 
@@ -141,6 +155,7 @@ export function ConnectionsBrowserSidePanel({
         selectedConnection={selectedConnection}
         boundaryElement={boundaryElement}
         fetchConnections={initState}
+        hideAddConnection={hideAddConnection}
       />
 
       <CreateConnectionModal
@@ -151,7 +166,9 @@ export function ConnectionsBrowserSidePanel({
         isEdit={false}
       />
 
-      <div className={classes.buttonContainer}>{connectionBtn}</div>
+      <If condition={!hideAddConnection}>
+        <div className={classes.buttonContainer}>{connectionBtn}</div>
+      </If>
     </Paper>
   );
 }

--- a/app/cdap/components/Connections/ConnectionsContext/index.tsx
+++ b/app/cdap/components/Connections/ConnectionsContext/index.tsx
@@ -49,6 +49,8 @@ export interface IConnections {
   initPath?: string;
   disabledTypes?: Record<string, boolean>;
   hideSidePanel?: boolean;
+  hideAddConnection?: boolean;
+  connectorType?: string;
 }
 export const ConnectionsContext = React.createContext<IConnections>({
   mode: IConnectionMode.ROUTED,

--- a/app/cdap/components/Connections/Home.tsx
+++ b/app/cdap/components/Connections/Home.tsx
@@ -37,8 +37,8 @@ const useStyle = makeStyles<Theme, IConnectionsHomeStyleProps>((theme) => {
   };
 });
 
-export function ConnectionsHome({ hideSidePanel }: { hideSidePanel?: boolean }) {
-  const { mode } = useContext(ConnectionsContext);
+export function ConnectionsHome() {
+  const { hideSidePanel, connectorType, hideAddConnection } = useContext(ConnectionsContext);
   const params = useParams();
   const [sidePanelCollapsed, setSidePanelCollapsed] = useState(false);
   const [selectedConnection, setSelectedConnection] = useState(
@@ -60,6 +60,8 @@ export function ConnectionsHome({ hideSidePanel }: { hideSidePanel?: boolean }) 
         onSidePanelToggle={() => setSidePanelCollapsed(true)}
         onConnectionSelection={(conn) => setSelectedConnection(conn)}
         selectedConnection={selectedConnection}
+        selectedConnectorType={connectorType}
+        hideAddConnection={hideAddConnection}
       />
       <ConnectionsBrowser
         selectedConnection={selectedConnection}

--- a/app/cdap/components/Connections/Routes.tsx
+++ b/app/cdap/components/Connections/Routes.tsx
@@ -19,20 +19,20 @@ import { Route, Switch } from 'react-router-dom';
 import { CreateConnection } from 'components/Connections/Create';
 import { ConnectionsHome } from 'components/Connections/Home';
 
-export function ConnectionRoutes({ hideSidePanel }: { hideSidePanel?: boolean }) {
+export function ConnectionRoutes() {
   return (
     <Switch>
       <Route exact path="/ns/:namespace/connections/create">
         <CreateConnection />
       </Route>
       <Route path="/ns/:namespace/connections/:connectionid">
-        <ConnectionsHome hideSidePanel={hideSidePanel} />
+        <ConnectionsHome />
       </Route>
       <Route path="/ns/:namespace/connections">
-        <ConnectionsHome hideSidePanel={hideSidePanel} />
+        <ConnectionsHome />
       </Route>
       <Route path="/ns/:namespace/connection-upload">
-        <ConnectionsHome hideSidePanel={hideSidePanel} />
+        <ConnectionsHome />
       </Route>
     </Switch>
   );

--- a/app/cdap/components/Connections/index.tsx
+++ b/app/cdap/components/Connections/index.tsx
@@ -50,6 +50,8 @@ export default function Connections({
   onEntitySelect,
   hideSidePanel,
   initPath,
+  connectorType,
+  hideAddConnection,
 }: IConnections) {
   const [state, setState] = React.useState({
     mode,
@@ -59,6 +61,9 @@ export default function Connections({
     connectionId,
     onEntitySelect,
     disabledTypes: {},
+    connectorType,
+    hideSidePanel,
+    hideAddConnection,
   });
   const classes = useStyle();
   const [loading, setLoading] = useState(true);
@@ -113,13 +118,13 @@ export default function Connections({
       <div className={classes.container}>
         <If condition={shouldUpdatePageTitle}>{pageTitle}</If>
         <If condition={mode === IConnectionMode.ROUTED}>
-          <ConnectionRoutes hideSidePanel={hideSidePanel} />
+          <ConnectionRoutes />
         </If>
         <If
           condition={mode === IConnectionMode.INMEMORY || mode === IConnectionMode.ROUTED_WORKSPACE}
         >
           <MemoryRouter initialEntries={[initialEntry]}>
-            <ConnectionRoutes hideSidePanel={hideSidePanel} />
+            <ConnectionRoutes />
           </MemoryRouter>
         </If>
       </div>

--- a/app/cdap/components/DataPrepConnections/PluginConnectionBrowser/index.tsx
+++ b/app/cdap/components/DataPrepConnections/PluginConnectionBrowser/index.tsx
@@ -14,24 +14,17 @@
  * the License.
  */
 
-import { Modal, ModalBody } from 'reactstrap';
 import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
 
 import Button from '@material-ui/core/Button';
-import { ConnectionType } from 'components/DataPrepConnections/ConnectionType';
 import ErrorBanner from 'components/ErrorBanner';
 import { IWidgetProps } from 'components/AbstractWidget';
-import If from 'components/If';
-import LoadingSVGCentered from 'components/LoadingSVGCentered';
-import MyDataPrepApi from 'api/dataprep';
 import React from 'react';
 import ThemeWrapper from 'components/ThemeWrapper';
 import ee from 'event-emitter';
-import { getCurrentNamespace } from 'services/NamespaceStore';
 import { objectQuery } from 'services/helpers';
 import Connections from 'components/Connections';
 import { IConnectionMode } from 'components/Connections/ConnectionsContext';
-import { ConnectionsApi } from 'api/connections';
 import PipelineModal from 'components/PipelineModal';
 import { extractConnectionName } from 'components/AbstractWidget/ConnectionsWidget';
 
@@ -121,9 +114,11 @@ class PluginConnectionBrowser extends React.PureComponent<
           modalBodyClassName={classes.modalBody}
         >
           <Connections
-            hideSidePanel={true}
+            hideSidePanel={!!this.state.connectionName}
+            hideAddConnection={true}
             mode={IConnectionMode.ROUTED_WORKSPACE}
             connectionId={this.state.connectionName}
+            connectorType={this.props.widgetProps.connectionType}
             onEntitySelect={this.handleEntitySelect}
           />
         </PipelineModal>


### PR DESCRIPTION
* When browsing from a pipeline source, if no connection is set, display that connector type's connections
* From browse, hide Add Connection, Upload, and action menu
* Pass the hideSidebar value in context for consistency

Jira: https://cdap.atlassian.net/browse/CDAP-18243

![image](https://user-images.githubusercontent.com/2728821/126710428-d0fe0daf-7bbd-438b-8541-43b327874d29.png)
