### PR TITLE
persist entered values when toggling macro button in pipeline studio …

### DIFF
--- a/app/cdap/components/ConfigurationGroup/PropertyRow/index.tsx
+++ b/app/cdap/components/ConfigurationGroup/PropertyRow/index.tsx
@@ -83,6 +83,8 @@ const WIDGET_CATEGORY = 'widget-category';
 
 interface IState {
   isMacroTextbox: boolean;
+  prevValue: string;
+  prevMacroValue: string;
 }
 
 class PropertyRowView extends React.Component<IPropertyRowProps, IState> {
@@ -92,6 +94,8 @@ class PropertyRowView extends React.Component<IPropertyRowProps, IState> {
 
   public state = {
     isMacroTextbox: this.isMacroTextbox(),
+    prevValue: '',
+    prevMacroValue: '${}',
   };
 
   public shouldComponentUpdate(nextProps) {
@@ -122,9 +126,11 @@ class PropertyRowView extends React.Component<IPropertyRowProps, IState> {
     const newValue = !this.state.isMacroTextbox;
 
     if (newValue) {
-      this.handleChange('${}');
+      this.setState({ prevValue: this.props.value });
+      this.handleChange(this.state.prevMacroValue);
     } else {
-      this.handleChange('');
+      this.setState({ prevMacroValue: this.props.value });
+      this.handleChange(this.state.prevValue);
     }
 
     this.setState({ isMacroTextbox: newValue });

--- a/app/cdap/components/ConfigurationGroup/PropertyRow/index.tsx
+++ b/app/cdap/components/ConfigurationGroup/PropertyRow/index.tsx
@@ -82,9 +82,7 @@ const PLUGIN = 'plugin';
 const WIDGET_CATEGORY = 'widget-category';
 
 interface IState {
-  isMacroTextbox: boolean;
-  prevValue: string;
-  prevMacroValue: string;
+  [key: string]: string | boolean;
 }
 
 class PropertyRowView extends React.Component<IPropertyRowProps, IState> {
@@ -124,16 +122,16 @@ class PropertyRowView extends React.Component<IPropertyRowProps, IState> {
       return;
     }
     const newValue = !this.state.isMacroTextbox;
+    let valueStateToBeUpdated = 'prevValue';
 
     if (newValue) {
-      this.setState({ prevValue: this.props.value });
       this.handleChange(this.state.prevMacroValue);
     } else {
-      this.setState({ prevMacroValue: this.props.value });
+      valueStateToBeUpdated = 'prevMacroValue';
       this.handleChange(this.state.prevValue);
     }
 
-    this.setState({ isMacroTextbox: newValue });
+    this.setState({ isMacroTextbox: newValue, [valueStateToBeUpdated]: this.props.value });
   };
 
   private handleChange = (value) => {


### PR DESCRIPTION
## **Issue:** [CDAP-18385](https://cdap.atlassian.net/browse/CDAP-18385)

This PR ensures previously entered values in pipeline studio configuration fields persist when toggling the macro button

**Current Behaviour:** Toggling the macro button clears the field

**Expected Behaviour:** Toggling the macro button should display previously entered value