### PR TITLE
[CDAP-18269] Don't show orphan errors twice when testing a connection

### DIFF
--- a/app/cdap/components/ConfigurationGroup/index.tsx
+++ b/app/cdap/components/ConfigurationGroup/index.tsx
@@ -188,6 +188,7 @@ const ConfigurationGroupView: React.FC<IConfigurationGroupProps> = ({
 
   function getOrphanedErrors() {
     if (!errors) {
+      setOrphanErrors([]);
       return;
     }
 

--- a/app/cdap/components/Connections/Create/index.tsx
+++ b/app/cdap/components/Connections/Create/index.tsx
@@ -203,7 +203,10 @@ export function CreateConnection({
 
       if (testResult) {
         const configErrors = constructErrors(testResult);
-        setConfigurationErrors(configErrors.propertyErrors);
+        // All test errors will be shown next to the test button,
+        // so don't repeat orphaned errors
+        const { orphanErrors, ...assignedErrors } = configErrors.propertyErrors;
+        setConfigurationErrors(assignedErrors);
       } else {
         setConfigurationErrors(null);
       }


### PR DESCRIPTION
Also, properly clear orphan errors in ConfigurationGroup

Jira: https://cdap.atlassian.net/browse/CDAP-18269