### PR TITLE
[CDAP-18065] Handle schemas with nested records of the same name

### DIFF
--- a/app/cdap/components/AbstractWidget/SchemaEditor/Context/SchemaGenerator.ts
+++ b/app/cdap/components/AbstractWidget/SchemaEditor/Context/SchemaGenerator.ts
@@ -121,13 +121,13 @@ function generateEnumType(children: IOrderedChildren, currentNode: INode, nullab
 }
 
 function generateRecordType(children: IOrderedChildren, currentNode: INode, nullable: boolean) {
+  const { typeProperties = {} } = currentNode;
   const finalType: IRecordField = {
     type: AvroSchemaTypesEnum.RECORD,
-    name: currentNode.name || `name_${uuidV4()}`,
+    name: typeProperties.typeName || currentNode.name || `name_${uuidV4()}`,
     fields: [],
   };
   finalType.name = finalType.name.replace(/-/g, '');
-  const { typeProperties = {} } = currentNode;
   if (typeProperties.doc) {
     finalType.doc = typeProperties.doc;
   }

--- a/app/cdap/components/AbstractWidget/SchemaEditor/Context/__tests__/SchemaManager.tests.ts
+++ b/app/cdap/components/AbstractWidget/SchemaEditor/Context/__tests__/SchemaManager.tests.ts
@@ -31,8 +31,10 @@ import {
   simpleSchema2,
   largeSchema,
   largeSchema2,
+  schemaWithNestedRecordName,
 } from './schemas';
 import { ISchemaType } from 'components/AbstractWidget/SchemaEditor/SchemaTypes';
+import cdapavsc from 'services/cdapavscwrapper';
 
 const childCountInTree = (tree) => {
   if (!tree || (tree && !tree.children)) {
@@ -205,6 +207,13 @@ describe('Unit tests for Schema Manager', () => {
       const { fieldId } = getNthFieldIdInFlatSchema(schema, 1);
       schema.onChange(fieldId, { type: OperationTypesEnum.REMOVE });
       expect(childCountInTree(schema.getSchemaTree())).toBe(3);
+    });
+
+    it('should parse a record whith a child record of the same name', () => {
+      const schema = SchemaManager(schemaWithNestedRecordName as ISchemaType).getInstance();
+      expect(() =>
+        cdapavsc.parse(schema.getAvroSchema().schema, { wrapUnions: true })
+      ).not.toThrow();
     });
   });
 

--- a/app/cdap/components/AbstractWidget/SchemaEditor/Context/__tests__/schemas.js
+++ b/app/cdap/components/AbstractWidget/SchemaEditor/Context/__tests__/schemas.js
@@ -63,6 +63,34 @@ const schemaWithMap = {
   },
 };
 
+const schemaWithNestedRecordName = {
+  name: 'etlSchemaBody',
+  schema: {
+    name: 'etlSchemaBody',
+    type: 'record',
+    fields: [
+      {
+        name: 'Record1',
+        type: {
+          type: 'record',
+          name: 'Record1',
+          fields: [{
+            name: 'Record1',
+            type: {
+              type: 'record',
+              name: 'Record1.Record1',
+              fields: [{
+                name: 'stringfield',
+                type: 'string'
+              }]
+            }
+          }]
+        }
+      }
+    ]
+  }
+}
+
 export {
   schemaWithMap,
   schemaWithName,
@@ -71,4 +99,5 @@ export {
   simpleSchema2,
   largeSchema,
   largeSchema2,
+  schemaWithNestedRecordName,
 };


### PR DESCRIPTION
# [CDAP-18065] Handle schemas with nested records of the same name

## Description
Parse schemas with nested records of the same name without errors

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement

## Links
Jira: https://cdap.atlassian.net/browse/CDAP-18065

## Test Plan
Added unit test

## Screenshots
N/A




[CDAP-18065]: https://cdap.atlassian.net/browse/CDAP-18065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ