### PR TITLE
Restore default values while toggling connection field in BQ pushdown…

### DIFF
--- a/app/cdap/components/shared/ConfigurationGroup/index.tsx
+++ b/app/cdap/components/shared/ConfigurationGroup/index.tsx
@@ -77,6 +77,7 @@ const ConfigurationGroupView: React.FC<IConfigurationGroupProps> = ({
   validateProperties,
 }) => {
   const [configurationGroups, setConfigurationGroups] = useState([]);
+  const [defaultValues, setDefaultValues] = useState({ ...values });
   const referenceValueForUnMount = useRef<{
     configurationGroups?: IFilteredConfigurationGroup[];
     values?: Record<string, string>;
@@ -110,6 +111,7 @@ const ConfigurationGroupView: React.FC<IConfigurationGroupProps> = ({
       initialValues = defaults(values, processedConfigurationGroup.defaultValues);
       changeParentHandler(initialValues);
     }
+    setDefaultValues(initialValues);
     updateFilteredConfigurationGroup(
       processedConfigurationGroup.configurationGroups,
       initialValues
@@ -139,7 +141,7 @@ const ConfigurationGroupView: React.FC<IConfigurationGroupProps> = ({
     const updatedFilteredValues = removeFilteredProperties(
       newValues,
       newFilteredConfigurationGroup,
-      true
+      defaultValues
     );
     setPropertyValues(updatedFilteredValues);
     setFilteredConfigurationGroups(newFilteredConfigurationGroup);
@@ -160,7 +162,7 @@ const ConfigurationGroupView: React.FC<IConfigurationGroupProps> = ({
       fcg = filterByCondition(configurationGroups, widgetJson, pluginProperties, changedValues);
     }
 
-    const updatedFilteredValues = removeFilteredProperties(changedValues, fcg, true);
+    const updatedFilteredValues = removeFilteredProperties(changedValues, fcg, defaultValues);
     changeParentHandler(updatedFilteredValues);
   }
 

--- a/app/cdap/components/shared/ConfigurationGroup/utilities/__tests__/utilities.test.ts
+++ b/app/cdap/components/shared/ConfigurationGroup/utilities/__tests__/utilities.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { removeFilteredProperties } from 'components/shared/ConfigurationGroup/utilities';
+
+describe('Unit tests for Utilities', () => {
+  describe('removeFilteredProperties should', () => {
+    it('Return processed values', () => {
+      const values = {
+        project: 'test',
+        tempTableTTLHours: '72',
+      };
+      const filteredConfigurationGroups = [
+        {
+          label: 'basic',
+          properties: [
+            {
+              name: 'location',
+              show: true,
+            },
+            {
+              name: 'project',
+              show: true,
+            },
+          ],
+        },
+        {
+          label: 'advanced',
+          properties: [
+            {
+              name: 'tempTableTTLHours',
+              show: false,
+            },
+          ],
+        },
+      ];
+      const defaultValues = {
+        location: 'US-default',
+        project: 'test-default',
+        tempTableTTLHours: '72-default',
+      };
+      expect(
+        removeFilteredProperties(values, filteredConfigurationGroups, defaultValues)
+      ).toStrictEqual({
+        location: 'US-default',
+        project: 'test',
+      });
+    });
+  });
+});

--- a/app/cdap/components/shared/ConfigurationGroup/utilities/index.ts
+++ b/app/cdap/components/shared/ConfigurationGroup/utilities/index.ts
@@ -382,17 +382,18 @@ export function countErrors(
  *
  * @param values latest field values
  * @param filteredConfigurationGroups configuration-groups from Widget JSON
- * @param addDefaults add default values for visible fields that are empty
+ * @param defaultValues default field values
  */
-export function removeFilteredProperties(values, filteredConfigurationGroups, addDefaults = false) {
+export function removeFilteredProperties(values, filteredConfigurationGroups, defaultValues = {}) {
   const newValues = { ...values };
   if (filteredConfigurationGroups) {
     filteredConfigurationGroups.forEach((group) => {
       group.properties.forEach((property) => {
         if (property.show === false) {
           delete newValues[property.name];
-        } else if (addDefaults && !newValues[property.name]) {
-          newValues[property.name] = property.defaultValue;
+        } else if (defaultValues[property.name] && !newValues[property.name]) {
+          // Restore default values for visible fields that are empty
+          newValues[property.name] = defaultValues[property.name];
         }
       });
     });


### PR DESCRIPTION
Issue:
    While toggling connections field we restore default values which were fetched as part of filter configuration groups(FCG). But for deployed pipelines FCG doesn't hold any default values.

Fix:
     Passing default values explicitly instead of relying on filter configuration groups.

## Description
Restore default values while toggling connection field in BQ pushdown config modal.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement

## Links
Jira: [1026](https://cdap.atlassian.net/browse/PLUGIN-1026)

## Test Plan
Added unit tests

## Screenshots
issue:
![image](https://user-images.githubusercontent.com/81957712/148766266-bba67d4d-1c4a-4378-87a8-8f9d54261d31.png)

fix:
![image](https://user-images.githubusercontent.com/81957712/148766320-18fd74a9-a950-47fe-8795-1cd0d0ff9b9b.png)


