### PR TITLE
CDAP-18264 | Link to replicator in profile associations

### DIFF
--- a/app/cdap/components/Cloud/Profiles/DetailView/Content/ProfileAssociations/index.js
+++ b/app/cdap/components/Cloud/Profiles/DetailView/Content/ProfileAssociations/index.js
@@ -28,6 +28,10 @@ import {
   getNodeHours,
 } from 'components/Cloud/Profiles/Store/ActionCreator';
 import { Observable } from 'rxjs/Observable';
+import {
+  createReplicatorDetailUrl,
+  identifyReplicatorEntityFromMetadata,
+} from 'components/Replicator/utilities';
 require('./ProfileAssociations.scss');
 
 const PREFIX = 'features.Cloud.Profiles.DetailView';
@@ -223,22 +227,28 @@ export default class ProfileAssociations extends Component {
   };
 
   renderGridBody = () => {
-    let { associationsMap } = this.state;
+    const { associationsMap } = this.state;
     return (
       <div className="grid-body">
         {Object.keys(associationsMap).map((app) => {
-          let appObj = associationsMap[app];
-          let onedayMetrics = objectQuery(appObj, 'metadata', ONEDAYMETRICKEY) || {};
-          let overallMetrics = objectQuery(appObj, 'metadata', OVERALLMETRICKEY) || {};
-          let pipelineUrl = window.getHydratorUrl({
+          const appObj = associationsMap[app];
+          const isReplicator = identifyReplicatorEntityFromMetadata(appObj.metadata);
+          const onedayMetrics = objectQuery(appObj, 'metadata', ONEDAYMETRICKEY) || {};
+          const overallMetrics = objectQuery(appObj, 'metadata', OVERALLMETRICKEY) || {};
+          const pipelineUrl = window.getHydratorUrl({
             stateName: 'hydrator.detail',
             stateParams: {
               namespace: appObj.namespace,
               pipelineId: appObj.name,
             },
           });
+
           return (
-            <a className="grid-row" href={pipelineUrl} key={app}>
+            <a
+              className="grid-row"
+              href={isReplicator ? createReplicatorDetailUrl(appObj.name) : pipelineUrl}
+              key={app}
+            >
               <div>{appObj.name}</div>
               <div>{appObj.namespace}</div>
               <div>

--- a/app/cdap/components/Replicator/Detail/DetailContent/index.tsx
+++ b/app/cdap/components/Replicator/Detail/DetailContent/index.tsx
@@ -24,6 +24,7 @@ import Overview from 'components/Replicator/Detail/Overview';
 import Monitoring from 'components/Replicator/Detail/Monitoring';
 import { humanReadableDate } from 'services/helpers';
 import Heading, { HeadingTypes } from 'components/Heading';
+import { createReplicatorDetailUrl } from '../../utilities';
 
 const styles = (theme): StyleRules => {
   return {
@@ -66,7 +67,7 @@ const styles = (theme): StyleRules => {
 const DetailContentView: React.FC<WithStyles<typeof styles>> = ({ classes }) => {
   const { name, lastUpdated } = useContext(DetailContext);
 
-  const linkBase = `/ns/${getCurrentNamespace()}/replication/detail/${name}`;
+  const linkBase = createReplicatorDetailUrl(name);
   const routeBase = `${basepath}/detail/:replicatorId`;
 
   return (

--- a/app/cdap/components/Replicator/List/Deployed/index.tsx
+++ b/app/cdap/components/Replicator/List/Deployed/index.tsx
@@ -26,6 +26,7 @@ import ActionsPopover, { IAction } from 'components/ActionsPopover';
 import DeleteConfirmation, { InstanceType } from 'components/Replicator/DeleteConfirmation';
 import DownloadFile from 'services/download-file';
 import { Redirect } from 'react-router-dom';
+import { createReplicatorDetailUrl } from '../../utilities';
 
 const styles = (theme): StyleRules => {
   return {
@@ -214,7 +215,7 @@ const DeployedView: React.FC<WithStyles<typeof styles>> = ({ classes }) => {
 
               return (
                 <Link
-                  to={`/ns/${getCurrentNamespace()}/replication/detail/${replicator.name}`}
+                  to={createReplicatorDetailUrl(replicator.name)}
                   className={`grid-row ${classes.row}`}
                   key={replicator.name}
                 >

--- a/app/cdap/components/Replicator/utilities/index.ts
+++ b/app/cdap/components/Replicator/utilities/index.ts
@@ -396,3 +396,24 @@ export function getTableDisplayName(row) {
 
   return displayName;
 }
+
+/**
+ * Returns detail url for replicator
+ * @param name name of the replicator
+ * @returns URL
+ */
+export function createReplicatorDetailUrl(name: string): string {
+  return `/ns/${getCurrentNamespace()}/replication/detail/${name}`;
+}
+
+/**
+ * Identifes the entity as a replicator instance
+ * @param metadata metadata about the entity
+ * @returns boolean
+ */
+export function identifyReplicatorEntityFromMetadata(metadata: {
+  type?: string;
+  program?: string;
+}): boolean {
+  return metadata.type === 'Worker' && metadata.program === 'DeltaWorker';
+}


### PR DESCRIPTION
# Bugfix 

### Changes
Added a function to create replicator detail url in replicator utilities and then in profile associations, if the metadata matches replicator `type === 'Worker' && program === 'DeltaWorker'` then link to replicator detail page.

### Jira
https://cdap.atlassian.net/browse/CDAP-18264