### PR TITLE
[CDAP-18429] Switch E2E Cypress tests to use sandbox 6.5.1-SNAPSHOT

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -38,6 +38,8 @@ steps:
   entrypoint: 'bash'
   args: ['-c', './cloudbuild/cloudbuildrun.sh $$CYPRESS_KEY']
   secretEnv: ['CYPRESS_KEY']
+  env:
+  - 'COMMIT_INFO_BRANCH=$BRANCH_NAME'
 availableSecrets:
   secretManager:
   - versionName: projects/cdap-gcp-project/secrets/cdap-e2e-tester-key-file/versions/latest

--- a/sandboxjs/bamboo_plan_info.json
+++ b/sandboxjs/bamboo_plan_info.json
@@ -1,4 +1,4 @@
 {
   "planName": "CDAP-BUT893",
-  "version": "6.5.0-SNAPSHOT"
+  "version": "6.5.1-SNAPSHOT"
 }


### PR DESCRIPTION
Also, attempt to report branch name to Cypress dashboard