### PR TITLE
[CDAP-11521] Show stats (no. of rows and columns) of data in data prep

### DIFF
--- a/app/cdap/components/DataPrep/TopPanel/TopPanel.scss
+++ b/app/cdap/components/DataPrep/TopPanel/TopPanel.scss
@@ -22,6 +22,7 @@ $dropdown_menu_color: $link-color;
 $dropdown_item_font_color: black;
 $success_alert_color: white;
 $success_alert_bg_color: $brand-success;
+$row_column_count_color: #6b6767;
 
 .dataprep-container {
   .top-panel {
@@ -62,10 +63,23 @@ $success_alert_bg_color: $brand-success;
         padding: 0 10px;
         width: 100%;
 
-        .title {
+        .title_bar {
+          white-space: nowrap;
+          text-align: center;
           overflow: hidden;
           text-overflow: ellipsis;
-          white-space: nowrap;
+
+          .title,
+          .row_column_count {
+            display: inline-block;
+            padding-right: 10px;
+          }
+
+          .row_column_count {
+            padding-left: 10px;
+            font-size: 13px;
+            color: $row_column_count_color;
+          }
         }
 
         .connection-type {

--- a/app/cdap/components/DataPrep/TopPanel/index.js
+++ b/app/cdap/components/DataPrep/TopPanel/index.js
@@ -190,6 +190,7 @@ export default class DataPrepTopPanel extends Component {
   renderTopPanelDisplay() {
     const { connectionName, path, workspaceName } = this.state;
     let connectionInfo = `${connectionName} - ${path}`;
+    let state = DataPrepStore.getState().dataprep;
 
     if (!connectionName || !path) {
       connectionInfo = 'File Upload';
@@ -201,8 +202,14 @@ export default class DataPrepTopPanel extends Component {
           {connectionInfo}
         </div>
 
-        <div className="title" title={workspaceName}>
-          {workspaceName}
+        <div className="title_bar">
+          <div className="title" title={workspaceName}>
+            {workspaceName}
+          </div>
+          <div className="row_column_count">
+            {T.translate('features.DataPrep.TopPanel.columns')}: {state.headers.length} |{' '}
+            {T.translate('features.DataPrep.TopPanel.rows')}: {state.data.length}
+          </div>
         </div>
       </div>
     );

--- a/app/cdap/components/DataPrep/TopPanel/index.js
+++ b/app/cdap/components/DataPrep/TopPanel/index.js
@@ -190,7 +190,7 @@ export default class DataPrepTopPanel extends Component {
   renderTopPanelDisplay() {
     const { connectionName, path, workspaceName } = this.state;
     let connectionInfo = `${connectionName} - ${path}`;
-    let state = DataPrepStore.getState().dataprep;
+    const { dataprep } = DataPrepStore.getState();
 
     if (!connectionName || !path) {
       connectionInfo = 'File Upload';
@@ -207,8 +207,8 @@ export default class DataPrepTopPanel extends Component {
             {workspaceName}
           </div>
           <div className="row_column_count">
-            {T.translate('features.DataPrep.TopPanel.columns')}: {state.headers.length} |{' '}
-            {T.translate('features.DataPrep.TopPanel.rows')}: {state.data.length}
+            {T.translate('features.DataPrep.TopPanel.columns')}: {dataprep.headers.length} |{' '}
+            {T.translate('features.DataPrep.TopPanel.rows')}: {dataprep.data.length}
           </div>
         </div>
       </div>

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -1179,6 +1179,8 @@ features:
       invalidFieldNameRemedies3: column names.
       kafka: Kafka
       more: More
+      columns: Columns
+      rows: Rows
       PlusButton:
         addDirective: Add directive
         successMessage: You successfully added a custom directive. Apply that directive by typing it into the power mode input area.


### PR DESCRIPTION
[CDAP-11521](https://cdap.atlassian.net/browse/CDAP-11521) Show stats (no. of rows and columns) of data in data prep

Added a div on the right of title of the file to display the count of rows and columns in the wrangler workspace!
<img width="1787" alt="Screen Shot 2021-08-17 at 12 05 46 PM" src="https://user-images.githubusercontent.com/88528384/129720183-011af56d-abef-4f5d-a73d-e70ea63068b6.png">

[CDAP-11521]: https://cdap.atlassian.net/browse/CDAP-11521
[CDAP-11521]: https://cdap.atlassian.net/browse/CDAP-11521