### PR TITLE
fix page nav when setting runtime args in control center

### DIFF
--- a/app/cdap/components/EntityListView/SearchStore/ActionCreator.js
+++ b/app/cdap/components/EntityListView/SearchStore/ActionCreator.js
@@ -28,7 +28,7 @@ import { Theme } from 'services/ThemeHelper';
 
 const search = () => {
   const namespace = getCurrentNamespace();
-  let { offset, limit, activeFilters, activeSort, query, cursor } = SearchStore.getState().search;
+  let { offset, limit, activeFilters, activeSort, query } = SearchStore.getState().search;
 
   let params = {
     namespace: namespace,
@@ -39,7 +39,6 @@ const search = () => {
     query,
     responseFormat: 'v6',
     cursorRequested: true,
-    cursor,
   };
   if (query !== DEFAULT_SEARCH_QUERY) {
     delete params.sort;


### PR DESCRIPTION
## **Issue:** [CDAP-18442](https://cdap.atlassian.net/browse/CDAP-18442)

This PR fixes the page navigation issue when setting runtime arguments for applications in control center

**Current Behaviour:** After setting a runtime arg and clicking on `Save & Close`, control center jumps to the next page

**Expected Behaviour:** After setting a runtime arg and clicking on `Save & Close`, control center should remain on current page