### PR TITLE
[CDAP-18424] Fix issue with ui elements not saving

### DIFF
--- a/app/cdap/components/AbstractWidget/index.tsx
+++ b/app/cdap/components/AbstractWidget/index.tsx
@@ -59,37 +59,29 @@ export interface IWidgetProps<T = any> {
 }
 
 interface IAbstractWidgetProps extends IWidgetProps {
-  type?: string;
+  type: string;
 }
 
-const AbstractWidget = ({
-  dataCy,
-  disabled,
-  errors,
-  extraConfig,
-  onChange,
-  type,
-  updateAllProperties,
-  value,
-  widgetProps,
-}: IAbstractWidgetProps = DEFAULT_WIDGET_PROPS) => {
-  const Comp = AbstractWidgetFactory[type];
+export default class AbstractWidget extends React.PureComponent<IAbstractWidgetProps> {
+  public static defaultProps = DEFAULT_WIDGET_PROPS;
 
-  return (
-    <div className="abstract-widget-wrapper">
-      <StateWrapper
-        comp={Comp}
-        onChange={onChange}
-        updateAllProperties={updateAllProperties}
-        value={value}
-        widgetProps={widgetProps}
-        extraConfig={extraConfig}
-        disabled={disabled}
-        errors={errors}
-        dataCy={dataCy}
-      />
-    </div>
-  );
-};
+  public render() {
+    const Comp = AbstractWidgetFactory[this.props.type];
 
-export default AbstractWidget;
+    return (
+      <div className={`abstract-widget-wrapper`}>
+        <StateWrapper
+          comp={Comp}
+          onChange={this.props.onChange}
+          updateAllProperties={this.props.updateAllProperties}
+          value={this.props.value}
+          widgetProps={this.props.widgetProps}
+          extraConfig={this.props.extraConfig}
+          disabled={this.props.disabled}
+          errors={this.props.errors}
+          dataCy={this.props.dataCy}
+        />
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
Reverts the change to a functional component from https://github.com/cdapio/cdap-ui/commit/5108c4b6f0a58ac7e12b0992f1d5365c9fa86521 - probably could use a pure functional component, but simply reverting seems lower risk to me.

Finally found it via git bisect. Turns out it had nothing to do with the binding to the reducer - the Widget component wasn't supposed to rerender under those conditions anyway.

https://cdap.atlassian.net/browse/CDAP-18424