### PR TITLE
Bugfix - use the shorthand for the array constructor instead of array.apply

### DIFF
--- a/app/cdap/components/PipelineSummary/RunsGraphHelpers.js
+++ b/app/cdap/components/PipelineSummary/RunsGraphHelpers.js
@@ -178,7 +178,7 @@ export function getGapFilledAccumulatedData(data, numOfDataPoints) {
   let maxx = data[data.length - 1].x;
   let numberOfEntries = maxx - minx;
   let lasty = miny;
-  let finalData = Array.apply(null, { length: numberOfEntries + 1 }).map((i, index) => {
+  let finalData = Array(numberOfEntries + 1).map((i, index) => {
     let matchInActualData = data.find((d) => d.x === minx + index);
     if (!isNil(matchInActualData)) {
       lasty = matchInActualData.y;


### PR DESCRIPTION
## Bugfix
Array.apply() over a certain size creates a max callstack range error. Array constructor doesn't have that problem (at least up to a certain value).

https://cdap.atlassian.net/browse/PLUGIN-917