### PR TITLE
CDAP 18339 - check if use connection is true before using connection name in plugin connection browser

### DIFF
--- a/app/cdap/components/AbstractWidget/ToggleSwitchWidget/index.tsx
+++ b/app/cdap/components/AbstractWidget/ToggleSwitchWidget/index.tsx
@@ -52,8 +52,6 @@ const ToggleSwitchWidgetView: React.FC<IToggleToggleSwitchProps> = ({
   disabled,
   classes,
   dataCy,
-  updateAllProperties,
-  extraConfig,
 }) => {
   const onValue = objectQuery(widgetProps, 'on', 'value') || 'on';
   const offValue = objectQuery(widgetProps, 'off', 'value') || 'off';
@@ -62,20 +60,7 @@ const ToggleSwitchWidgetView: React.FC<IToggleToggleSwitchProps> = ({
   const isOn = value === onValue;
 
   function toggleSwitch() {
-    // if connection toggle
-    if (isOn && extraConfig.properties.hasOwnProperty('useConnection')) {
-      updateAllProperties(
-        {
-          connection: '',
-          useConnection: false,
-          serviceAccountType: 'filePath',
-          serviceFilePath: 'auto-detect',
-        },
-        { updateFilteredConfigurationGroups: true }
-      );
-    } else {
-      onChange(isOn ? offValue : onValue);
-    }
+    onChange(isOn ? offValue : onValue);
   }
 
   return (

--- a/app/cdap/components/AbstractWidget/ToggleSwitchWidget/index.tsx
+++ b/app/cdap/components/AbstractWidget/ToggleSwitchWidget/index.tsx
@@ -52,6 +52,8 @@ const ToggleSwitchWidgetView: React.FC<IToggleToggleSwitchProps> = ({
   disabled,
   classes,
   dataCy,
+  updateAllProperties,
+  extraConfig,
 }) => {
   const onValue = objectQuery(widgetProps, 'on', 'value') || 'on';
   const offValue = objectQuery(widgetProps, 'off', 'value') || 'off';
@@ -60,8 +62,22 @@ const ToggleSwitchWidgetView: React.FC<IToggleToggleSwitchProps> = ({
   const isOn = value === onValue;
 
   function toggleSwitch() {
-    onChange(isOn ? offValue : onValue);
+    // if connection toggle
+    if (isOn && extraConfig.properties.hasOwnProperty('useConnection')) {
+      updateAllProperties(
+        {
+          connection: '',
+          useConnection: false,
+          serviceAccountType: 'filePath',
+          serviceFilePath: 'auto-detect',
+        },
+        { updateFilteredConfigurationGroups: true }
+      );
+    } else {
+      onChange(isOn ? offValue : onValue);
+    }
   }
+
   return (
     <div className={classes.root}>
       <ToggleSwitch

--- a/app/cdap/components/AbstractWidget/index.tsx
+++ b/app/cdap/components/AbstractWidget/index.tsx
@@ -21,7 +21,7 @@ import { IErrorObj } from 'components/ConfigurationGroup/utilities';
 import StateWrapper from 'components/AbstractWidget/StateWrapper';
 require('./AbstractWidget.scss');
 
-export const DEFAULT_WIDGET_PROPS = {
+export const DEFAULT_WIDGET_PROPS: IAbstractWidgetProps = {
   widgetProps: {},
   value: '',
   disabled: false,
@@ -44,7 +44,7 @@ export interface IWidgetExtraConfig {
 
 export interface IWidgetProps<T = any> {
   widgetProps?: T;
-  value: string | number;
+  value?: string | number;
   onChange?: (value) => void | React.Dispatch<any>;
   onBlur?: (value) => void | React.Dispatch<any>;
   onKeyPress?: (event: React.KeyboardEvent) => void;
@@ -59,29 +59,37 @@ export interface IWidgetProps<T = any> {
 }
 
 interface IAbstractWidgetProps extends IWidgetProps {
-  type: string;
+  type?: string;
 }
 
-export default class AbstractWidget extends React.PureComponent<IAbstractWidgetProps> {
-  public static defaultProps = DEFAULT_WIDGET_PROPS;
+const AbstractWidget = ({
+  dataCy,
+  disabled,
+  errors,
+  extraConfig,
+  onChange,
+  type,
+  updateAllProperties,
+  value,
+  widgetProps,
+}: IAbstractWidgetProps = DEFAULT_WIDGET_PROPS) => {
+  const Comp = AbstractWidgetFactory[type];
 
-  public render() {
-    const Comp = AbstractWidgetFactory[this.props.type];
+  return (
+    <div className="abstract-widget-wrapper">
+      <StateWrapper
+        comp={Comp}
+        onChange={onChange}
+        updateAllProperties={updateAllProperties}
+        value={value}
+        widgetProps={widgetProps}
+        extraConfig={extraConfig}
+        disabled={disabled}
+        errors={errors}
+        dataCy={dataCy}
+      />
+    </div>
+  );
+};
 
-    return (
-      <div className={`abstract-widget-wrapper`}>
-        <StateWrapper
-          comp={Comp}
-          onChange={this.props.onChange}
-          updateAllProperties={this.props.updateAllProperties}
-          value={this.props.value}
-          widgetProps={this.props.widgetProps}
-          extraConfig={this.props.extraConfig}
-          disabled={this.props.disabled}
-          errors={this.props.errors}
-          dataCy={this.props.dataCy}
-        />
-      </div>
-    );
-  }
-}
+export default AbstractWidget;

--- a/app/cdap/components/DataPrepConnections/PluginConnectionBrowser/index.tsx
+++ b/app/cdap/components/DataPrepConnections/PluginConnectionBrowser/index.tsx
@@ -71,10 +71,12 @@ class PluginConnectionBrowser extends React.PureComponent<
     const connectionProperty = this.props?.widgetProps?.connectionProperty || 'connection';
     const connection = objectQuery(this.props, 'extraConfig', 'properties', connectionProperty);
     const connectionName = extractConnectionName(connection);
+    const useConnection =
+      objectQuery(this.props, 'extraConfig', 'properties', 'useConnection') !== 'false';
 
     this.setState({
       showBrowserModal: !this.state.showBrowserModal,
-      connectionName,
+      connectionName: useConnection ? connectionName : null,
     });
   };
 


### PR DESCRIPTION
# Bugfix

### Changes
- plugin connection browser checks if use connection is turned on to use connection name to hide sidebar of connection modal
- Converted AbstractWidget to functional component

### Buglink
https://cdap.atlassian.net/browse/CDAP-18339
-https://cdap.atlassian.net/browse/CDAP-18338-