### PR TITLE
Repl transforms - connecting ui with backend/add delete transformations

### DIFF
--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/TransformAdd.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/TransformAdd.tsx
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { useState } from 'react';
+import ArrowRight from '@material-ui/icons/ArrowRight';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import { ITransformAddProps } from './types';
+import { SmallButton, KeyboardArrowDownIconTransformGrid } from './styles';
+import { Popover, TextField } from '@material-ui/core';
+import { addRenameToTransforms } from './addToTransforms';
+import { ITransformInformation } from 'components/Replicator/types';
+
+export default function TransformAddButton({
+  row,
+  addColumnsToTransforms,
+  tableInfo,
+}: ITransformAddProps) {
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [subMenuAnchorEl, setSubMenuAnchorEl] = useState(null);
+  const [directiveText, setDirectiveText] = useState('');
+  const open = Boolean(anchorEl);
+  const subMenuOpen = Boolean(subMenuAnchorEl);
+
+  const handleClick = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleMenuClick = (event) => {
+    setSubMenuAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+    setSubMenuAnchorEl(null);
+    setDirectiveText('');
+  };
+
+  const handleDirectiveChange = (event) => {
+    setDirectiveText(event.target.value);
+  };
+
+  const handleAddToTransforms = () => {
+    const transformInfo: ITransformInformation = {
+      tableName: tableInfo.table,
+      columnName: row.name,
+      directive: directiveText,
+    };
+    addRenameToTransforms({ transformInfo, addColumnsToTransforms });
+    handleClose();
+  };
+
+  return (
+    <>
+      <SmallButton
+        color="primary"
+        id={`transform-menu-${row.name}-button`}
+        aria-controls="trasnform-column-menu"
+        aria-haspopup="true"
+        variant="text"
+        aria-expanded={open ? 'true' : undefined}
+        onClick={handleClick}
+      >
+        Transform
+        <KeyboardArrowDownIconTransformGrid />
+      </SmallButton>
+      <Menu
+        getContentAnchorEl={null}
+        id={`transform-menu-${row.name}`}
+        anchorEl={anchorEl}
+        open={open}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right',
+        }}
+        onClose={handleClose}
+        MenuListProps={{
+          'aria-labelledby': `transform-menu-${row.name}-button`,
+        }}
+      >
+        <MenuItem onClick={handleMenuClick}>
+          TINK <ArrowRight />
+        </MenuItem>
+      </Menu>
+
+      <Popover
+        id={`transform-menu-${row.name}-TINK`}
+        anchorEl={subMenuAnchorEl}
+        open={open && subMenuOpen}
+        anchorOrigin={{
+          vertical: 'center',
+          horizontal: 'right',
+        }}
+        onClose={handleClose}
+      >
+        <TextField
+          id={`${row.name}-outlined-multiline-flexible-directive-text`}
+          label="Multiline"
+          multiline
+          maxRows={4}
+          value={directiveText}
+          onChange={handleDirectiveChange}
+        />
+        <SmallButton color="primary" variant="text" onClick={handleAddToTransforms}>
+          Save
+        </SmallButton>
+        <SmallButton color="primary" variant="text" onClick={handleClose}>
+          Cancel
+        </SmallButton>
+      </Popover>
+    </>
+  );
+}

--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/TransformDelete.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/TransformDelete.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { useState } from 'react';
+import Delete from '@material-ui/icons/Delete';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import { ITransformDeleteProps } from './types';
+import { SmallButton, KeyboardArrowDownIconTransformGrid } from './styles';
+
+export default function TransformMenuButton({
+  row,
+  deleteColumnsFromTransforms,
+  transforms,
+}: ITransformDeleteProps) {
+  if (transforms === undefined) {
+    return <>--</>;
+  }
+
+  const cols = transforms.columnTransformations;
+  const transformsInColumn = cols.filter(({ columnName }) => {
+    return columnName === row.name;
+  });
+
+  const numTransformsInColumn = transformsInColumn.length;
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [subMenuAnchorEl, setSubMenuAnchorEl] = useState(null);
+  const open = Boolean(anchorEl);
+
+  const handleClick = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleDeleteClick = (index) => {
+    deleteColumnsFromTransforms(transforms.tableName, index);
+    handleClose();
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+    setSubMenuAnchorEl(null);
+  };
+
+  return (
+    <>
+      <SmallButton
+        color="primary"
+        id={`transform-delete-${row.name}-button`}
+        aria-controls="trasnform-column-menu"
+        aria-haspopup="true"
+        variant="text"
+        disabled={numTransformsInColumn === 0}
+        aria-expanded={open ? 'true' : undefined}
+        onClick={handleClick}
+      >
+        {`${numTransformsInColumn}`}
+        <KeyboardArrowDownIconTransformGrid />
+      </SmallButton>
+      <Menu
+        getContentAnchorEl={null}
+        id={`transform-menu-${row.name}`}
+        anchorEl={anchorEl}
+        open={open}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right',
+        }}
+        onClose={handleClose}
+        MenuListProps={{
+          'aria-labelledby': `transform-menu-${row.name}-button`,
+        }}
+      >
+        {cols.map((col, i) => {
+          const name = col.columnName;
+          const dir = col.directive;
+          const thisCol = name === row.name;
+          return (
+            <MenuItem
+              onClick={() => handleDeleteClick(i)}
+              disabled={!thisCol}
+              style={{ background: thisCol ? 'blue' : '' }}
+            >
+              {dir} <Delete />
+            </MenuItem>
+          );
+        })}
+      </Menu>
+    </>
+  );
+}

--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/addToTransforms.ts
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/addToTransforms.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { IAddColumnsToTransforms, ITransformInformation } from 'components/Replicator/types';
+
+export interface IAddToTransforms {
+  transformInfo: ITransformInformation;
+  addColumnsToTransforms: (opts: IAddColumnsToTransforms) => void;
+}
+
+export const addTinkToTransforms = (transform: IAddToTransforms): void => {
+  const { tableName, columnName, directive } = transform.transformInfo;
+  const actualDirective = `TINK ${columnName} ${directive}`;
+  const columnTransformation = {
+    directive: actualDirective,
+    columnName,
+  };
+  transform.addColumnsToTransforms({ tableName, columnTransformation });
+};
+
+export const addRenameToTransforms = (transform: IAddToTransforms): void => {
+  const { tableName, columnName, directive } = transform.transformInfo;
+  const actualDirective = `rename ${columnName} ${directive}`;
+  const columnTransformation = {
+    directive: actualDirective,
+    columnName,
+  };
+  transform.addColumnsToTransforms({ tableName, columnTransformation });
+};

--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/index.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/index.tsx
@@ -291,7 +291,17 @@ const SelectColumnsView: React.FC<ISelectColumnsProps> = (props) => {
         )}
         {state.loading
           ? renderLoading()
-          : renderTable({ state, toggleSelectAll, toggleSelected, I18N_PREFIX, handleSearch })}
+          : renderTable({
+              state,
+              toggleSelectAll,
+              toggleSelected,
+              I18N_PREFIX,
+              handleSearch,
+              addColumnsToTransforms: props.addColumnsToTransforms,
+              deleteColumnsFromTransforms: props.deleteColumnsFromTransforms,
+              transforms: props.transformations[props.tableInfo.table],
+              tableInfo: props.tableInfo,
+            })}
       </Root>
     </Backdrop>
   );

--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/styles.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/styles.tsx
@@ -204,6 +204,7 @@ export const WarningMessage = styled.span`
 
 export const SmallButton = styled(Button)`
   font-size: 12px;
+  align-self: center;
 `;
 
 export const RefreshContainer = styled.div`

--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/table.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/table.tsx
@@ -31,26 +31,36 @@ import {
   CenteredTextSpan,
   GridCellContainer,
   GridBorderBottom,
-  KeyboardArrowDownIconTransformGrid,
   SmallButton,
   WarningMessage,
   GridDividerCell,
 } from './styles';
 import SearchBox from 'components/Replicator/Create/Content/SearchBox';
 import StatusButton from 'components/StatusButton';
+import TransformAddButton from './TransformAdd';
+import { IAddColumnsToTransforms, ITableInfo, ITransformation } from 'components/Replicator/types';
+import TransformDelete from './TransformDelete';
 
 export const renderTable = ({
   state,
+  tableInfo,
   handleSearch,
   toggleSelectAll,
   toggleSelected,
   I18N_PREFIX,
+  addColumnsToTransforms,
+  deleteColumnsFromTransforms,
+  transforms,
 }: {
   state: ISelectColumnsState;
+  addColumnsToTransforms: (opts: IAddColumnsToTransforms) => void;
+  deleteColumnsFromTransforms: (tableName: string, colTransIndex: number) => void;
   handleSearch: (search: any) => void;
   toggleSelectAll: () => void;
   toggleSelected: (row: any) => void;
+  transforms: ITransformation;
   I18N_PREFIX: string;
+  tableInfo: ITableInfo;
 }) => {
   const numNotSupported = 3;
   let supportedError;
@@ -223,13 +233,19 @@ export const renderTable = ({
                   <StatusButton status="success" />
                 </GridButtonCell>
                 <GridCell item xs={4}>
-                  <SmallButton color="primary">
-                    Transform
-                    <KeyboardArrowDownIconTransformGrid />
-                  </SmallButton>
+                  <TransformAddButton
+                    row={row}
+                    addColumnsToTransforms={addColumnsToTransforms}
+                    tableInfo={tableInfo}
+                  />
                 </GridCell>
                 <GridCell item xs={6}>
-                  <span>--</span>
+                  <TransformDelete
+                    row={row}
+                    tableInfo={tableInfo}
+                    transforms={transforms}
+                    deleteColumnsFromTransforms={deleteColumnsFromTransforms}
+                  />
                 </GridCell>
               </GridCellContainer>
             </GridBorderBottom>

--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/types.ts
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/types.ts
@@ -14,7 +14,13 @@
  * the License.
  */
 
-import { IColumnsList, IColumnImmutable, ITableInfo } from 'components/Replicator/types';
+import {
+  IColumnsList,
+  IColumnImmutable,
+  ITableInfo,
+  IAddColumnsToTransforms,
+  ITransformation,
+} from 'components/Replicator/types';
 
 export interface ISelectColumnsProps {
   tableInfo?: ITableInfo;
@@ -22,6 +28,9 @@ export interface ISelectColumnsProps {
   initialSelected: IColumnsList;
   toggle: () => void;
   draftId: string;
+  addColumnsToTransforms: (opts: IAddColumnsToTransforms) => void;
+  deleteColumnsFromTransforms: (tableName: string, colTransIndex: number) => void;
+  transformations: ITransformation;
 }
 
 interface IColumn {
@@ -44,4 +53,17 @@ export interface ISelectColumnsState {
   loading: boolean;
   error: any;
   search: string;
+}
+
+export interface ITransformAddProps {
+  row: IColumn;
+  tableInfo: ITableInfo;
+  addColumnsToTransforms: (opts: IAddColumnsToTransforms) => void;
+}
+
+export interface ITransformDeleteProps {
+  row: IColumn;
+  tableInfo: ITableInfo;
+  transforms: ITransformation;
+  deleteColumnsFromTransforms: (tableName: string, colTransIndex: number) => void;
 }

--- a/app/cdap/components/Replicator/Create/Content/SelectTables/index.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectTables/index.tsx
@@ -481,7 +481,7 @@ class SelectTablesView extends React.PureComponent<ISelectTablesProps, ISelectTa
 
   public renderColumns = () => {
     let Columns = SelectColumns;
-    if (true) {
+    if (false) {
       // this will eventually be a feature flag but just leaving it as a boolean
       // for now as a convenience
       Columns = SelectColumnsWithTransforms;

--- a/app/cdap/components/Replicator/Create/index.tsx
+++ b/app/cdap/components/Replicator/Create/index.tsx
@@ -35,6 +35,8 @@ import {
   ITablesStore,
   IColumnsStore,
   IDMLStore,
+  ITransformation,
+  IAddColumnsToTransforms,
 } from 'components/Replicator/types';
 import { IWidgetJson } from 'components/ConfigurationGroup/types';
 
@@ -107,6 +109,9 @@ export interface ICreateState {
   saveDraft: () => Observable<any>;
   setColumns: (columns, callback) => void;
   isStateFilled: (stateKeys: string[]) => boolean;
+  transformations: { [tableName: string]: ITransformation };
+  addColumnsToTransforms: (opts: IAddColumnsToTransforms) => void;
+  deleteColumnsFromTransforms: (tableName: string, colTransIndex: number) => void;
 }
 
 export type ICreateContext = Partial<ICreateState>;
@@ -166,6 +171,51 @@ class CreateView extends React.PureComponent<ICreateProps, ICreateContext> {
 
   public setTables = (tables, columns, dmlBlacklist) => {
     this.setState({ tables, columns, dmlBlacklist });
+  };
+
+  public deleteColumnsFromTransforms = (tableName: string, colTransIndex: number) => {
+    if (colTransIndex === 0) {
+      this.setState({
+        transformations: {
+          ...this.state.transformations,
+          [tableName]: undefined,
+        },
+      });
+    } else {
+      const transformationTable = this.state.transformations[tableName];
+      const newTransformations = transformationTable.columnTransformations.splice(0, colTransIndex);
+      transformationTable.columnTransformations = newTransformations;
+      this.setState({
+        transformations: {
+          ...this.state.transformations,
+          [tableName]: transformationTable,
+        },
+      });
+    }
+  };
+
+  public addColumnsToTransforms = (opts: IAddColumnsToTransforms) => {
+    const { tableName, columnTransformation } = opts;
+    const transformationTable = this.state.transformations[tableName];
+    if (!transformationTable) {
+      this.setState({
+        transformations: {
+          ...this.state.transformations,
+          [tableName]: {
+            tableName,
+            columnTransformations: [columnTransformation],
+          },
+        },
+      });
+    } else {
+      transformationTable.columnTransformations.push(columnTransformation);
+      this.setState({
+        transformations: {
+          ...this.state.transformations,
+          [tableName]: transformationTable,
+        },
+      });
+    }
   };
 
   public setAdvanced = (numInstances) => {
@@ -232,6 +282,7 @@ class CreateView extends React.PureComponent<ICreateProps, ICreateContext> {
       parallelism: {
         numInstances: this.state.numInstances,
       },
+      tableTransformations: Object.values(this.state.transformations),
     };
 
     return config;
@@ -271,6 +322,7 @@ class CreateView extends React.PureComponent<ICreateProps, ICreateContext> {
     draftId: null,
     isInvalidSource: false,
     loading: true,
+    transformations: {},
 
     activeStep: 0,
 
@@ -288,6 +340,8 @@ class CreateView extends React.PureComponent<ICreateProps, ICreateContext> {
     saveDraft: this.saveDraft,
     setColumns: this.setColumns,
     isStateFilled: this.isStateFilled,
+    addColumnsToTransforms: this.addColumnsToTransforms,
+    deleteColumnsFromTransforms: this.deleteColumnsFromTransforms,
   };
 
   public componentDidMount() {

--- a/app/cdap/components/Replicator/types.ts
+++ b/app/cdap/components/Replicator/types.ts
@@ -94,3 +94,22 @@ export interface IRawMetricData {
   resolution: string;
   series: IMetricSeries[];
 }
+
+export interface ITransformInformation extends IColumnTransformation {
+  tableName: string;
+}
+
+export interface IColumnTransformation {
+  columnName: string;
+  directive: string;
+}
+
+export interface ITransformation {
+  tableName: string;
+  columnTransformations: IColumnTransformation[];
+}
+
+export interface IAddColumnsToTransforms {
+  tableName: string;
+  columnTransformation: IColumnTransformation;
+}


### PR DESCRIPTION
Add/delete transformations from replication job. 

Still need to :
- Fix styling on add/delete experience.
- Connect transformation validation and table error checks.
- Fix styling in a few other places.
- Add feature flags. 