### PR TITLE
Fix cypress test failures

### DIFF
--- a/cypress/integration/pipeline.joiner.spec.ts
+++ b/cypress/integration/pipeline.joiner.spec.ts
@@ -301,6 +301,7 @@ describe('Creating pipeline with joiner in pipeline studio', () => {
       }
     });
     // Start and then immediately stop preview
+    cy.get(dataCy('preview-config-btn')).trigger('click', { force: true });
     cy.get(dataCy('preview-top-run-btn')).click();
     cy.get(dataCy('stop-preview-btn')).click();
     cy.get(dataCy('preview-top-run-btn'), { timeout: 35000 }).should('exist');
@@ -319,6 +320,7 @@ describe('Creating pipeline with joiner in pipeline studio', () => {
       }
     });
     // Start and run preview
+    cy.get(dataCy('preview-config-btn')).trigger('click', { force: true });
     cy.get(dataCy('preview-top-run-btn')).click();
     cy.wait(2000);
     cy.get(dataCy('stop-preview-btn')).should('be.visible');
@@ -350,6 +352,7 @@ describe('Creating pipeline with joiner in pipeline studio', () => {
       }
     });
 
+    cy.get(dataCy('preview-config-btn')).trigger('click', { force: true });
     cy.get(dataCy(`plugin-node-Joiner-batchjoiner-2`)).within(() => {
       cy.get(dataCy(`${joinerNode.nodeName}-preview-data-btn`)).click();
     });


### PR DESCRIPTION
Fix cypress test failures

## Description
Since configure popup is hiding top panels's visibility, hiding it before clicking the top panel action buttons.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement

## Links
Jira: [1051](https://cdap.atlassian.net/browse/PLUGIN-1051)

## Screenshot
![image](https://user-images.githubusercontent.com/81957712/150160559-7cc09e7b-0d43-457d-8616-81f653b55031.png)




