### PR TITLE
update node gyp to use 7.1.2 for build error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,7 @@
                   <goal>yarn</goal>
                 </goals>
                 <configuration>
-                  <arguments>global add node-gyp</arguments>
+                  <arguments>global add node-gyp@7.1.2</arguments>
                 </configuration>
               </execution>
               <execution>


### PR DESCRIPTION
# use node gyp 7.1.2

## Description
update pom to use node gyp 7.1.2

## PR Type
- [x] Bug Fix
- [ ] Feature
- [x] Build Fix
- [ ] Testing
- [ ] General Improvement



