### PR TITLE
Fixes date formatting in API call history page

### DIFF
--- a/app/cdap/components/HttpExecutor/RequestHistoryTab/index.tsx
+++ b/app/cdap/components/HttpExecutor/RequestHistoryTab/index.tsx
@@ -23,6 +23,7 @@ import {
   getRequestsByDate,
 } from 'components/HttpExecutor/utilities';
 import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
+import moment from 'moment';
 
 import Button from '@material-ui/core/Button';
 import ClearAllDialog from 'components/HttpExecutor/RequestHistoryTab/RequestActionDialogs/ClearAllDialog';
@@ -171,7 +172,7 @@ const RequestHistoryTabView: React.FC<IRequestHistoryTabProps> = ({
             compareByTimestamp(a.timestamp, b.timestamp)
           )
           .forEach((req: IRequestHistory) => {
-            const timestamp = new Date(req.timestamp);
+            const timestamp = moment(req.timestamp, 'MM/DD/YYYY').toDate();
             const dateID: string = getDateID(timestamp);
             const requestsGroup = getRequestsByDate(newRequestLog, dateID);
             newRequestLog = newRequestLog.set(dateID, requestsGroup.push(req));


### PR DESCRIPTION
Api call history page is showing wrong date format.

## Description
Dates are stored in MM/DD/YYYY format but UI displays in DD/MM/YYYY format.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement

## Links
Jira: [18734](https://cdap.atlassian.net/browse/CDAP-18734)

## Screenshots
Issue:
![image](https://user-images.githubusercontent.com/81957712/149089873-ffad20d7-eb8b-4b43-b32f-896be9eb9783.png)


Fix:
![image](https://user-images.githubusercontent.com/81957712/149089779-8ffab9b2-70d1-4d32-8ab4-079c50c99bea.png)



