### PR TITLE
CDAP-18227 - use correct object query to display correct number of tasks

### DIFF
--- a/app/cdap/components/Replicator/Detail/index.tsx
+++ b/app/cdap/components/Replicator/Detail/index.tsx
@@ -379,7 +379,7 @@ class DetailView extends React.PureComponent<IDetailProps, IDetailContext> {
         offsetBasePath: config.offsetBasePath,
         loading: false,
         lastUpdated: Date.now(),
-        numInstances: objectQuery(config, 'config', 'parallelism', 'numInstances') || 1,
+        numInstances: objectQuery(config, 'parallelism', 'numInstances') || 1,
       });
     });
 


### PR DESCRIPTION
### Bugfix

Uses the right query so the number of instances is correct for replication jobs.

https://cdap.atlassian.net/browse/CDAP-18227