### PR TITLE
Revert: Restore default values while toggling connection field

### DIFF
--- a/app/cdap/components/shared/ConfigurationGroup/PropertyRow/index.tsx
+++ b/app/cdap/components/shared/ConfigurationGroup/PropertyRow/index.tsx
@@ -27,8 +27,6 @@ import { isEmpty, isEqual, xorWith } from 'lodash';
 import { IErrorObj } from 'components/shared/ConfigurationGroup/utilities';
 import { isConnection } from 'components/AbstractWidget/ConnectionsWidget';
 
-const PropertiesWithFilterGroupUpdate = ['useConnection'];
-
 const styles = (theme): StyleRules => {
   return {
     root: {
@@ -141,13 +139,7 @@ class PropertyRowView extends React.Component<IPropertyRowProps, IState> {
       ...this.props.extraConfig.properties,
       [this.props.widgetProperty.name]: value,
     };
-    // Update filter group while toggling connection.
-    const params = {
-      updateFilteredConfigurationGroups: PropertiesWithFilterGroupUpdate.includes(
-        this.props.widgetProperty.name
-      ),
-    };
-    this.props.onChange(newValues, params);
+    this.props.onChange(newValues);
   };
 
   private updateAllProperties = (values, params: { [key: string]: any } = {}) => {

--- a/app/cdap/components/shared/ConfigurationGroup/index.tsx
+++ b/app/cdap/components/shared/ConfigurationGroup/index.tsx
@@ -77,14 +77,12 @@ const ConfigurationGroupView: React.FC<IConfigurationGroupProps> = ({
   validateProperties,
 }) => {
   const [configurationGroups, setConfigurationGroups] = useState([]);
-  const [defaultValues, setDefaultValues] = useState({ ...values });
   const referenceValueForUnMount = useRef<{
     configurationGroups?: IFilteredConfigurationGroup[];
     values?: Record<string, string>;
   }>({});
   const [filteredConfigurationGroups, setFilteredConfigurationGroups] = useState([]);
   const [orphanErrors, setOrphanErrors] = useState([]);
-  const [propertyValues, setPropertyValues] = useState({ ...values });
 
   // Initialize the configurationGroups based on widgetJson and pluginProperties obtained from backend
   useEffect(() => {
@@ -111,7 +109,6 @@ const ConfigurationGroupView: React.FC<IConfigurationGroupProps> = ({
       initialValues = defaults(values, processedConfigurationGroup.defaultValues);
       changeParentHandler(initialValues);
     }
-    setDefaultValues(initialValues);
     updateFilteredConfigurationGroup(
       processedConfigurationGroup.configurationGroups,
       initialValues
@@ -138,12 +135,6 @@ const ConfigurationGroupView: React.FC<IConfigurationGroupProps> = ({
       configurationGroups: newFilteredConfigurationGroup,
       values: newValues,
     };
-    const updatedFilteredValues = removeFilteredProperties(
-      newValues,
-      newFilteredConfigurationGroup,
-      defaultValues
-    );
-    setPropertyValues(updatedFilteredValues);
     setFilteredConfigurationGroups(newFilteredConfigurationGroup);
     getOrphanedErrors();
   }
@@ -162,7 +153,7 @@ const ConfigurationGroupView: React.FC<IConfigurationGroupProps> = ({
       fcg = filterByCondition(configurationGroups, widgetJson, pluginProperties, changedValues);
     }
 
-    const updatedFilteredValues = removeFilteredProperties(changedValues, fcg, defaultValues);
+    const updatedFilteredValues = removeFilteredProperties(changedValues, fcg);
     changeParentHandler(updatedFilteredValues);
   }
 
@@ -280,7 +271,7 @@ const ConfigurationGroupView: React.FC<IConfigurationGroupProps> = ({
                     key={`${property.name}-${j}`}
                     widgetProperty={property}
                     pluginProperty={pluginProperties[property.name]}
-                    value={propertyValues[property.name]}
+                    value={values[property.name]}
                     onChange={handleValueChanges}
                     extraConfig={extraConfig}
                     disabled={disabled}

--- a/app/cdap/components/shared/ConfigurationGroup/utilities/__tests__/utilities.test.ts
+++ b/app/cdap/components/shared/ConfigurationGroup/utilities/__tests__/utilities.test.ts
@@ -22,6 +22,7 @@ describe('Unit tests for Utilities', () => {
       const values = {
         project: 'test',
         tempTableTTLHours: '72',
+        location: 'US-default',
       };
       const filteredConfigurationGroups = [
         {
@@ -47,14 +48,7 @@ describe('Unit tests for Utilities', () => {
           ],
         },
       ];
-      const defaultValues = {
-        location: 'US-default',
-        project: 'test-default',
-        tempTableTTLHours: '72-default',
-      };
-      expect(
-        removeFilteredProperties(values, filteredConfigurationGroups, defaultValues)
-      ).toStrictEqual({
+      expect(removeFilteredProperties(values, filteredConfigurationGroups)).toStrictEqual({
         location: 'US-default',
         project: 'test',
       });

--- a/app/cdap/components/shared/ConfigurationGroup/utilities/index.ts
+++ b/app/cdap/components/shared/ConfigurationGroup/utilities/index.ts
@@ -382,18 +382,14 @@ export function countErrors(
  *
  * @param values latest field values
  * @param filteredConfigurationGroups configuration-groups from Widget JSON
- * @param defaultValues default field values
  */
-export function removeFilteredProperties(values, filteredConfigurationGroups, defaultValues = {}) {
+export function removeFilteredProperties(values, filteredConfigurationGroups) {
   const newValues = { ...values };
   if (filteredConfigurationGroups) {
     filteredConfigurationGroups.forEach((group) => {
       group.properties.forEach((property) => {
         if (property.show === false) {
           delete newValues[property.name];
-        } else if (defaultValues[property.name] && !newValues[property.name]) {
-          // Restore default values for visible fields that are empty
-          newValues[property.name] = defaultValues[property.name];
         }
       });
     });


### PR DESCRIPTION
# Revert: Restore default values while toggling connection field

## Description
Reverting fix that was added to restore default values while toggling connection field. This breaks other user flows [18764](https://cdap.atlassian.net/browse/CDAP-18764)

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
[18764](https://cdap.atlassian.net/browse/CDAP-18764)


