### PR TITLE
Fixes tab height for horizontal tabs

### DIFF
--- a/app/cdap/components/shared/Tabs/Tabs.scss
+++ b/app/cdap/components/shared/Tabs/Tabs.scss
@@ -51,8 +51,8 @@
       &:first-child {
         height: 50px;
       }
-      &:nth-child(2) {
-        height: calc(100% - 35px);
+      &.active {
+        height: calc(100% - 50px);
       }
     }
   }


### PR DESCRIPTION
# TITLE

## Description
Since we render both active/hidden tabs need to change CSS selector to fix height of the active tab.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement

## Links
Jira: [970](https://cdap.atlassian.net/browse/PLUGIN-970)

## Test Plan

## Screenshots


