### PR TITLE
Adds total worker cores column in compute profile list

### DIFF
--- a/app/cdap/components/Cloud/Profiles/AutoScaleBadge/index.tsx
+++ b/app/cdap/components/Cloud/Profiles/AutoScaleBadge/index.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React from 'react';
+import T from 'i18n-react';
+import styled from 'styled-components';
+import Tooltip from '@material-ui/core/Tooltip';
+import withStyles from '@material-ui/core/styles/withStyles';
+
+const PREFIX = 'features.Cloud.Profiles';
+
+const Badge = styled.span`
+  color: #fff;
+  font-size: 0.85rem;
+  background: var(--brand-primary-color);
+  padding: 2px 6px;
+  display: inline-block;
+  border-radius: 20px;
+  margin-left: 6px;
+  cursor: pointer;
+`;
+
+const BadgeTooltip = withStyles(() => {
+  return {
+    tooltip: {
+      backgroundColor: '#999',
+      fontSize: '1rem',
+    },
+  };
+})(Tooltip);
+
+interface IProfile {
+  autoScalingPolicy: string;
+  enableCdfAutoScaling: boolean;
+}
+
+interface IAutoScaleBadgeProps {
+  profile: IProfile;
+}
+
+const AutoScaleBadge = ({ profile }: IAutoScaleBadgeProps) => {
+  const hasAutoScaling =
+    (profile.autoScalingPolicy && profile.autoScalingPolicy !== '') || profile.enableCdfAutoScaling;
+  if (!hasAutoScaling) {
+    return null;
+  }
+  return (
+    <BadgeTooltip title={T.translate(`${PREFIX}.common.autoScaleTooltip`)}>
+      <Badge>{T.translate(`${PREFIX}.common.autoScaleBadge`)}</Badge>
+    </BadgeTooltip>
+  );
+};
+
+export default AutoScaleBadge;

--- a/app/cdap/components/Cloud/Profiles/DetailView/Content/BasicInfo/index.js
+++ b/app/cdap/components/Cloud/Profiles/DetailView/Content/BasicInfo/index.js
@@ -31,6 +31,7 @@ import {
   deleteProfile,
 } from 'components/Cloud/Profiles/Store/ActionCreator';
 import ProfileStatusToggle from 'components/Cloud/Profiles/DetailView/Content/BasicInfo/ProfileStatusToggle';
+import AutoScaleBadge from 'components/Cloud/Profiles/AutoScaleBadge';
 import { CLOUD, SYSTEM_NAMESPACE } from 'services/global-constants';
 import { humanReadableDate } from 'services/helpers';
 import CopyableId from 'components/CopyableID';
@@ -150,6 +151,7 @@ export default class ProfileDetailViewBasicInfo extends Component {
           <div className="grid-header">
             <div className="grid-row">
               <strong>{T.translate(`${PREFIX}.common.provisioner`)}</strong>
+              <strong>{T.translate(`${PREFIX}.common.totalWorkerCores`)}</strong>
               <strong>{T.translate('commons.scope')}</strong>
               <strong>{T.translate(`${PREFIX}.common.last24HrRuns`)}</strong>
               <strong>{T.translate(`${PREFIX}.common.totalRuns`)}</strong>
@@ -163,6 +165,10 @@ export default class ProfileDetailViewBasicInfo extends Component {
               <div>
                 <IconSVG name="icon-cloud" />
                 <span>{this.state.provisionerLabel}</span>
+              </div>
+              <div>
+                {profile.totalWorkerCores || '--'}
+                <AutoScaleBadge profile={profile} />
               </div>
               <div>{profile.scope}</div>
               <div>{this.state.oneDayMetrics.runs}</div>

--- a/app/cdap/components/Cloud/Profiles/ListView/ListView.scss
+++ b/app/cdap/components/Cloud/Profiles/ListView/ListView.scss
@@ -26,7 +26,7 @@ $disabled-color: $red-02;
   .grid.grid-container {
     max-height: none;
     .grid-row {
-      grid-template-columns: 70px 1.5fr 1.5fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 30px;
+      grid-template-columns: 70px 1.5fr 1.5fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 30px;
 
       .sortable-header {
         cursor: pointer;

--- a/app/cdap/components/Cloud/Profiles/ListView/index.js
+++ b/app/cdap/components/Cloud/Profiles/ListView/index.js
@@ -25,6 +25,7 @@ import LoadingSVG from 'components/shared/LoadingSVG';
 import orderBy from 'lodash/orderBy';
 import ViewAllLabel from 'components/shared/ViewAllLabel';
 import ConfirmationModal from 'components/shared/ConfirmationModal';
+import AutoScaleBadge from 'components/Cloud/Profiles/AutoScaleBadge';
 import ProfilesStore, { PROFILE_STATUSES } from 'components/Cloud/Profiles/Store';
 import {
   getProfiles,
@@ -61,6 +62,10 @@ const PROFILES_TABLE_HEADERS = [
   {
     property: (profile) => profile.provisioner.label,
     label: T.translate(`${PREFIX}.common.provisioner`),
+  },
+  {
+    property: 'totalWorkerCores',
+    label: T.translate(`${PREFIX}.common.totalWorkerCores`),
   },
   {
     property: 'scope',
@@ -357,6 +362,10 @@ class ProfilesListView extends Component {
           {profile.label || profile.name}
         </div>
         <div>{profile.provisioner.label}</div>
+        <div>
+          {profile.totalWorkerCores || '--'}
+          <AutoScaleBadge profile={profile} />
+        </div>
         <div>{profile.scope}</div>
         {/*
           We should set the defaults in the metrics call but since it is not certain that we get metrics

--- a/app/cdap/components/PipelineConfigurations/PipelineConfigurations.scss
+++ b/app/cdap/components/PipelineConfigurations/PipelineConfigurations.scss
@@ -16,7 +16,7 @@
 
 @import "../../styles/variables.scss";
 
-$modeless-width: 830px;
+$modeless-width: 980px;
 $modeless-height: 450px;
 $top-panel-height: 54px;
 $right-position: -360px;

--- a/app/cdap/components/PipelineConfigurations/index.js
+++ b/app/cdap/components/PipelineConfigurations/index.js
@@ -44,7 +44,7 @@ const TABS = {
     id: 1,
     name: T.translate(`${PREFIX}.ComputeConfig.title`),
     content: <ComputeTabContent />,
-    contentClassName: 'pipeline-configurations-body',
+    contentClassName: 'pipeline-configurations-body compute-profile-tab',
     paneClassName: 'configuration-content',
   },
   pipelineConfig: {

--- a/app/cdap/components/PipelineDetails/PipelineModeless/PipelineModeless.scss
+++ b/app/cdap/components/PipelineDetails/PipelineModeless/PipelineModeless.scss
@@ -16,7 +16,7 @@
 
 @import '../../../styles/variables.scss';
 
-$modeless-width: 730px;
+$modeless-width: 880px;
 $sidepanel-width: 170px;
 $modeless-header-height: 60px;
 $header-close-icon-size: 16px;
@@ -148,6 +148,13 @@ $header-close-icon-size: 16px;
               font-size: 14px;
               position: relative;
               text-align: left;
+            }
+          }
+          &.tab-content {
+            &.compute-profile-tab {
+              .tab-pane {
+                margin: 10px;
+              }
             }
           }
         }

--- a/app/cdap/components/PipelineDetails/ProfilesListView/ProfilesListViewInPipeline.scss
+++ b/app/cdap/components/PipelineDetails/ProfilesListView/ProfilesListViewInPipeline.scss
@@ -49,8 +49,9 @@ $enabled-color: $green-02;
     max-height: calc(100% - 50px); // 100% - 17px (title) - 30px (profile count)
 
     .grid-row {
-      grid-template-columns: 30px 1.5fr 1.5fr 1fr 70px 1fr 50px;
-      align-items: start;
+      grid-template-columns: 30px 1.3fr 1fr 1.3fr 0.8fr 70px 1fr 50px;
+      align-items: center;
+      white-space: nowrap;
 
       &.enabled {
         .profile-status {

--- a/app/cdap/components/PipelineDetails/ProfilesListView/index.js
+++ b/app/cdap/components/PipelineDetails/ProfilesListView/index.js
@@ -25,6 +25,7 @@ import { MyPreferenceApi } from 'api/preference';
 import { Observable } from 'rxjs/Observable';
 import PipelineDetailStore from 'components/PipelineDetails/store';
 import ProfileCustomizePopover from 'components/PipelineDetails/ProfilesListView/ProfileCustomizePopover';
+import AutoScaleBadge from 'components/Cloud/Profiles/AutoScaleBadge';
 import { isNilOrEmpty } from 'services/helpers';
 import isEqual from 'lodash/isEqual';
 import { getCustomizationMap } from 'components/PipelineConfigurations/Store/ActionCreator';
@@ -174,6 +175,7 @@ export default class ProfilesListViewInPipeline extends Component {
           <div />
           <strong>{T.translate('features.Cloud.Profiles.ListView.profileName')}</strong>
           <strong>{T.translate('features.Cloud.Profiles.common.provisioner')}</strong>
+          <strong>{T.translate('features.Cloud.Profiles.common.totalWorkerCores')}</strong>
           <strong>{T.translate('commons.scope')}</strong>
           <strong>{T.translate('commons.status')}</strong>
           <strong />
@@ -243,6 +245,10 @@ export default class ProfilesListViewInPipeline extends Component {
           {profileLabel}
         </div>
         <div onClick={onProfileSelectHandler}>{provisionerLabel}</div>
+        <div onClick={onProfileSelectHandler}>
+          {profile.totalWorkerCores || '--'}
+          <AutoScaleBadge profile={profile} />
+        </div>
         <div onClick={onProfileSelectHandler}>{profile.scope}</div>
         <div className="profile-status" onClick={onProfileSelectHandler}>
           {T.translate(`features.Cloud.Profiles.common.${profileStatus}`)}

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -306,6 +306,9 @@ features:
         provisioner: Provisioner
         totalNodeHr: Total node hours
         totalRuns: Total runs
+        totalWorkerCores: Total worker cores
+        autoScaleBadge: Auto
+        autoScaleTooltip: AutoScaling of worker nodes is enabled.
       CreateView:
         ProvisionerSelection:
           pageTitle: '{productName} | Profiles | Create'


### PR DESCRIPTION
Auto-Scaling as an Alternative Compute Profile

[Design doc](go/cdf-dataproc-autoscaling-profile)

## Description
Adds "total worker cores" column in compute profile list pages.

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement

## Links
Jira: [18753](https://cdap.atlassian.net/browse/CDAP-18753)

## Screenshots
![image](https://user-images.githubusercontent.com/81957712/150785780-d1d9adfc-4853-4639-968e-2ed7bc9c4a57.png)


