### PR TITLE
CDAP - 18439 | check if widget props exist in memory textbox

### DIFF
--- a/app/cdap/components/AbstractWidget/MemoryTextbox/index.js
+++ b/app/cdap/components/AbstractWidget/MemoryTextbox/index.js
@@ -25,9 +25,14 @@ require('./MemoryTextbox.scss');
 // backend in MB. we are "big data". We don't talk in Mb we only start with Gb -_-
 export default function MemoryTextbox({ ...props }) {
   let { onChange, value, widgetProps } = props;
-  let min, max;
-  min = widgetProps.min || Number.MIN_SAFE_INTEGER;
-  max = widgetProps.max || Number.MAX_SAFE_INTEGER;
+  let min = Number.MIN_SAFE_INTEGER;
+  let max = Number.MAX_SAFE_INTEGER;
+  if (widgetProps && widgetProps.min) {
+    min = widgetProps.min;
+  }
+  if (widgetProps && widgetProps.max) {
+    max = widgetProps.max;
+  }
   min = Math.floor(min / 1024);
   max = Math.floor(max / 1024);
   let numberValue = parseInt(value, 10);

--- a/app/cdap/components/Replicator/ConfigDisplay/PluginConfigDisplay/index.tsx
+++ b/app/cdap/components/Replicator/ConfigDisplay/PluginConfigDisplay/index.tsx
@@ -14,7 +14,7 @@
  * the License.
  */
 
-import * as React from 'react';
+import React, { useState, useEffect } from 'react';
 import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
 import { objectQuery } from 'services/helpers';
 import difference from 'lodash/difference';
@@ -60,9 +60,9 @@ const PluginConfigDisplayView: React.FC<IPluginConfigProps> = ({
   pluginWidget,
   pluginConfig,
 }) => {
-  const [config, setConfig] = React.useState([]);
+  const [config, setConfig] = useState([]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const finalConfig = [];
     // get order and label name from widget
     // fill in values from config


### PR DESCRIPTION
##BUGFIX
check to see if widget props exist before using min/max. No idea what changed because this is something that is created through the abstract widget factory. Likely some json widget change caused this to break.

[jira](https://cdap.atlassian.net/browse/CDAP-18439)