### PR TITLE
[CDAP-18209] Update insights page to new connection manager API

### DIFF
--- a/app/cdap/api/dataprep.js
+++ b/app/cdap/api/dataprep.js
@@ -39,6 +39,7 @@ const MyDataPrepApi = {
   getSpecification: apiCreator(dataSrc, 'GET', 'REQUEST', `${basepathV2}/specification`),
   getUsage: apiCreator(dataSrc, 'GET', 'REQUEST', `${contextPath}/usage`),
   getInfo: apiCreator(dataSrc, 'GET', 'REQUEST', `${baseServicePath}/methods/info`),
+  setWorkspace: apiCreator(dataSrc, 'POST', 'REQUEST', `${basepathV2}`),
   getWorkspace: apiCreator(dataSrc, 'GET', 'REQUEST', `${basepathV2}`),
   getWorkspaceList: apiCreator(dataSrc, 'GET', 'REQUEST', `${contextPathV2}/workspaces`),
 

--- a/app/cdap/components/DataPrep/DataPrepBrowser/GCSBrowser/BrowserData/TableContents.tsx
+++ b/app/cdap/components/DataPrep/DataPrepBrowser/GCSBrowser/BrowserData/TableContents.tsx
@@ -153,7 +153,7 @@ export default class TableContents extends React.PureComponent<
     const ContainerElement = enableRouting ? Link : 'div';
     const pathname = window.location.pathname.replace(/\/cdap/, '');
 
-    const { connectionid, uri } = DataPrepStore.getState().dataprep.properties;
+    const { connectionid, uri } = DataPrepStore.getState().dataprep.insights;
     const selectedPath = uri ? uri.substring(4) : '';
 
     if (enableRouting) {

--- a/app/cdap/components/DataPrep/DataPrepBrowser/S3Browser/BucketData/TableContents.tsx
+++ b/app/cdap/components/DataPrep/DataPrepBrowser/S3Browser/BucketData/TableContents.tsx
@@ -163,7 +163,7 @@ export default class TableContents extends React.PureComponent<
       connectionid,
       key,
       'bucket-name': bucketName,
-    } = DataPrepStore.getState().dataprep.properties;
+    } = DataPrepStore.getState().dataprep.insights;
     const selectedPath = `/${bucketName}/${key}/`;
 
     if (enableRouting) {

--- a/app/cdap/components/DataPrep/DataPrepVisualization/index.js
+++ b/app/cdap/components/DataPrep/DataPrepVisualization/index.js
@@ -73,8 +73,8 @@ export default class DataPrepVisualization extends Component {
   };
 
   renderVoyager = () => {
-    let { properties, data } = DataPrepStore.getState().dataprep;
-    let visualization = properties.visualization || {};
+    let { insights, data } = DataPrepStore.getState().dataprep;
+    let visualization = insights.visualization || {};
     this.voyagerInstance = CreateVoyager(
       this.containerRef,
       {
@@ -110,8 +110,8 @@ export default class DataPrepVisualization extends Component {
     let localData = [...DataPrepStore.getState().dataprep.data];
     this.datapreSubscription = DataPrepStore.subscribe(() => {
       let { dataprep } = DataPrepStore.getState();
-      let properties = dataprep.properties || {};
-      let visualization = properties.visualization || {};
+      let insights = dataprep.insights || {};
+      let visualization = insights.visualization || {};
       if (
         !localData ||
         dataprep.data.length !== localData.length ||

--- a/app/cdap/components/DataPrep/TopPanel/index.js
+++ b/app/cdap/components/DataPrep/TopPanel/index.js
@@ -88,9 +88,9 @@ export default class DataPrepTopPanel extends Component {
       this.setState({
         higherVersion: state.higherVersion,
         workspaceInfo: state.workspaceInfo,
-        connectionName: objectQuery(state, 'properties', 'name'),
+        connectionName: objectQuery(state, 'insights', 'name'),
         path: state.workspaceUri,
-        workspaceName: objectQuery(state, 'properties', 'workspaceName'),
+        workspaceName: objectQuery(state, 'insights', 'workspaceName'),
       });
     });
   }

--- a/app/cdap/components/DataPrep/index.js
+++ b/app/cdap/components/DataPrep/index.js
@@ -98,7 +98,7 @@ export default class DataPrep extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.state.currentWorkspace !== nextProps.workspaceId) {
+    if (this.props.workspaceId !== nextProps.workspaceId || this.props.mode !== nextProps.mode) {
       this.init(nextProps);
     }
   }
@@ -186,8 +186,8 @@ export default class DataPrep extends Component {
     }
     setWorkspace(workspaceId).subscribe(
       () => {
-        let { properties } = DataPrepStore.getState().dataprep;
-        let workspaceName = properties.name;
+        let { insights } = DataPrepStore.getState().dataprep;
+        let workspaceName = insights.name;
         if (this._isMounted) {
           this.setState({
             loading: false,

--- a/app/cdap/components/DataPrep/store/DataPrepActions.js
+++ b/app/cdap/components/DataPrep/store/DataPrepActions.js
@@ -17,7 +17,7 @@
 const DataPrepActions = {
   setData: 'DATAPREP_SET_DATA',
   setDirectives: 'DATAPREP_SET_DIRECTIVES',
-  setProperties: 'DATAPREP_SET_PROPERTIES',
+  setInsights: 'DATAPREP_SET_INSIGHTS',
   setWorkspace: 'DATAPREP_SET_WORKSPACE',
   setWorkspaceId: 'DATAPREP_SET_WORKSPACE_ID',
   setInitialized: 'DATAPREP_SET_INITIALIZED',

--- a/app/cdap/components/DataPrep/store/index.ts
+++ b/app/cdap/components/DataPrep/store/index.ts
@@ -72,7 +72,7 @@ export interface IDataPrepState {
   loading?: boolean;
   singleWorkspaceMode?: boolean;
   workspaceInfo?: any;
-  properties?: any;
+  insights?: any;
   dataModelList?: IDataModel[];
   targetDataModel?: IDataModel;
   targetModel?: IModel;
@@ -97,7 +97,7 @@ const defaultInitialState: IDataPrepState = {
   loading: false,
   singleWorkspaceMode: false,
   workspaceInfo: null,
-  properties: {},
+  insights: {},
   dataModelList: null,
   targetDataModel: null,
   targetModel: null,
@@ -170,14 +170,14 @@ const dataprep = (state = defaultInitialState, action = defaultAction) => {
         newHeaders: findNewHeaders(state.headers, action.payload.headers),
       });
       break;
-    case DataPrepActions.setProperties: {
-      const properties = {
-        ...state.properties,
-        ...action.payload.properties,
+    case DataPrepActions.setInsights: {
+      const insights = {
+        ...state.insights,
+        ...action.payload.insights,
       };
       return {
         ...state,
-        properties,
+        insights,
       };
     }
     case DataPrepActions.setWorkspaceId:
@@ -195,7 +195,7 @@ const dataprep = (state = defaultInitialState, action = defaultAction) => {
         data: action.payload.data || [],
         types: action.payload.types || {},
         typesCheck: getTypesCheck(action.payload.types, action.payload.headers),
-        properties: action.payload.properties || {},
+        insights: action.payload.insights || {},
         initialized: true,
         loading: false,
         selectedHeaders: [],

--- a/app/cdap/components/DataPrepHome/index.js
+++ b/app/cdap/components/DataPrepHome/index.js
@@ -284,7 +284,7 @@ export default class DataPrepHome extends Component {
   renderContents() {
     const workspaceId = this.state.currentWorkspaceId;
     const { mode, ...attributes } = this.props;
-    const workspaceProperties = DataPrepStore.getState().dataprep.properties;
+    const workspaceProperties = DataPrepStore.getState().dataprep.insights;
 
     const connectionId = workspaceProperties.name;
     const path = getContainerPath(workspaceProperties.path || '');

--- a/app/cdap/components/Experiments/store/CreateExperimentActionCreator.js
+++ b/app/cdap/components/Experiments/store/CreateExperimentActionCreator.js
@@ -448,7 +448,7 @@ function applyDirectives(workspaceId, directives) {
       namespace: getCurrentNamespace(),
     };
     let requestBody = directiveRequestBodyCreator(directives);
-    requestBody.properties = workspaceInfo.properties;
+    requestBody.insights = workspaceInfo.properties;
     return MyDataPrepApi.execute(params, requestBody);
   });
 }


### PR DESCRIPTION
1) Workspace state persistence: Replaces POST 'v2/contexts/{context}/workspaces/{id}/execute' with POST 'v2/contexts/{context}/workspaces/{id}' API call.

2) Replaces 'properties' with 'insights' state as per the new API requirement.