### PR TITLE
Fix z-index of BQ pushdown connection popup

### DIFF
--- a/app/cdap/components/PipelineConfigurations/PipelineConfigurations.scss
+++ b/app/cdap/components/PipelineConfigurations/PipelineConfigurations.scss
@@ -22,6 +22,10 @@ $top-panel-height: 54px;
 $right-position: -360px;
 $sidepanel-width: 170px;
 
+.pipeline-config-modal {
+  z-index: 1060; // overriding default 1300 to make nested modals (1061) visible.
+}
+
 .pipeline-configurations-content {
   width: $modeless-width;
   height: $modeless-height;

--- a/app/cdap/components/PipelineConfigurations/index.js
+++ b/app/cdap/components/PipelineConfigurations/index.js
@@ -210,6 +210,7 @@ export default class PipelineConfigurations extends Component {
         anchorEl={this.props.anchorEl}
         onClose={this.props.onClose}
         title={this.getHeaderLabel()}
+        popoverClassName="pipeline-config-modal"
       >
         <Provider store={PipelineConfigurationsStore}>
           <div


### PR DESCRIPTION
# TITLE

## Description
Fixing z-index of parent modal to make the nested ones visibles.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement

## Links
Jira: [1020](https://cdap.atlassian.net/browse/PLUGIN-1020)

## Test Plan

## Screenshots
Issue:
![image](https://user-images.githubusercontent.com/81957712/147426028-73bdab6a-8fd5-4e15-b03c-077b38d17e1b.png)

