### PR TITLE
Limit number of records user can set when running pipeline preview

### DIFF
--- a/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ConfigurationsContent.scss
+++ b/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ConfigurationsContent.scss
@@ -35,6 +35,16 @@ $secondary-btn-color: $brand-primary;
       width: auto;
     }
 
+    .num-preview-input-col {
+      display: flex;
+      flex-direction: column;
+
+      .num-preview-info {
+        padding: 3px 0 0 5px;
+        font-size: 11px;
+      }
+    }
+
     .configuration-content-container {
       /* 50px: height from bottom of buttons to horizontal line */
       height: calc(100% - 50px);
@@ -80,6 +90,10 @@ $secondary-btn-color: $brand-primary;
           width: 65px;
           display: inline-block;
         }
+      }
+
+      .num-records-preview {
+        align-items: baseline;
       }
 
       .key-value-pair-labels {

--- a/app/cdap/services/global-constants.js
+++ b/app/cdap/services/global-constants.js
@@ -304,6 +304,8 @@ const HYDRATOR_DEFAULT_VALUES = {
     memoryMB: 2048,
   },
   numOfRecordsPreview: 100,
+  minRecordsPreview: 1,
+  maxRecordsPreview: 5000,
   previewTimeoutInMin: 2,
   engine: 'spark',
   processTimingEnabled: true,

--- a/app/directives/my-pipeline-configurations/my-batch-pipeline-config/my-batch-pipeline-config-ctrl.js
+++ b/app/directives/my-pipeline-configurations/my-batch-pipeline-config/my-batch-pipeline-config-ctrl.js
@@ -25,6 +25,7 @@ class MyBatchPipelineConfigCtrl {
     this.instrumentation = this.store.getInstrumentation();
     this.stageLogging = this.store.getStageLogging();
     this.numRecordsPreview = this.store.getNumRecordsPreview();
+    const rangeRecordsPreview = this.store.getRangeRecordsPreview();
     this.startingPipeline = false;
     this.updatingPipeline = false;
     this.driverResources = {
@@ -38,7 +39,8 @@ class MyBatchPipelineConfigCtrl {
     this.enablePipelineUpdate = false;
     this.numberConfig = {
       'widget-attributes': {
-        min: 0,
+        min: rangeRecordsPreview.min,
+        max: rangeRecordsPreview.max,
         default: HYDRATOR_DEFAULT_VALUES.numOfRecordsPreview,
         showErrorMessage: false,
         convertToInteger: true

--- a/app/directives/my-pipeline-configurations/my-batch-pipeline-config/my-batch-pipeline-config.html
+++ b/app/directives/my-pipeline-configurations/my-batch-pipeline-config/my-batch-pipeline-config.html
@@ -99,14 +99,21 @@
         </div>
         <div class="label-with-toggle num-records-preview row">
           <span class="toggle-label col-xs-5">Number of records to preview</span>
-          <my-number-widget
-            class="num-records-input"
-            ng-model="BatchPipelineConfigCtrl.numRecordsPreview"
-            config="BatchPipelineConfigCtrl.numberConfig"
-          ></my-number-widget>
-          <i class="fa fa-info-circle"
-             uib-tooltip="The number of records to be read during the pipeline preview. For MapReduce, this translates to the number of records that are read by each map task."
-             tooltip-placement="right">
+          <div class="col-xs-7 num-preview-input-col">
+            <div class="toggle-container">
+                <my-number-widget
+                class="num-records-input"
+                ng-model="BatchPipelineConfigCtrl.numRecordsPreview"
+                config="BatchPipelineConfigCtrl.numberConfig"
+              ></my-number-widget>
+              <i class="fa fa-info-circle"
+                uib-tooltip="The number of records to be read during the pipeline preview. For MapReduce, this translates to the number of records that are read by each map task."
+                tooltip-placement="right"></i>
+            </div>
+            <span class="num-preview-info">
+              Max up to {{BatchPipelineConfigCtrl.numberConfig['widget-attributes'].max}} records
+            </span>
+          </div>
         </div>
       </div>
 

--- a/app/hydrator/services/create/stores/config-store.js
+++ b/app/hydrator/services/create/stores/config-store.js
@@ -109,6 +109,7 @@ class HydratorPlusPlusConfigStore {
       } else {
         this.setEngine(this.state.config.engine);
         this.setNumRecordsPreview(this.state.config.numOfRecordsPreview);
+        this.setRangeRecordsPreview(this.state.artifact.config || {});
         this.setMaxConcurrentRuns(this.state.config.maxConcurrentRuns);
       }
     }
@@ -270,6 +271,7 @@ class HydratorPlusPlusConfigStore {
       config.stageLoggingEnabled = this.getStageLogging();
       config.processTimingEnabled = this.getInstrumentation();
       config.numOfRecordsPreview = this.getNumRecordsPreview();
+      config.rangeRecordsPreview = this.getRangeRecordsPreview();
     } else if (appType === this.GLOBALS.etlRealtime) {
       config.instances = this.getInstance();
     } else if (appType === this.GLOBALS.etlDataStreams) {
@@ -566,9 +568,20 @@ class HydratorPlusPlusConfigStore {
   getNumRecordsPreview() {
     return this.getConfig().numOfRecordsPreview;
   }
-  setNumRecordsPreview(val=100) {
+  setNumRecordsPreview(val = this.HYDRATOR_DEFAULT_VALUES.numOfRecordsPreview) {
     if (this.GLOBALS.etlBatchPipelines.includes(this.state.artifact.name)) {
       this.state.config.numOfRecordsPreview = val;
+    }
+  }
+  getRangeRecordsPreview() {
+    return this.getConfig().rangeRecordsPreview;
+  }
+  setRangeRecordsPreview({minRecordsPreview = this.HYDRATOR_DEFAULT_VALUES.minRecordsPreview, maxRecordsPreview = this.HYDRATOR_DEFAULT_VALUES.maxRecordsPreview}) {
+    if (this.GLOBALS.etlBatchPipelines.includes(this.state.artifact.name)) {
+      this.state.config.rangeRecordsPreview = {
+        min: minRecordsPreview,
+        max: maxRecordsPreview,
+      };
     }
   }
   setArtifact(artifact) {


### PR DESCRIPTION
Limit number of records user can set when running pipeline preview - Cherry picking the feature changes into 6.6 branch.

## Description
Limit number of records user can set when running pipeline preview

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement

## Links
Jira: [18668](https://cdap.atlassian.net/browse/CDAP-18668)



