### PR TITLE
[CDAP-18383] Don't attempt default conn in namespace

### DIFF
--- a/app/cdap/components/Connections/Browser/GenericBrowser/index.tsx
+++ b/app/cdap/components/Connections/Browser/GenericBrowser/index.tsx
@@ -27,7 +27,7 @@ import debounce from 'lodash/debounce';
 import makeStyle from '@material-ui/core/styles/makeStyles';
 import T from 'i18n-react';
 import { getCurrentNamespace } from 'services/NamespaceStore';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useRouteMatch, useParams } from 'react-router-dom';
 import Breadcrumb from 'components/Connections/Browser/GenericBrowser/Breadcrumb';
 import SearchField from 'components/Connections/Browser/GenericBrowser/SearchField';
 import { BrowserTable } from 'components/Connections/Browser/GenericBrowser/BrowserTable';
@@ -67,6 +67,7 @@ const useStyle = makeStyle(() => {
 
 export function GenericBrowser({ initialConnectionId }) {
   const loc = useLocation();
+  const rmatch = useRouteMatch({ path: '/ns/:namespace/connections/:connectionid' });
   const queryParams = new URLSearchParams(loc.search);
   const pathFromUrl = queryParams.get('path') || '/';
   const [currentConnection, setCurrentConnection] = useState(initialConnectionId);
@@ -184,7 +185,7 @@ export function GenericBrowser({ initialConnectionId }) {
 
   useEffect(() => {
     const query = new URLSearchParams(loc.search);
-    const newConnection = loc.pathname.substring(loc.pathname.lastIndexOf('/') + 1);
+    const newConnection = rmatch?.params?.connectionid;
     const urlPath = query.get('path') || '/';
     if (newConnection !== currentConnection) {
       setCurrentConnection(newConnection);
@@ -194,7 +195,7 @@ export function GenericBrowser({ initialConnectionId }) {
       setPath(urlPath);
       clearSearchString();
     }
-  }, [loc]);
+  }, [loc, rmatch]);
 
   const lowerSearchString = searchString.trim().toLocaleLowerCase();
   const filteredEntities = lowerSearchString.length

--- a/app/cdap/components/Connections/index.tsx
+++ b/app/cdap/components/Connections/index.tsx
@@ -121,7 +121,7 @@ export default function Connections({
         const disabledTypes = config?.connectionConfig?.disabledTypes;
         const def = config?.connectionConfig?.defaultConnection;
 
-        if (def && allowDefaultConnection && !connectionId) {
+        if (def && getCurrentNamespace() === 'default' && allowDefaultConnection && !connectionId) {
           updatedState = {
             ...updatedState,
             connectionId: def,


### PR DESCRIPTION
Also fixes error that was occurring when opening the connections page with no default connection, due to the way the custom path splitting logic was pulling off "/connections" as though it was a connection name. Using react-router's path parsing fixes that, and retains the lock-step updating needed to reduce spurious useEffects.