### PR TITLE
CDAP 18283 - Add plugin name to use as reference name default

### DIFF
--- a/app/cdap/components/Connections/Browser/GenericBrowser/index.tsx
+++ b/app/cdap/components/Connections/Browser/GenericBrowser/index.tsx
@@ -14,7 +14,7 @@
  * the License.
  */
 
-import * as React from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { isNilOrEmptyString } from 'services/helpers';
 import {
   exploreConnection,
@@ -72,17 +72,17 @@ export function GenericBrowser({ selectedConnection }) {
   const loc = useLocation();
   const queryParams = new URLSearchParams(loc.search);
   const pathFromUrl = queryParams.get('path') || '/';
-  const [entities, setEntities] = React.useState([]);
-  const [propertyHeaders, setPropertyHeaders] = React.useState([]);
-  const [totalCount, setTotalCount] = React.useState(0);
-  const [loading, setLoading] = React.useState(true);
-  const [error, setError] = React.useState(null);
-  const [path, setPath] = React.useState(pathFromUrl);
-  const [searchString, setSearchString] = React.useState('');
-  const [searchStringDisplay, setSearchStringDisplay] = React.useState('');
-  const [workspaceId, setWorkspaceId] = React.useState(null);
+  const [entities, setEntities] = useState([]);
+  const [propertyHeaders, setPropertyHeaders] = useState([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [path, setPath] = useState(pathFromUrl);
+  const [searchString, setSearchString] = useState('');
+  const [searchStringDisplay, setSearchStringDisplay] = useState('');
+  const [workspaceId, setWorkspaceId] = useState(null);
   const classes = useStyle();
-  const { onWorkspaceCreate, onEntitySelect } = React.useContext(ConnectionsContext);
+  const { onWorkspaceCreate, onEntitySelect } = useContext(ConnectionsContext);
 
   const fetchEntities = async () => {
     setLoading(true);
@@ -164,9 +164,13 @@ export function GenericBrowser({ selectedConnection }) {
     try {
       const spec = await getPluginSpec(entity, selectedConnection);
       const plugin = spec?.relatedPlugins?.[0];
-
       const properties = plugin?.properties;
       const schema = plugin?.schema;
+
+      // if reference name is already set, don't set default.
+      if (!properties.referenceName) {
+        properties.referenceName = plugin?.name;
+      }
 
       onEntitySelect({
         properties,
@@ -178,14 +182,14 @@ export function GenericBrowser({ selectedConnection }) {
     }
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (isNilOrEmptyString(selectedConnection)) {
       return setLoading(false);
     }
     fetchEntities();
   }, [selectedConnection, path]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const query = new URLSearchParams(loc.search);
     const urlPath = query.get('path') || '/';
     if (path !== urlPath && !loading) {
@@ -210,7 +214,7 @@ export function GenericBrowser({ selectedConnection }) {
   const entityCounts = countBy(filteredEntities, (entity) => entity.type.toLowerCase());
 
   return (
-    <React.Fragment>
+    <>
       <div className={classes.topBar}>
         <div className={classes.topBarBreadcrumb}>
           <Breadcrumb
@@ -261,6 +265,6 @@ export function GenericBrowser({ selectedConnection }) {
       <If condition={error && !loading}>
         <ErrorBanner error={error} canEditPageWhileOpen={true} />
       </If>
-    </React.Fragment>
+    </>
   );
 }


### PR DESCRIPTION
### Bugfix

Use plugin.name as the default referenceName for bigquery browse inside of studio. Was unsure of what to use for the name - it looks like we could parse the name of the big query connection from inside the connection string like below:
<img width="1139" alt="Screen Shot 2021-07-28 at 8 07 06 PM" src="https://user-images.githubusercontent.com/2054644/127425860-1f4c0940-0326-41be-a511-92bb79c5130c.png">
But there was also name which defaults to `BigQueryTable`.

https://cdap.atlassian.net/browse/CDAP-18283