### PR TITLE
Add api calls to odf

### DIFF
--- a/app/cdap/api/tethering.ts
+++ b/app/cdap/api/tethering.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Cask Data, Inc.
+ * Copyright © 2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/app/cdap/api/tethering.ts
+++ b/app/cdap/api/tethering.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import DataSourceConfigurer from 'services/datasource/DataSourceConfigurer';
+import { apiCreator } from 'services/resource-helper';
+
+const dataSrc = DataSourceConfigurer.getInstance();
+const basePath = '/tethering';
+const connectionsBasePath = `${basePath}/connections`;
+const connectionPeerPath = `${connectionsBasePath}/:peer`;
+
+export const TetheringApi = {
+  createTethering: apiCreator(dataSrc, 'PUT', 'REQUEST', `${basePath}/create`),
+  acceptOrRejectTethering: apiCreator(dataSrc, 'POST', 'REQUEST', `${connectionPeerPath}`),
+  deleteTethering: apiCreator(dataSrc, 'DELETE', 'REQUEST', `${connectionPeerPath}`),
+  getTetheringStatus: apiCreator(dataSrc, 'GET', 'REQUEST', `${connectionPeerPath}`),
+  getTetheringStatusForAll: apiCreator(dataSrc, 'GET', 'REQUEST', `${connectionsBasePath}`),
+  getOdfInstanceNames: apiCreator(dataSrc, 'GET', 'REQUEST', `${connectionsBasePath}/peers`), // TODO: update with new endpoints when ready
+  getOdfInstanceName: apiCreator(
+    dataSrc,
+    'GET',
+    'REQUEST',
+    `${connectionsBasePath}/peers/:peer/namespaces`
+  ), // TODO: updtae with new endpoints when ready
+};

--- a/app/cdap/components/Administration/TetheringTabContent/CdfTetheringConnections/Connections.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/CdfTetheringConnections/Connections.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Cask Data, Inc.
+ * Copyright © 2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/app/cdap/components/Administration/TetheringTabContent/CdfTetheringConnections/Connections.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/CdfTetheringConnections/Connections.tsx
@@ -22,18 +22,14 @@ import { HeaderContainer, HeaderTitle, BodyContainer, NoDataText } from '../shar
 const PREFIX = 'features.Administration.Tethering';
 const I18NPREFIX = `${PREFIX}.Connections`;
 
-const ConnectionsHeader = styled(HeaderContainer)`
-  background-color: ${(props) => props.theme.palette.grey[700]};
-`;
-
 const Connections = () => {
   const [connections, setConnections] = useState([]);
 
   return (
     <>
-      <ConnectionsHeader>
+      <HeaderContainer>
         <HeaderTitle>{T.translate(`${I18NPREFIX}.connectionsHeader`)}</HeaderTitle>
-      </ConnectionsHeader>
+      </HeaderContainer>
       <BodyContainer>
         {connections.length > 0 ? (
           <span>Connections Table goes here</span>

--- a/app/cdap/components/Administration/TetheringTabContent/CdfTetheringConnections/NewRequests.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/CdfTetheringConnections/NewRequests.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Cask Data, Inc.
+ * Copyright © 2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/app/cdap/components/Administration/TetheringTabContent/CdfTetheringConnections/NewRequests.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/CdfTetheringConnections/NewRequests.tsx
@@ -22,18 +22,14 @@ import { HeaderContainer, HeaderTitle, BodyContainer, NoDataText } from '../shar
 const PREFIX = 'features.Administration.Tethering';
 const I18NPREFIX = `${PREFIX}.NewRequests`;
 
-const NewRequestsHeader = styled(HeaderContainer)`
-  background-color: ${(props) => props.theme.palette.grey[700]};
-`;
-
 const NewRequests = () => {
   const [newRequests, setNewRequests] = useState([]);
 
   return (
     <>
-      <NewRequestsHeader>
+      <HeaderContainer>
         <HeaderTitle>{T.translate(`${I18NPREFIX}.newRequestsHeader`)}</HeaderTitle>
-      </NewRequestsHeader>
+      </HeaderContainer>
       <BodyContainer>
         {newRequests.length > 0 ? (
           <span>NewRequests Table goes here</span>

--- a/app/cdap/components/Administration/TetheringTabContent/CdfTetheringConnections/index.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/CdfTetheringConnections/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Cask Data, Inc.
+ * Copyright © 2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/Connections/ConnectionsTable.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/Connections/ConnectionsTable.tsx
@@ -15,12 +15,26 @@
  */
 
 import React from 'react';
+import { IConnection } from '../types';
 
-const ConnectionsTable = () => {
+interface IConnectionsTableProps {
+  tableData: IConnection[];
+}
+
+const ConnectionsTable = ({ tableData }: IConnectionsTableProps) => {
+  const transformedTableData = tableData.map((req) => ({
+    requestTime: '00:00:00',
+    gcloudProject: req.metadata.metadata.project,
+    instanceName: req.name,
+    region: req.metadata.metadata.location,
+    requestedResources: req.metadata.namespaceAllocations,
+  }));
+
   return (
     <>
-      {/* TODO: Add table here*/}
-      <span> Table Goes Here </span>
+      {transformedTableData.map((row) => {
+        return <span> {row.gcloudProject} </span>;
+      })}
     </>
   );
 };

--- a/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/Connections/ConnectionsTable.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/Connections/ConnectionsTable.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Cask Data, Inc.
+ * Copyright © 2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -34,7 +34,7 @@ const ConnectionsTable = ({ tableData }: IConnectionsTableProps) => {
     <>
       {/* TODO: Will be completed after pending requests and new request creation*/}
       {transformedTableData.map((row) => {
-        return <span> {row.gcloudProject} </span>;
+        row.gcloudProject;
       })}
     </>
   );

--- a/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/Connections/ConnectionsTable.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/Connections/ConnectionsTable.tsx
@@ -33,9 +33,7 @@ const ConnectionsTable = ({ tableData }: IConnectionsTableProps) => {
   return (
     <>
       {/* TODO: Will be completed after pending requests and new request creation*/}
-      {transformedTableData.map((row) => {
-        row.gcloudProject;
-      })}
+      {transformedTableData.map((row) => row.gcloudProject)}
     </>
   );
 };

--- a/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/Connections/ConnectionsTable.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/Connections/ConnectionsTable.tsx
@@ -32,6 +32,7 @@ const ConnectionsTable = ({ tableData }: IConnectionsTableProps) => {
 
   return (
     <>
+      {/* TODO: Will be completed after pending requests and new request creation*/}
       {transformedTableData.map((row) => {
         return <span> {row.gcloudProject} </span>;
       })}

--- a/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/Connections/index.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/Connections/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Cask Data, Inc.
+ * Copyright © 2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/Connections/index.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/Connections/index.tsx
@@ -19,6 +19,7 @@ import styled from 'styled-components';
 import T from 'i18n-react';
 import ConnectionsTable from './ConnectionsTable';
 import { HeaderContainer, HeaderTitle, BodyContainer, NoDataText } from '../../shared.styles';
+import { IConnection } from '../types';
 
 const PREFIX = 'features.Administration.Tethering';
 const I18NPREFIX = `${PREFIX}.Connections`;
@@ -27,9 +28,11 @@ const ConnectionsHeader = styled(HeaderContainer)`
   background-color: ${(props) => props.theme.palette.grey[700]};
 `;
 
-const Connections = () => {
-  const [connections, setConnections] = useState([]);
+interface IConnectionsProps {
+  connections: IConnection[];
+}
 
+const Connections = ({ connections }: IConnectionsProps) => {
   return (
     <>
       <ConnectionsHeader>
@@ -37,7 +40,7 @@ const Connections = () => {
       </ConnectionsHeader>
       <BodyContainer>
         {connections.length > 0 ? (
-          <ConnectionsTable />
+          <ConnectionsTable tableData={connections} />
         ) : (
           <NoDataText>{T.translate(`${I18NPREFIX}.noConnections`)}</NoDataText>
         )}

--- a/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/Connections/index.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/Connections/index.tsx
@@ -24,10 +24,6 @@ import { IConnection } from '../types';
 const PREFIX = 'features.Administration.Tethering';
 const I18NPREFIX = `${PREFIX}.Connections`;
 
-const ConnectionsHeader = styled(HeaderContainer)`
-  background-color: ${(props) => props.theme.palette.grey[700]};
-`;
-
 interface IConnectionsProps {
   connections: IConnection[];
 }
@@ -35,9 +31,9 @@ interface IConnectionsProps {
 const Connections = ({ connections }: IConnectionsProps) => {
   return (
     <>
-      <ConnectionsHeader>
+      <HeaderContainer>
         <HeaderTitle>{T.translate(`${I18NPREFIX}.connectionsHeader`)}</HeaderTitle>
-      </ConnectionsHeader>
+      </HeaderContainer>
       <BodyContainer>
         {connections.length > 0 ? (
           <ConnectionsTable tableData={connections} />

--- a/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/PendingRequests/PendingRequestsTable.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/PendingRequests/PendingRequestsTable.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Cask Data, Inc.
+ * Copyright © 2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,7 +18,7 @@ import React from 'react';
 import T from 'i18n-react';
 import styled, { css } from 'styled-components';
 import { IConnection, IPendingReqsTableData } from '../types';
-import { addPercentSign } from 'services/helpers';
+import { formatAsPercentage } from 'services/DataFormatter';
 
 const PREFIX = 'features.Administration.Tethering';
 
@@ -73,13 +73,13 @@ const GridRow = styled.div`
   ${(props) =>
     props.border &&
     css`
-      border-bottom: 1px solid ${(props) => props.theme.palette.grey[1000]};
+      border-bottom: 1px solid ${(properties) => properties.theme.palette.grey[1000]};
     `}
 
   ${(props) =>
     props.header &&
     css`
-      background-color: ${(props) => props.theme.palette.grey[700]};
+      background-color: ${(properties) => properties.theme.palette.grey[700]};
     `}
 `;
 
@@ -93,7 +93,7 @@ const GridCell = styled.div`
     props.border &&
     css`
       margin-bottom: -5px;
-      border-bottom: 1px solid ${(props) => props.theme.palette.grey[1000]};
+      border-bottom: 1px solid ${(properties) => properties.theme.palette.grey[1000]};
     `}
 `;
 
@@ -146,14 +146,14 @@ const PendingRequestsTable = ({ tableData }: IPendingReqsTableProps) => {
           <GridCell>{isFirst ? instanceName : ''}</GridCell>
           <GridCell>{isFirst ? region : ''}</GridCell>
           <GridCell border={!isLast}>{namespace}</GridCell>
-          <GridCell border={!isLast}>{addPercentSign(cpuLimit)}</GridCell>
-          <GridCell border={!isLast}>{addPercentSign(memoryLimit)}</GridCell>
+          <GridCell border={!isLast}>{formatAsPercentage(cpuLimit)}</GridCell>
+          <GridCell border={!isLast}>{formatAsPercentage(memoryLimit)}</GridCell>
         </GridRow>
       );
     });
   };
 
-  return <>{renderTable(transformedTableData)}</>;
+  return renderTable(transformedTableData);
 };
 
 export default PendingRequestsTable;

--- a/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/PendingRequests/PendingRequestsTable.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/PendingRequests/PendingRequestsTable.tsx
@@ -73,13 +73,13 @@ const GridRow = styled.div`
   ${(props) =>
     props.border &&
     css`
-      border-bottom: 1px solid ${(properties) => properties.theme.palette.grey[1000]};
+      border-bottom: 1px solid var(--grey11);
     `}
 
   ${(props) =>
     props.header &&
     css`
-      background-color: ${(properties) => properties.theme.palette.grey[700]};
+      background-color: var(--grey08);
     `}
 `;
 
@@ -93,7 +93,7 @@ const GridCell = styled.div`
     props.border &&
     css`
       margin-bottom: -5px;
-      border-bottom: 1px solid ${(properties) => properties.theme.palette.grey[1000]};
+      border-bottom: 1px solid 1px solid var(--grey11);
     `}
 `;
 

--- a/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/PendingRequests/PendingRequestsTable.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/PendingRequests/PendingRequestsTable.tsx
@@ -19,8 +19,10 @@ import T from 'i18n-react';
 import styled, { css } from 'styled-components';
 import { IConnection, IPendingReqsTableData } from '../types';
 import { formatAsPercentage } from 'services/DataFormatter';
+import { humanReadableDate } from 'services/helpers';
 
 const PREFIX = 'features.Administration.Tethering';
+const REQUEST_DATE_FORMAT = 'MM/DD/YYYY - hh:mm A';
 
 const PENDING_REQS_TABLE_HEADERS = [
   {
@@ -103,7 +105,7 @@ interface IPendingReqsTableProps {
 
 const PendingRequestsTable = ({ tableData }: IPendingReqsTableProps) => {
   const transformedTableData = tableData.map((req) => ({
-    requestTime: '00/00/00 - 00:00 AM', // will be updated once backend server captures request time upon creation
+    requestTime: humanReadableDate(Date.now(), true, false, REQUEST_DATE_FORMAT), // will be updated once backend server captures request time upon creation
     gcloudProject: req.metadata.metadata.project,
     instanceName: req.name,
     region: req.metadata.metadata.location,

--- a/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/PendingRequests/PendingRequestsTable.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/PendingRequests/PendingRequestsTable.tsx
@@ -15,7 +15,87 @@
  */
 
 import React from 'react';
-import { IConnection } from '../types';
+import T from 'i18n-react';
+import styled, { css } from 'styled-components';
+import { IConnection, IPendingReqsTableData } from '../types';
+import { addPercentSign } from 'services/helpers';
+
+const PREFIX = 'features.Administration.Tethering';
+
+const PENDING_REQS_TABLE_HEADERS = [
+  {
+    property: 'requestTime', // properties may come handy when adding sort by columns to the table, will remove if not needed
+    label: T.translate(`${PREFIX}.ColumnHeaders.requestTime`),
+  },
+  {
+    property: 'gcp',
+    label: T.translate(`${PREFIX}.ColumnHeaders.gcp`),
+  },
+  {
+    property: 'instanceName',
+    label: T.translate(`${PREFIX}.ColumnHeaders.instanceName`),
+  },
+  {
+    property: 'region',
+    label: T.translate(`${PREFIX}.ColumnHeaders.region`),
+  },
+  {
+    property: 'omniNamespace',
+    label: T.translate(`${PREFIX}.ColumnHeaders.omniNamespace`),
+  },
+  {
+    property: 'cpu',
+    label: T.translate(`${PREFIX}.ColumnHeaders.cpu`),
+  },
+  {
+    property: 'memory',
+    label: T.translate(`${PREFIX}.ColumnHeaders.memory`),
+  },
+  {
+    label: '',
+  },
+];
+
+const GridContainer = styled.div`
+  width: 100%;
+  margin-top: 30px;
+  margin-bottom: 15px;
+  padding: 0 30px;
+  max-height: none;
+`;
+
+const GridRow = styled.div`
+  display: grid;
+  height: 30px;
+  padding: 5px 5px 5px 20px;
+  grid-template-columns: 1.5fr 1.5fr 2fr 1fr 2fr 1fr 0.5fr 1fr;
+
+  ${(props) =>
+    props.border &&
+    css`
+      border-bottom: 1px solid ${(props) => props.theme.palette.grey[1000]};
+    `}
+
+  ${(props) =>
+    props.header &&
+    css`
+      background-color: ${(props) => props.theme.palette.grey[700]};
+    `}
+`;
+
+const GridCell = styled.div`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-right: 20px;
+
+  ${(props) =>
+    props.border &&
+    css`
+      margin-bottom: -5px;
+      border-bottom: 1px solid ${(props) => props.theme.palette.grey[1000]};
+    `}
+`;
 
 interface IPendingReqsTableProps {
   tableData: IConnection[];
@@ -23,20 +103,57 @@ interface IPendingReqsTableProps {
 
 const PendingRequestsTable = ({ tableData }: IPendingReqsTableProps) => {
   const transformedTableData = tableData.map((req) => ({
-    requestTime: '00:00:00',
+    requestTime: '00/00/00 - 00:00 AM', // will be updated once backend server captures request time upon creation
     gcloudProject: req.metadata.metadata.project,
     instanceName: req.name,
     region: req.metadata.metadata.location,
     requestedResources: req.metadata.namespaceAllocations,
   }));
 
-  return (
-    <>
-      {transformedTableData.map((row) => {
-        return <span> {row.gcloudProject} </span>;
-      })}
-    </>
-  );
+  const renderTable = (data: IPendingReqsTableData[]) => {
+    return (
+      <GridContainer>
+        {renderTableHeader()}
+        {renderTableBody(data)}
+      </GridContainer>
+    );
+  };
+
+  const renderTableHeader = () => {
+    return (
+      <GridRow header={true}>
+        {PENDING_REQS_TABLE_HEADERS.map((header, i) => {
+          return <strong key={i}>{header.label}</strong>;
+        })}
+      </GridRow>
+    );
+  };
+
+  const renderTableBody = (data: IPendingReqsTableData[]) => {
+    return <div>{data.map((req: IPendingReqsTableData) => renderRow(req))}</div>;
+  };
+
+  const renderRow = (req: IPendingReqsTableData) => {
+    const { requestedResources, requestTime, gcloudProject, instanceName, region } = req;
+    return requestedResources.map((resource, i) => {
+      const { namespace, cpuLimit, memoryLimit } = resource;
+      const isFirst = i === 0;
+      const isLast = requestedResources.length === i + 1;
+      return (
+        <GridRow border={isLast} key={i}>
+          <GridCell>{isFirst ? requestTime : ''}</GridCell>
+          <GridCell>{isFirst ? gcloudProject : ''}</GridCell>
+          <GridCell>{isFirst ? instanceName : ''}</GridCell>
+          <GridCell>{isFirst ? region : ''}</GridCell>
+          <GridCell border={!isLast}>{namespace}</GridCell>
+          <GridCell border={!isLast}>{addPercentSign(cpuLimit)}</GridCell>
+          <GridCell border={!isLast}>{addPercentSign(memoryLimit)}</GridCell>
+        </GridRow>
+      );
+    });
+  };
+
+  return <>{renderTable(transformedTableData)}</>;
 };
 
 export default PendingRequestsTable;

--- a/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/PendingRequests/PendingRequestsTable.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/PendingRequests/PendingRequestsTable.tsx
@@ -15,12 +15,26 @@
  */
 
 import React from 'react';
+import { IConnection } from '../types';
 
-const PendingRequestsTable = () => {
+interface IPendingReqsTableProps {
+  tableData: IConnection[];
+}
+
+const PendingRequestsTable = ({ tableData }: IPendingReqsTableProps) => {
+  const transformedTableData = tableData.map((req) => ({
+    requestTime: '00:00:00',
+    gcloudProject: req.metadata.metadata.project,
+    instanceName: req.name,
+    region: req.metadata.metadata.location,
+    requestedResources: req.metadata.namespaceAllocations,
+  }));
+
   return (
     <>
-      {/* TODO: Add table here*/}
-      <span> Table Goes Here </span>
+      {transformedTableData.map((row) => {
+        return <span> {row.gcloudProject} </span>;
+      })}
     </>
   );
 };

--- a/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/PendingRequests/index.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/PendingRequests/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Cask Data, Inc.
+ * Copyright © 2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/PendingRequests/index.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/PendingRequests/index.tsx
@@ -25,10 +25,6 @@ import { IConnection } from '../types';
 const PREFIX = 'features.Administration.Tethering';
 const I18NPREFIX = `${PREFIX}.PendingRequests`;
 
-const PendingRequestsHeader = styled(HeaderContainer)`
-  background-color: ${(props) => props.theme.palette.grey[700]};
-`;
-
 const PendingRequestHistory = styled(Link)`
   margin-left: 40px;
   font-size: 1rem;
@@ -41,12 +37,12 @@ interface IPendingRequestsProps {
 const PendingRequests = ({ pendingRequests }: IPendingRequestsProps) => {
   return (
     <>
-      <PendingRequestsHeader>
+      <HeaderContainer>
         <HeaderTitle>{T.translate(`${I18NPREFIX}.pendingRequestHeader`)}</HeaderTitle>
         <PendingRequestHistory to="/administration/tethering/newRequest">
           {T.translate(`${I18NPREFIX}.pendingRequestHistory`)}
         </PendingRequestHistory>
-      </PendingRequestsHeader>
+      </HeaderContainer>
       <BodyContainer>
         {pendingRequests.length > 0 ? (
           <PendingRequestsTable tableData={pendingRequests} />

--- a/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/PendingRequests/index.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/PendingRequests/index.tsx
@@ -20,6 +20,7 @@ import styled from 'styled-components';
 import T from 'i18n-react';
 import PendingRequestsTable from './PendingRequestsTable';
 import { HeaderContainer, HeaderTitle, BodyContainer, NoDataText } from '../../shared.styles';
+import { IConnection } from '../types';
 
 const PREFIX = 'features.Administration.Tethering';
 const I18NPREFIX = `${PREFIX}.PendingRequests`;
@@ -33,9 +34,11 @@ const PendingRequestHistory = styled(Link)`
   font-size: 1rem;
 `;
 
-const PendingRequests = () => {
-  const [pendingRequests, setPendingRequests] = useState([]);
+interface IPendingRequestsProps {
+  pendingRequests: IConnection[];
+}
 
+const PendingRequests = ({ pendingRequests }: IPendingRequestsProps) => {
   return (
     <>
       <PendingRequestsHeader>
@@ -46,7 +49,7 @@ const PendingRequests = () => {
       </PendingRequestsHeader>
       <BodyContainer>
         {pendingRequests.length > 0 ? (
-          <PendingRequestsTable />
+          <PendingRequestsTable tableData={pendingRequests} />
         ) : (
           <NoDataText>{T.translate(`${I18NPREFIX}.noPendingRequests`)}</NoDataText>
         )}

--- a/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/index.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/index.tsx
@@ -28,15 +28,15 @@ const PENDING_STATUS = 'PENDING';
 
 const NewRequestBtn = styled(Button)`
   margin: 0 0 20px 30px;
-  background-color: ${(props) => props.theme.palette.white[50]};
-  color: ${(props) => props.theme.palette.primary.main};
+  background-color: var(--white01);
+  color: var(--primary);
   height: 30px;
   width: 190px;
   font-size: 1rem;
 
   &:hover {
-    background-color: ${(props) => props.theme.palette.primary.main};
-    color: ${(props) => props.theme.palette.white[50]};
+    background-color: var(--primary);
+    color: var(--white01);
   }
 `;
 

--- a/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/index.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Cask Data, Inc.
+ * Copyright © 2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -54,7 +54,7 @@ const OdfTetheringConnections = (): JSX.Element => {
       const establishedConnections = [];
       const pendingConnections = [];
 
-      list.map((conn: IConnection) =>
+      list.forEach((conn: IConnection) =>
         conn.tetheringStatus === PENDING_STATUS
           ? pendingConnections.push(conn)
           : establishedConnections.push(conn)
@@ -63,6 +63,7 @@ const OdfTetheringConnections = (): JSX.Element => {
       setConnections(establishedConnections);
       setPendingRequests(pendingConnections);
     } catch (e) {
+      // TODO: Add proper error messaging here
       setConnections([]);
       setPendingRequests([]);
     }

--- a/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/index.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/index.tsx
@@ -49,17 +49,6 @@ const OdfTetheringConnections = (): JSX.Element => {
   const [pendingRequests, setPendingRequests] = useState([]);
 
   const fetchConnectionsList = async () => {
-    // const connectionInfo = {
-    //   peer: 'cdfTest',
-    //   endpoint: 'http://www.google.com',
-    //   namespaceAllocations: [{ namespace: 's1', cpuLimit: '60', memoryLimit: '80' }],
-    //   metadata: {
-    //     project: 'gcs1',
-    //     location: 'us-west-1b',
-    //   },
-    // };
-    // const create = await TetheringApi.createTethering({}, connectionInfo).toPromise();
-
     try {
       const list = await TetheringApi.getTetheringStatusForAll().toPromise();
       const establishedConnections = [];

--- a/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/types.ts
+++ b/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Cask Data, Inc.
+ * Copyright © 2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/types.ts
+++ b/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/types.ts
@@ -36,7 +36,7 @@ export interface IConnection {
 export interface ITableData {
   requestTime: string;
   gcloudProject: string;
-  instanceName: IMetadata;
+  instanceName: string;
   region: string;
 }
 

--- a/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/types.ts
+++ b/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/types.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+export interface INamespaceAllocations {
+  namespace: string;
+  cpuLimit: string;
+  memoryLimit: string;
+}
+
+export interface IMetadata {
+  metadata: { project: string; location: string };
+  namespaceAllocations: INamespaceAllocations[];
+}
+
+export interface IConnection {
+  connectionStatus: string;
+  endpoint: string;
+  metadata: IMetadata;
+  name: string;
+  tetheringStatus: string;
+}
+
+export interface ITableData {
+  requestTime: string;
+  gcloudProject: string;
+  instanceName: IMetadata;
+  region: string;
+}
+
+export interface IAllocationData extends INamespaceAllocations {
+  pods: number;
+}
+
+export interface IPendingReqsTableData extends ITableData {
+  requestedResources: INamespaceAllocations[];
+}
+
+export interface IConnectionsTableData extends ITableData {
+  status: string;
+  allocationData: IAllocationData[];
+}

--- a/app/cdap/components/Administration/TetheringTabContent/index.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Cask Data, Inc.
+ * Copyright © 2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/app/cdap/components/Administration/TetheringTabContent/index.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/index.tsx
@@ -21,7 +21,6 @@ import styled from 'styled-components';
 import { Theme } from 'services/ThemeHelper';
 import OdfTetheringConnections from './OdfTetheringConnections';
 import CdfTetheringConnections from './CdfTetheringConnections';
-import If from 'components/shared/If';
 
 const PREFIX = 'features.Administration';
 const I18NPREFIX = `${PREFIX}.Tethering`;

--- a/app/cdap/components/Administration/TetheringTabContent/shared.styles.ts
+++ b/app/cdap/components/Administration/TetheringTabContent/shared.styles.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Cask Data, Inc.
+ * Copyright © 2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/app/cdap/components/Administration/TetheringTabContent/shared.styles.ts
+++ b/app/cdap/components/Administration/TetheringTabContent/shared.styles.ts
@@ -21,6 +21,7 @@ export const HeaderContainer = styled.div`
   align-items: center;
   width: 100%;
   height: 60px;
+  background-color: var(--grey08);
 `;
 
 export const HeaderTitle = styled.h5`

--- a/app/cdap/services/DataFormatter/index.ts
+++ b/app/cdap/services/DataFormatter/index.ts
@@ -110,3 +110,7 @@ export function format(value, type, options: { concise?: boolean } = {}) {
       return value.toString ? value.toString() : JSON.stringify(value);
   }
 }
+
+export function formatAsPercentage(str: string) {
+  return `${str}%`;
+}

--- a/app/cdap/services/helpers.js
+++ b/app/cdap/services/helpers.js
@@ -117,12 +117,12 @@ function truncateNumber(num, precision = 0) {
 
 // FIXME: humanReadableDate(date, options = {isMilliseconds: false, shortForm: false}) would have been\
 // more readable api. We should think about changing the function signature.
-function humanReadableDate(date, isMilliseconds, shortForm = false) {
+function humanReadableDate(date, isMilliseconds, shortForm = false, customFormat = '') {
   if (!date) {
     return '--';
   }
 
-  const format = shortForm ? 'MM-DD-YYYY' : 'MM-DD-YYYY hh:mm:ss A';
+  const format = customFormat ? customFormat : (shortForm ? 'MM-DD-YYYY' : 'MM-DD-YYYY hh:mm:ss A');
   if (isMilliseconds) {
     return moment(date).format(format);
   }

--- a/app/cdap/services/helpers.js
+++ b/app/cdap/services/helpers.js
@@ -737,6 +737,10 @@ function santizeStringForHTMLID(str) {
   return str.replace(/[ \/]/g, '-');
 }
 
+function addPercentSign(str) {
+  return `${str}%`;
+};
+
 const PIPELINE_ARTIFACTS = [
   'cdap-data-pipeline',
   'cdap-data-streams',
@@ -795,5 +799,6 @@ export {
   isAuthSetToProxyMode,
   isAuthSetToManagedMode,
   santizeStringForHTMLID,
+  addPercentSign,
   PIPELINE_ARTIFACTS,
 };

--- a/app/cdap/services/helpers.js
+++ b/app/cdap/services/helpers.js
@@ -737,10 +737,6 @@ function santizeStringForHTMLID(str) {
   return str.replace(/[ \/]/g, '-');
 }
 
-function addPercentSign(str) {
-  return `${str}%`;
-};
-
 const PIPELINE_ARTIFACTS = [
   'cdap-data-pipeline',
   'cdap-data-streams',
@@ -799,6 +795,5 @@ export {
   isAuthSetToProxyMode,
   isAuthSetToManagedMode,
   santizeStringForHTMLID,
-  addPercentSign,
   PIPELINE_ARTIFACTS,
 };

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -191,7 +191,16 @@ features:
       NewRequests:
         newRequestsHeader: New requests
         noNewRequests: There are no new requests
-      createRequest: CREATE NEW REQUEST  
+      createRequest: CREATE NEW REQUEST 
+      ColumnHeaders:
+         requestTime: Request Time
+         gcp: Google cloud project
+         instanceName: Instance name
+         region: Region
+         omniNamespace: Omni namespace
+         cpu: CPU
+         memory: Memory
+         pods: Pods
       pageTitle: '{productName} | Administration | Tethering Connections'
     Services:
       title: Services

--- a/server/config/themes/default.json
+++ b/server/config/themes/default.json
@@ -52,7 +52,7 @@
     "reload-system-artifacts": true,
     "cdc": true,
     "allow-force-dynamic-execution": false,
-    "tethering": true,
-    "odf": true
+    "tethering": false,
+    "odf": false
   }
 }

--- a/server/config/themes/default.json
+++ b/server/config/themes/default.json
@@ -52,7 +52,7 @@
     "reload-system-artifacts": true,
     "cdc": true,
     "allow-force-dynamic-execution": false,
-    "tethering": false,
-    "odf": false
+    "tethering": true,
+    "odf": true
   }
 }


### PR DESCRIPTION
# ODF API

## Description
This PR adds API calls logic to odf components as well as new UI components to display pending requests (see screenshot). The only remaining part of the pending requests table is the popover which I need some clarifications from the backend team. Will add that in a separate PR as this PR has gotten big enough. Next step is to finish `create request` functionality. 

Design docs can be found [here](https://docs.google.com/document/d/1JgYSNLUZArlJ84BF8-Wiampwqde12MBTLqEjDm2pEhE/edit)

## PR Type
- [ ] Bug Fix
- [X] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement

## Links
Jira: [Jira issue #](fill-in.org)

## Test Plan
At this point, it's difficult to test as there is no way to create new requests through the UI, after that functionality is added, then testing connection requests becomes feasible. 

## Screenshots
<img width="1442" alt="Screen Shot 2022-01-05 at 3 51 26 PM" src="https://user-images.githubusercontent.com/94018249/148306142-2ddb7b61-02bb-4739-8781-ccec254e8f66.png">

