### PR TITLE
Feature flags using react context api

### DIFF
--- a/app/cdap/components/Replicator/Create/Content/SelectTables/index.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectTables/index.tsx
@@ -32,7 +32,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Heading, { HeadingTypes } from 'components/shared/Heading';
 import ManualSelectTable from 'components/Replicator/Create/Content/SelectTables/ManualSelectTable';
 import SearchBox from 'components/Replicator/Create/Content/SearchBox';
-import { useFeatureFlag } from 'services/react/customHooks/useFeatureFlag';
+import { useFeatureFlagDefaultFalse } from 'services/react/customHooks/useFeatureFlag';
 import debounce from 'lodash/debounce';
 import classnames from 'classnames';
 import {
@@ -709,6 +709,14 @@ const SelectTables = createContextConnect(StyledSelectTables);
 
 // Higher Order Component wrapping class component so we can use useFeatureFlag hook
 export default ({ children, ...props }) => {
-  props.useReplicationTransformation = useFeatureFlag('replication.transformations.enabled');
-  return <SelectTables {...props} />;
+  return (
+    <SelectTables
+      {...{
+        useReplicationTransformation: useFeatureFlagDefaultFalse(
+          'replication.transformations.enabled'
+        ),
+        ...props,
+      }}
+    />
+  );
 };

--- a/app/cdap/components/Replicator/Create/Content/SelectTables/index.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectTables/index.tsx
@@ -32,6 +32,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Heading, { HeadingTypes } from 'components/shared/Heading';
 import ManualSelectTable from 'components/Replicator/Create/Content/SelectTables/ManualSelectTable';
 import SearchBox from 'components/Replicator/Create/Content/SearchBox';
+import { useFeatureFlag } from 'services/react/customHooks/useFeatureFlag';
 import debounce from 'lodash/debounce';
 import classnames from 'classnames';
 import {
@@ -164,7 +165,8 @@ const styles = (theme): StyleRules => {
   };
 };
 
-type ISelectTablesProps = ICreateContext & WithStyles<typeof styles>;
+type ISelectTablesProps = ICreateContext &
+  WithStyles<typeof styles> & { useReplicationTransformation: boolean };
 
 interface ISelectTablesState {
   tables: ITable[];
@@ -481,9 +483,7 @@ class SelectTablesView extends React.PureComponent<ISelectTablesProps, ISelectTa
 
   public renderColumns = () => {
     let Columns = SelectColumns;
-    if (true) {
-      // this will eventually be a feature flag but just leaving it as a boolean
-      // for now as a convenience
+    if (this.props.useReplicationTransformation) {
       Columns = SelectColumnsWithTransforms;
     }
 
@@ -706,4 +706,9 @@ class SelectTablesView extends React.PureComponent<ISelectTablesProps, ISelectTa
 
 const StyledSelectTables = withStyles(styles)(SelectTablesView);
 const SelectTables = createContextConnect(StyledSelectTables);
-export default SelectTables;
+
+// Higher Order Component wrapping class component so we can use useFeatureFlag hook
+export default ({ children, ...props }) => {
+  props.useReplicationTransformation = useFeatureFlag('replication.transformations.enabled');
+  return <SelectTables {...props} />;
+};

--- a/app/cdap/components/Replicator/Create/Content/StepButtons/index.tsx
+++ b/app/cdap/components/Replicator/Create/Content/StepButtons/index.tsx
@@ -17,10 +17,11 @@
 import * as React from 'react';
 import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
 import { createContextConnect, ICreateContext } from 'components/Replicator/Create';
-import { STEPS } from 'components/Replicator/Create/steps';
+import { returnSteps } from 'components/Replicator/Create/steps';
 import Button from '@material-ui/core/Button';
 import If from 'components/shared/If';
 import LoadingSVG from 'components/shared/LoadingSVG';
+import { useFeatureFlagDefaultFalse } from 'services/react/customHooks/useFeatureFlag';
 
 const styles = (theme): StyleRules => {
   return {
@@ -51,6 +52,8 @@ const StepButtonsView: React.FC<IStepButtonProps> = ({
   onComplete,
   completeLoading,
 }) => {
+  const transformationsEnabled = useFeatureFlagDefaultFalse('replication.transformations.enabled');
+  const STEPS = returnSteps(transformationsEnabled);
   function handleNextClick() {
     if (activeStep === STEPS.length - 1) {
       return;

--- a/app/cdap/components/Replicator/Create/Content/index.tsx
+++ b/app/cdap/components/Replicator/Create/Content/index.tsx
@@ -15,14 +15,17 @@
  */
 
 import * as React from 'react';
-import { STEPS } from 'components/Replicator/Create/steps';
+import { returnSteps } from 'components/Replicator/Create/steps';
 import { createContextConnect } from 'components/Replicator/Create';
+import { useFeatureFlagDefaultFalse } from 'services/react/customHooks/useFeatureFlag';
 
 interface IContentProps {
   activeStep: number;
 }
 
 const ContentView: React.FC<IContentProps> = ({ activeStep }) => {
+  const transformationsEnabled = useFeatureFlagDefaultFalse('replication.transformations.enabled');
+  const STEPS = returnSteps(transformationsEnabled);
   if (!STEPS[activeStep] || !STEPS[activeStep].component) {
     return null;
   }

--- a/app/cdap/components/Replicator/Create/LeftPanel/index.tsx
+++ b/app/cdap/components/Replicator/Create/LeftPanel/index.tsx
@@ -18,9 +18,10 @@ import * as React from 'react';
 import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
 import { createContextConnect } from 'components/Replicator/Create';
 import Chip from '@material-ui/core/Chip';
-import { STEPS } from 'components/Replicator/Create/steps';
+import { returnSteps } from 'components/Replicator/Create/steps';
 import classnames from 'classnames';
 import Check from '@material-ui/icons/Check';
+import { useFeatureFlagDefaultFalse } from 'services/react/customHooks/useFeatureFlag';
 
 const styles = (theme): StyleRules => {
   return {
@@ -75,6 +76,8 @@ const LeftPanelView: React.FC<ILeftPanelProps> = ({
   activeStep,
   isStateFilled,
 }) => {
+  const transformationsEnabled = useFeatureFlagDefaultFalse('replication.transformations.enabled');
+  const STEPS = returnSteps(transformationsEnabled);
   function handleStepClick(step) {
     if (!isRowFinished(step)) {
       return;

--- a/app/cdap/components/Replicator/Create/TopPanel/index.tsx
+++ b/app/cdap/components/Replicator/Create/TopPanel/index.tsx
@@ -27,7 +27,8 @@ import Close from '@material-ui/icons/Close';
 import ChevronRight from '@material-ui/icons/ChevronRight';
 import PluginInfo from 'components/Replicator/Create/TopPanel/PluginInfo';
 import If from 'components/shared/If';
-import { STEPS } from 'components/Replicator/Create/steps';
+import { returnSteps } from 'components/Replicator/Create/steps';
+import { useFeatureFlagDefaultFalse } from 'services/react/customHooks/useFeatureFlag';
 
 const styles = (theme): StyleRules => {
   return {
@@ -86,6 +87,8 @@ const TopPanelView: React.FC<ICreateContext & WithStyles<typeof styles>> = ({
   targetPluginWidget,
   activeStep,
 }) => {
+  const transformationsEnabled = useFeatureFlagDefaultFalse('replication.transformations.enabled');
+  const STEPS = returnSteps(transformationsEnabled);
   const reviewDisplayCondition = activeStep === STEPS.length - 1;
 
   return (

--- a/app/cdap/components/Replicator/Create/index.tsx
+++ b/app/cdap/components/Replicator/Create/index.tsx
@@ -48,6 +48,7 @@ import {
 } from 'components/Replicator/types';
 import { IWidgetJson } from 'components/shared/ConfigurationGroup/types';
 import ErrorBanner from 'components/shared/ErrorBanner';
+import { FeatureProvider } from 'services/react/providers/featureFlagProvider';
 
 export const CreateContext = React.createContext({});
 export const LEFT_PANEL_WIDTH = 275;
@@ -638,7 +639,11 @@ export function createContextConnect(Comp) {
             ...extraProps,
           };
 
-          return <Comp {...finalProps} />;
+          return (
+            <FeatureProvider>
+              <Comp {...finalProps} />
+            </FeatureProvider>
+          );
         }}
       </CreateContext.Consumer>
     );

--- a/app/cdap/components/Replicator/Create/steps.tsx
+++ b/app/cdap/components/Replicator/Create/steps.tsx
@@ -29,39 +29,47 @@ interface IStep {
   required?: string[];
 }
 
-export const STEPS: IStep[] = [
-  {
-    label: 'Specify basic information',
-    component: NameDescription,
-    required: ['name'],
-  },
-  {
-    label: 'Configure source',
-    component: SourceConfig,
-    required: ['sourceConfig'],
-  },
-  {
-    label: 'Configure target',
-    component: TargetConfig,
-    required: ['targetConfig'],
-  },
-  {
-    label: 'Select tables and transformations',
+export const returnSteps = (transformationsEnabled: boolean): IStep[] => {
+  const tableIndex = transformationsEnabled ? 3 : 2;
+  const tables = {
+    label: transformationsEnabled ? 'Select tables and transformations' : 'Select tables',
     component: SelectTables,
     required: ['tables'],
-  },
-  {
-    label: 'Configure advanced properties',
-    component: Advanced,
-    required: ['numInstances'],
-  },
-  {
-    label: 'Review assessment',
-    component: Assessment,
-    required: ['name', 'sourceConfig', 'tables', 'targetConfig', 'numInstances'],
-  },
-  {
-    label: 'View summary',
-    component: Summary,
-  },
-];
+  };
+
+  const steps = [
+    {
+      label: 'Specify basic information',
+      component: NameDescription,
+      required: ['name'],
+    },
+    {
+      label: 'Configure source',
+      component: SourceConfig,
+      required: ['sourceConfig'],
+    },
+    {
+      label: 'Configure target',
+      component: TargetConfig,
+      required: ['targetConfig'],
+    },
+    {
+      label: 'Configure advanced properties',
+      component: Advanced,
+      required: ['numInstances'],
+    },
+    {
+      label: 'Review assessment',
+      component: Assessment,
+      required: ['name', 'sourceConfig', 'tables', 'targetConfig', 'numInstances'],
+    },
+    {
+      label: 'View summary',
+      component: Summary,
+    },
+  ];
+
+  steps.splice(tableIndex, 0, tables);
+
+  return steps;
+};

--- a/app/cdap/main.js
+++ b/app/cdap/main.js
@@ -36,7 +36,6 @@ import Footer from 'components/shared/Footer';
 import Helmet from 'react-helmet';
 import Home from 'components/Home';
 import HttpExecutor from 'components/HttpExecutor';
-import If from 'components/shared/If';
 import Loadable from 'react-loadable';
 import LoadingIndicator from 'components/shared/LoadingIndicator';
 import LoadingSVG from 'components/shared/LoadingSVG';
@@ -373,43 +372,39 @@ class CDAP extends Component {
             <LoadingIndicator />
             <StatusAlertMessage />
             {this.state.apiError && <ApiErrorDialog />}
-            <If condition={this.state.isNamespaceFetchInFlight}>
+            {this.state.isNamespaceFetchInFlight && (
               <div className="loading-svg">
                 <LoadingSVG />
               </div>
-            </If>
-            <If condition={!this.state.isNamespaceFetchInFlight}>
-              <If condition={isNamespaceNotFound}>
-                <Page404 message={this.state.pageLevelError.message} />
-              </If>
-              {/** We show authorization failure message when the specific namespace API returns 403 */}
-              <If condition={isUserUnAuthorizedForNamespace}>
-                <AuthorizationErrorMessage message={this.state.pageLevelError.message} />
-              </If>
-              <If
-                condition={
-                  !isUserUnAuthorizedForNamespace &&
-                  !isNamespaceNotFound &&
-                  this.state.pageLevelError
-                }
-              >
-                <Page500
-                  message={this.state.pageLevelError.message}
-                  refreshFn={this.retrieveNamespace}
-                />
-              </If>
-              {/**
-               * We show authorization failure message when the backend return empty
-               * namespace. This indicates the user has access to no namespace.
-               */}
-              <If condition={!this.state.pageLevelError}>
-                {this.state.authorizationFailed ? (
+            )}
+            {!this.state.isNamespaceFetchInFlight && (
+              <div>
+                {isNamespaceNotFound && <Page404 message={this.state.pageLevelError.message} />}
+                {/** We show authorization failure message when the specific namespace API returns 403 */}
+                {isUserUnAuthorizedForNamespace && (
                   <AuthorizationErrorMessage message={this.state.pageLevelError.message} />
-                ) : (
-                  container
                 )}
-              </If>
-            </If>
+
+                {!isUserUnAuthorizedForNamespace &&
+                  !isNamespaceNotFound &&
+                  this.state.pageLevelError && (
+                    <Page500
+                      message={this.state.pageLevelError.message}
+                      refreshFn={this.retrieveNamespace}
+                    />
+                  )}
+                {/**
+                 * We show authorization failure message when the backend return empty
+                 * namespace. This indicates the user has access to no namespace.
+                 */}
+                {!this.state.pageLevelError &&
+                  (this.state.authorizationFailed ? (
+                    <AuthorizationErrorMessage message={this.state.pageLevelError.message} />
+                  ) : (
+                    container
+                  ))}
+              </div>
+            )}
             <Footer />
             <AuthRefresher />
           </div>

--- a/app/cdap/services/react/customHooks/useFeatureFlag.ts
+++ b/app/cdap/services/react/customHooks/useFeatureFlag.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { useContext } from 'react';
+import { FeatureFlagsContext, IFeatureFlags } from '../providers/featureFlagProvider';
+
+/**
+ * Returns true if feature if enabled, false if the flag
+ * does not exist or disabled
+ * Must wrap parent component with services/react/providers/featureFlagProvider
+ * @param name feature flag name
+ * @returns boolean
+ */
+
+export function useFeatureFlag(name: keyof IFeatureFlags | string): boolean {
+  const features = useContext(FeatureFlagsContext);
+  if (features === null) {
+    throw new Error('Components must be wrapped in services/react/providers/featureFlagProvider');
+  }
+  // if name is not in features explicitly return false
+  if (features[name] === undefined) {
+    return false;
+  }
+
+  return features[name] === 'true';
+}

--- a/app/cdap/services/react/customHooks/useFeatureFlag.ts
+++ b/app/cdap/services/react/customHooks/useFeatureFlag.ts
@@ -17,6 +17,20 @@
 import { useContext } from 'react';
 import { FeatureFlagsContext, IFeatureFlags } from '../providers/featureFlagProvider';
 
+const useFeatureFlag = (name: keyof IFeatureFlags | string, defaultResult: boolean): boolean => {
+  const features = useContext(FeatureFlagsContext);
+  if (features === null) {
+    throw new Error('Components must be wrapped in services/react/providers/featureFlagProvider');
+  }
+
+  // returns default result if flag doesn't exist
+  if (features[name] === undefined) {
+    return defaultResult;
+  }
+
+  return features[name] === 'true';
+};
+
 /**
  * Returns true if feature if enabled, false if the flag
  * does not exist or disabled
@@ -25,15 +39,15 @@ import { FeatureFlagsContext, IFeatureFlags } from '../providers/featureFlagProv
  * @returns boolean
  */
 
-export function useFeatureFlag(name: keyof IFeatureFlags | string): boolean {
-  const features = useContext(FeatureFlagsContext);
-  if (features === null) {
-    throw new Error('Components must be wrapped in services/react/providers/featureFlagProvider');
-  }
-  // if name is not in features explicitly return false
-  if (features[name] === undefined) {
-    return false;
-  }
+export const useFeatureFlagDefaultFalse = (name: keyof IFeatureFlags | string): boolean =>
+  useFeatureFlag(name, false);
 
-  return features[name] === 'true';
-}
+/**
+ * Returns true if feature if enabled or does not exist,
+ * false if feature flag is disabled
+ * Must wrap parent component with services/react/providers/featureFlagProvider
+ * @param name feature flag name
+ * @returns boolean
+ */
+export const useFeatureFlagDefaultTrue = (name: keyof IFeatureFlags | string): boolean =>
+  useFeatureFlag(name, true);

--- a/app/cdap/services/react/providers/featureFlagProvider.tsx
+++ b/app/cdap/services/react/providers/featureFlagProvider.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { createContext } from 'react';
+
+// unfortunately our booleans come back as strings in this instance
+type IStringBoolean = 'true' | 'false';
+
+export interface IFeatureFlags {
+  'replication.transformations.enabled'?: IStringBoolean;
+}
+
+export const FeatureFlagsContext = createContext(null);
+
+/**
+ * Feature flag provider - checks CDAP_CONFIG on the window for
+ * the features
+ * server/express.js contains where the feature flags are added to the window
+ * server.js contains where feature flags are extracted from the config
+ *
+ */
+export function FeatureProvider({ children }: { children: React.ReactElement }) {
+  // Unfortunately all config pieces are passed onto the window like this - needs to change in the future
+  return (
+    <FeatureFlagsContext.Provider value={window.CDAP_CONFIG.featureFlags}>
+      {children}
+    </FeatureFlagsContext.Provider>
+  );
+}

--- a/server.js
+++ b/server.js
@@ -96,7 +96,20 @@ async function setAllowedOrigin() {
 log.info('Starting CDAP UI ...');
 getCDAPConfig()
   .then(function(c) {
+    // extract feature flags from the config with shorter keys to make it easier
+    // to consume
+    const featureFlags = {};
+    for (const [key, value] of Object.entries(c)) {
+      if (key.match(/^feature.ui/)) {
+        // feature.ui. is 11 characters and we only want to include
+        // ui feature flags
+        featureFlags[key.substring(11)] = value;
+        delete c[key];
+      }
+    }
+
     cdapConfig = c;
+    cdapConfig.featureFlags = featureFlags;
     if (cdapConfig['security.enabled'] === 'true') {
       log.debug('CDAP Security has been enabled');
       return extractConfig('security');

--- a/server/config/development/cdap.json
+++ b/server/config/development/cdap.json
@@ -13,5 +13,5 @@
   "market.base.url": "https://hub.cdap.io/dev/v2",
   "ui.theme.file": "config/themes/default.json",
   "session.secret.key": "sample-secret-key-for-encryption",
-  "feature.ui.replication.transformations.enabled": "true"
+  "feature.ui.replication.transformations.enabled": "false"
 }

--- a/server/config/development/cdap.json
+++ b/server/config/development/cdap.json
@@ -12,5 +12,6 @@
   "dashboard.router.check.timeout.secs": "0",
   "market.base.url": "https://hub.cdap.io/dev/v2",
   "ui.theme.file": "config/themes/default.json",
-  "session.secret.key": "sample-secret-key-for-encryption"
+  "session.secret.key": "sample-secret-key-for-encryption",
+  "feature.ui.replication.transformations.enabled": "true"
 }

--- a/server/express.js
+++ b/server/express.js
@@ -205,6 +205,7 @@ function makeApp(authAddress, cdapConfig, uiSettings) {
       authRefreshURL: cdapConfig['dashboard.auth.refresh.path'] || false,
       instanceMetadataId: cdapConfig['instance.metadata.id'],
       sslEnabled: isSecure,
+      featureFlags: cdapConfig.featureFlags,
     });
 
     res.header({


### PR DESCRIPTION
# React Context Feature Flags

## Description
Adds feature flags using the react context api and adds the feature flag support for replication transformations. This also shows how to use the feature flag hook from inside a class component using the higher order component pattern.

Unfortunately CDAP UI currently gets all configuration from the window in `server/express.js` so making use of that to have these feature flags from the backend.

I also removed `<If></If>` from main.js while working on other things. 

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick




