### PR TITLE
Returns the actual response status code for backend status API error

### DIFF
--- a/app/cdap/services/datasource/index.js
+++ b/app/cdap/services/datasource/index.js
@@ -56,9 +56,7 @@ export default class Datasource {
 
       genericResponseHandlers.forEach((handler) => handler(data));
       const errorCode = objectQuery(data.response, 'errorCode') || null;
-      if (errorCode !== null) {
-        this.eventEmitter.emit(globalEvents.API_ERROR, true);
-      }
+      this.eventEmitter.emit(globalEvents.API_ERROR, errorCode !== null);
       if (data.statusCode > 299 || data.warning) {
         /**
          * There is an issue here. When backend goes down we stop all the poll

--- a/server/express.js
+++ b/server/express.js
@@ -536,7 +536,7 @@ function makeApp(authAddress, cdapConfig, uiSettings) {
         function(err, response) {
           if (err) {
             log.info('Server responded with error: ' + err + ' for API : "/v3/namespaces"');
-            res.status(500).send(err);
+            res.status(response.statusCode || 500).send(err);
           } else {
             res.status(response.statusCode).send('OK');
           }


### PR DESCRIPTION
Context:
Returning 500 triggers "backend not available" error modal dialog. For CMEK revocation case (403) we have a custom modal dialog, hence need to return the actual status code (instead of 500) to show only CMEK modal dialog.