### PR TITLE
Edit connection modal: Removes breadcrumb & adds connector/connection…

### DIFF
--- a/app/cdap/components/Connections/Create/index.tsx
+++ b/app/cdap/components/Connections/Create/index.tsx
@@ -15,6 +15,7 @@
  */
 
 import * as React from 'react';
+import T from 'i18n-react';
 import { CategorizedConnectors } from 'components/Connections/Create/CategorizedConnectors';
 import makeStyle from '@material-ui/core/styles/makeStyles';
 import { EntityTopPanel } from 'components/EntityTopPanel';
@@ -41,6 +42,8 @@ import { extractErrorMessage, objectQuery } from 'services/helpers';
 import Alert from 'components/shared/Alert';
 import { ConnectionsContext, IConnectionMode } from 'components/Connections/ConnectionsContext';
 import { constructErrors } from 'components/shared/ConfigurationGroup/utilities';
+
+const PREFIX = 'features.DataPrepConnections.ConnectionManagement';
 
 const useStyle = makeStyle(() => {
   return {
@@ -231,7 +234,13 @@ export function CreateConnection({
 
     onToggle();
   }
-
+  const editPanelTitle = T.translate(`${PREFIX}.editConnection`, {
+    connector: state?.selectedConnector?.name,
+    connectionName: objectQuery(initValues, 'initName'),
+  });
+  const createPanelTitle = T.translate(`${PREFIX}.createConnection`, {
+    connector: state?.selectedConnector?.name,
+  });
   return (
     <div className={classes.root}>
       {state.activeStep === ICreateConnectionSteps.CONNECTOR_CONFIG && (
@@ -239,9 +248,10 @@ export function CreateConnection({
           historyBack={false}
           breadCrumbAnchorLabel="Select Connection"
           onBreadCrumbClick={() => navigateToConnectionCategoryStep(dispatch)}
-          title={`Create a ${state?.selectedConnector?.name} connection`}
+          title={`${isEdit ? editPanelTitle : createPanelTitle}`}
           closeBtnAnchorLink={onClose}
           className={classes.topPanel}
+          showBreadcrumb={!isEdit}
         />
       )}
       {state.activeStep === ICreateConnectionSteps.CONNECTOR_SELECTION && (

--- a/app/cdap/components/EntityTopPanel/index.tsx
+++ b/app/cdap/components/EntityTopPanel/index.tsx
@@ -33,6 +33,7 @@ interface IEntityTopPanelProps {
   historyBack?: boolean;
   inheritBackground?: boolean;
   className?: string;
+  showBreadcrumb?: boolean;
 }
 
 const useStyle = makeStyle<Theme>((theme) => {
@@ -65,6 +66,7 @@ export function EntityTopPanel({
   historyBack,
   inheritBackground,
   className,
+  showBreadcrumb = true,
 }: IEntityTopPanelProps) {
   const multilineTitle = typeof entityIcon === 'string' && typeof entityType === 'string';
   const classes = useStyle({ multiline: multilineTitle });
@@ -77,12 +79,14 @@ export function EntityTopPanel({
       })}
     >
       <div className={classes.titleContainer}>
-        <EntityBreadCrumb
-          breadCrumbAnchorLabel={breadCrumbAnchorLabel}
-          breadCrumbAnchorLink={breadCrumbAnchorLink}
-          historyBack={historyBack}
-          onBreadCrumbClick={onBreadCrumbClick}
-        />
+        {showBreadcrumb && (
+          <EntityBreadCrumb
+            breadCrumbAnchorLabel={breadCrumbAnchorLabel}
+            breadCrumbAnchorLink={breadCrumbAnchorLink}
+            historyBack={historyBack}
+            onBreadCrumbClick={onBreadCrumbClick}
+          />
+        )}
         <EntityTitle title={title} entityIcon={entityIcon} entityType={entityType} />
       </div>
       <EntityCloseBtn closeBtnAnchorLink={closeBtnAnchorLink} />

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -1444,6 +1444,8 @@ features:
       delete: Delete
       duplicate: Duplicate
       edit: Edit
+      editConnection: 'Edit {connector} connection - "{connectionName}"'
+      createConnection: "Create a {connector} connection"
     database: Database ({count})
     gcs: Google Cloud Storage ({count})
     hdfs: File System


### PR DESCRIPTION
Edit connection modal: Removes breadcrumb & adds connector/connection…

## Description
1. The title should be changed to reflect the edit operation (connector & connection name)
2. Remove breadcrumb as the modal can be accessed from multiple places.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement

## Links
Jira: [18724](https://cdap.atlassian.net/browse/CDAP-18724)

## Test Plan

## Screenshots
![image](https://user-images.githubusercontent.com/81957712/148563925-c6169bbe-8ae3-44cf-be5c-5e31f24fbf29.png)


