### PR TITLE
fix ignoring of click event on navbar items when market modal is active

### DIFF
--- a/app/cdap/components/AppHeader/AppToolBar/AppToolbar.tsx
+++ b/app/cdap/components/AppHeader/AppToolBar/AppToolbar.tsx
@@ -87,11 +87,13 @@ class AppToolbar extends React.PureComponent<IAppToolbarProps, IAppToolbarState>
             featureFlag={Theme.showDashboard}
             featureName={Theme.featureNames.dashboard}
             featureUrl={`/ns/${namespace}/operations`}
+            onClick={() => this.eventEmitter.emit(globalEvents.CLOSEMARKET)}
           />
           <ToolBarFeatureLink
             featureFlag={Theme.showReports}
             featureName={Theme.featureNames.reports}
             featureUrl={`/ns/${namespace}/reports`}
+            onClick={() => this.eventEmitter.emit(globalEvents.CLOSEMARKET)}
           />
           <HubButton />
           <ToolBarFeatureLink
@@ -100,7 +102,10 @@ class AppToolbar extends React.PureComponent<IAppToolbarProps, IAppToolbarState>
             featureUrl={`/administration`}
             // This is needed here when Authorization fails for all namespaces.
             // In this case navigating to Admin section doesn't have restriction (yet).
-            onClick={() => this.eventEmitter.emit(globalEvents.PAGE_LEVEL_ERROR, { reset: true })}
+            onClick={() => {
+              this.eventEmitter.emit(globalEvents.PAGE_LEVEL_ERROR, { reset: true });
+              this.eventEmitter.emit(globalEvents.CLOSEMARKET);
+            }}
           />
         </div>
         <AppToolbarMenu />

--- a/app/cdap/components/AppHeader/BrandImage.tsx
+++ b/app/cdap/components/AppHeader/BrandImage.tsx
@@ -20,6 +20,8 @@ import { withContext, INamespaceLinkContext } from 'components/AppHeader/Namespa
 import { Theme } from 'services/ThemeHelper';
 import { Link } from 'react-router-dom';
 import { getCurrentNamespace } from 'services/NamespaceStore';
+import globalEvents from 'services/global-events';
+import ee from 'event-emitter';
 
 interface IBrandImageProps extends WithStyles<typeof imageStyle> {
   context: INamespaceLinkContext;
@@ -30,9 +32,15 @@ const BrandImage: React.SFC<IBrandImageProps> = ({ classes, context }) => {
   const { isNativeLink } = context;
   const namespace = getCurrentNamespace();
   const LinkEl = isNativeLink ? 'a' : Link;
+  const eventEmitter = ee(ee);
+
   return (
     <LinkEl to={`/ns/${namespace}`} href={`/cdap/ns/${namespace}`}>
-      <img className={classes.img} src={brandLogoSrc} />
+      <img
+        className={classes.img}
+        src={brandLogoSrc}
+        onClick={() => eventEmitter.emit(globalEvents.CLOSEMARKET)}
+      />
     </LinkEl>
   );
 };


### PR DESCRIPTION
## **Issue:** [CDAP-18524](https://cdap.atlassian.net/browse/CDAP-18524)

This PR fixes the issue of navigating to other tabs (e.g., Operations, Report, etc.) when the market modal is active.

**Current Behaviour:** Click event is ignored on `navbar` items (except for `HUB` button) when market modal is active.

**Expected Behaviour:** User should be able to exit out of the modal by clicking on other items in the `navbar`.