### PR TITLE
Update pom.xml to use older node-gyp version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,7 @@
                   <goal>yarn</goal>
                 </goals>
                 <configuration>
-                  <arguments>global add node-gyp@8.3.0</arguments>
+                  <arguments>global add node-gyp@7.1.2</arguments>
                 </configuration>
               </execution>
               <execution>


### PR DESCRIPTION
# Fix 6.6 build

## Description
update pom.xml to use older node-gyp

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [x] Build Fix
- [ ] Testing
- [ ] General Improvement



