### PR TITLE
display 0 as the value for scale and precision of decimal fields

### DIFF
--- a/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/FieldAttributes/DecimalAttributes.tsx
+++ b/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/FieldAttributes/DecimalAttributes.tsx
@@ -31,10 +31,12 @@ function DecimalTypeAttributes({
   onChange,
   handleClose,
 }: IAttributesComponentProps) {
-  const [scale, setScale] = React.useState(objectQuery(typeProperties, 'scale') || defaultScale);
-  const [precision, setPrecision] = React.useState(
-    objectQuery(typeProperties, 'precision') || defaultPrecision
-  );
+  let derivedScale = objectQuery(typeProperties, 'scale');
+  let derivedPrecision = objectQuery(typeProperties, 'precision');
+  derivedScale = typeof derivedScale === 'number' ? derivedScale : defaultScale;
+  derivedPrecision = typeof derivedPrecision === 'number' ? derivedPrecision : defaultPrecision;
+  const [scale, setScale] = React.useState(derivedScale);
+  const [precision, setPrecision] = React.useState(derivedPrecision);
   const classes = useAttributePopoverStyles();
 
   const onChangeHandler = () => {


### PR DESCRIPTION
## **Issue:** [CDAP-18588](https://cdap.atlassian.net/browse/CDAP-18588)

**Current Behaviour:** Setting the scale or precision as 0 for decimal fields in the pipeline studio is captured behind the scene, but not displayed in the UI (fall back to default values).

**Expected Behaviour:** Setting the scale or precision as 0 for decimal fields in the pipeline studio should be reflected in the UI as well.

**Context:** We had a truthy condition check against zero values that would return false, hence falling back to default values.