### PR TITLE
Removes sourcemap from production cdap.js build

### DIFF
--- a/webpack.config.cdap.js
+++ b/webpack.config.cdap.js
@@ -217,7 +217,6 @@ if (mode === 'development') {
 
 var webpackConfig = {
   mode: isModeProduction(mode) ? 'production' : 'development',
-  devtool: 'eval-source-map',
   context: __dirname + '/app/cdap',
   entry: {
     cdap: ['@babel/polyfill', './cdap.js'],


### PR DESCRIPTION
Removes sourcemap from production cdap.js build

'eval-source-map' (This bloats final JS by adding sourceMap into the bundle, ex: below)
https://vitalii-test-rbac-rc6-vitalii-playground-294422-dot-r.datafusion-dev.googleusercontent.com/cdap_assets/cdap.dd3bbd7e2a67cbb81646.js?c4a6b45056018b32011c