### PR TITLE
Adds dynamic fields in create compute profile page

### DIFF
--- a/app/cdap/components/Cloud/Profiles/CreateView/CreateProfileActionCreator.js
+++ b/app/cdap/components/Cloud/Profiles/CreateView/CreateProfileActionCreator.js
@@ -40,19 +40,22 @@ function initializeProperties(provisionerJson = {}) {
   }
   let configs = provisionerJson['configuration-groups'] || [];
   let properties = {};
+  const values = {};
   configs.forEach((config) => {
     config.properties.forEach((prop) => {
       let widgetAttributes = prop['widget-attributes'] || {};
+      const value = widgetAttributes.default || '';
       properties[prop.name] = {
-        value: widgetAttributes.default || '',
+        value,
         isEditable: true,
         required: prop.required || false,
       };
+      values[prop.name] = value;
     });
   });
   CreateProfileStore.dispatch({
     type: ACTIONS.initializeProperties,
-    payload: { properties },
+    payload: { properties, values },
   });
 }
 

--- a/app/cdap/components/Cloud/Profiles/CreateView/CreateProfileStore.js
+++ b/app/cdap/components/Cloud/Profiles/CreateView/CreateProfileStore.js
@@ -30,6 +30,7 @@ const STORE_DEFAULT = {
   name: '',
   description: '',
   properties: {},
+  values: {},
 };
 const createProfileStore = (state = STORE_DEFAULT, action = defaultAction) => {
   switch (action.type) {
@@ -50,6 +51,7 @@ const createProfileStore = (state = STORE_DEFAULT, action = defaultAction) => {
       return {
         ...state,
         properties: action.payload.properties,
+        values: action.payload.values,
       };
     case ACTIONS.updateProperty:
       return {
@@ -60,6 +62,10 @@ const createProfileStore = (state = STORE_DEFAULT, action = defaultAction) => {
             ...state.properties[action.payload.propName],
             value: action.payload.propValue,
           },
+        },
+        values: {
+          ...state.values,
+          [action.payload.propName]: action.payload.propValue,
         },
       };
     case ACTIONS.togglePropertyLock:

--- a/app/cdap/components/Cloud/Profiles/CreateView/PropertyRow/index.tsx
+++ b/app/cdap/components/Cloud/Profiles/CreateView/PropertyRow/index.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React from 'react';
+import PropertyLock from 'components/Cloud/Profiles/CreateView/PropertyLock';
+import WidgetWrapper from 'components/shared/ConfigurationGroup/WidgetWrapper';
+import { isEmpty, isEqual, xorWith } from 'lodash';
+import { objectQuery } from 'services/helpers';
+import { IPluginProperty } from 'components/shared/ConfigurationGroup/types';
+import { IErrorObj } from 'components/shared/ConfigurationGroup/utilities';
+
+interface IPropertyRowProps {
+  properties: { [key: string]: any };
+  property: IPluginProperty;
+  onChange: (values, params?: { [key: string]: any }) => void;
+  extraConfig: any;
+  errors?: IErrorObj[];
+}
+
+const PropertyRowWrapper = ({ properties, property, onChange, extraConfig }: IPropertyRowProps) => {
+  return (
+    <div className="property-row">
+      <WidgetWrapper
+        pluginProperty={{
+          name: property.name,
+          required: !!property.required,
+          description: property.description,
+        }}
+        widgetProperty={property}
+        value={objectQuery(properties, property.name, 'value')}
+        onChange={onChange}
+        extraConfig={extraConfig}
+        size={objectQuery(property, 'widget-attributes', 'size')}
+      />
+      <PropertyLock propertyName={property.name} />
+    </div>
+  );
+};
+
+const PropertyRow = React.memo(PropertyRowWrapper, (prevProps, nextProps) => {
+  const prevVal = objectQuery(prevProps.properties, prevProps.property.name, 'value');
+  const curVal = objectQuery(nextProps.properties, nextProps.property.name, 'value');
+  const rule =
+    prevVal === curVal &&
+    nextProps.property['widget-type'] === prevProps.property['widget-type'] &&
+    prevProps.extraConfig.properties === nextProps.extraConfig.properties;
+  // Comparison of array of objects
+  const isArrayEqual = (x: IErrorObj[], y: IErrorObj[]) => isEmpty(xorWith(x, y, isEqual));
+  const errorChange = isArrayEqual(nextProps.errors, prevProps.errors);
+  return rule && errorChange;
+});
+
+export default PropertyRow;

--- a/app/cdap/components/Cloud/Profiles/CreateView/index.js
+++ b/app/cdap/components/Cloud/Profiles/CreateView/index.js
@@ -27,7 +27,6 @@ import ProvisionerInfoStore from 'components/Cloud/Store';
 import { fetchProvisionerSpec } from 'components/Cloud/Store/ActionCreator';
 import { ADMIN_CONFIG_ACCORDIONS } from 'components/Administration/AdminConfigTabContent';
 import { EntityTopPanel } from 'components/EntityTopPanel';
-import PropertyLock from 'components/Cloud/Profiles/CreateView/PropertyLock';
 import {
   ConnectedProfileName,
   ConnectedProfileDescription,
@@ -39,15 +38,15 @@ import {
   resetCreateProfileStore,
 } from 'components/Cloud/Profiles/CreateView/CreateProfileActionCreator';
 import CreateProfileBtn from 'components/Cloud/Profiles/CreateView/CreateProfileBtn';
-import uuidV4 from 'uuid/v4';
 import CreateProfileStore from 'components/Cloud/Profiles/CreateView/CreateProfileStore';
+import PropertyRow from 'components/Cloud/Profiles/CreateView/PropertyRow';
 import { highlightNewProfile } from 'components/Cloud/Profiles/Store/ActionCreator';
 import Helmet from 'react-helmet';
 import T from 'i18n-react';
 import { SCOPES, SYSTEM_NAMESPACE } from 'services/global-constants';
 import { Theme } from 'services/ThemeHelper';
-import WidgetWrapper from 'components/shared/ConfigurationGroup/WidgetWrapper';
 import If from 'components/shared/If';
+import { filterByCondition } from 'components/shared/ConfigurationGroup/utilities/DynamicPluginFilters';
 
 const PREFIX = 'features.Cloud.Profiles.CreateView';
 
@@ -70,11 +69,13 @@ class ProfileCreateView extends Component {
     creatingProfile: false,
     isSystem: objectQuery(this.props.match, 'params', 'namespace') === SYSTEM_NAMESPACE,
     selectedProvisioner: objectQuery(this.props.match, 'params', 'provisionerId'),
+    filteredConfigurationGroup: [],
   };
 
   componentWillReceiveProps(nextProps) {
     let { selectedProvisioner } = this.state;
     initializeProperties(nextProps.provisionerJsonSpecMap[selectedProvisioner]);
+    this.setFilteredConfigurationGroup(nextProps);
   }
 
   componentDidMount() {
@@ -109,18 +110,27 @@ class ProfileCreateView extends Component {
     if (properties['projectId'] && properties['projectId'].value === '') {
       delete properties['projectId'];
     }
+    // Add only fields that are shown to the users.
+    const visibilityMap = {};
+    for (const groupInfo of this.state.filteredConfigurationGroup) {
+      for (const propertyInfo of groupInfo.properties) {
+        visibilityMap[propertyInfo.name] = propertyInfo.show !== false;
+      }
+    }
     let jsonBody = {
       description,
       label,
       provisioner: {
         name: this.state.selectedProvisioner,
-        properties: Object.entries(properties).map(([property, propObj]) => {
-          return {
-            name: property,
-            value: propObj.value,
-            isEditable: propObj.isEditable,
-          };
-        }),
+        properties: Object.entries(properties)
+          .filter(([property]) => visibilityMap[property])
+          .map(([property, propObj]) => {
+            return {
+              name: property,
+              value: propObj.value,
+              isEditable: propObj.isEditable,
+            };
+          }),
       },
     };
     let apiObservable$ = MyCloudApi.create;
@@ -157,6 +167,44 @@ class ProfileCreateView extends Component {
     );
   };
 
+  setFilteredConfigurationGroup(props) {
+    const { selectedProvisioner } = this.state;
+    const { values } = CreateProfileStore.getState();
+    const configurationGroups = objectQuery(
+      props,
+      'provisionerJsonSpecMap',
+      selectedProvisioner,
+      'configuration-groups'
+    );
+    const filters = objectQuery(props, 'provisionerJsonSpecMap', selectedProvisioner, 'filters');
+    if (!configurationGroups) {
+      this.setState({
+        filteredConfigurationGroup: [],
+      });
+    } else {
+      let filteredConfigurationGroup = configurationGroups;
+      if (filters && filters.length > 0) {
+        filteredConfigurationGroup = filterByCondition(
+          configurationGroups,
+          {
+            'configuration-groups': configurationGroups,
+            filters,
+          },
+          {},
+          values
+        );
+      }
+      this.setState({
+        filteredConfigurationGroup,
+      });
+    }
+  }
+
+  onUpdateProperty(property, value) {
+    updateProperty(property, value);
+    this.setFilteredConfigurationGroup(this.props);
+  }
+
   renderProfileName = () => {
     return (
       <div className="property-row">
@@ -182,6 +230,9 @@ class ProfileCreateView extends Component {
   };
 
   renderGroup = (group) => {
+    if (group.show === false) {
+      return null;
+    }
     let { properties } = CreateProfileStore.getState();
     const extraConfig = {
       namespace: this.state.isSystem ? SYSTEM_NAMESPACE : getCurrentNamespace(),
@@ -194,24 +245,17 @@ class ProfileCreateView extends Component {
         <div className="group-description">{group.description}</div>
         <div className="fields-container">
           {group.properties.map((property) => {
-            let uniqueId = `provisioner-${uuidV4()}`;
-
+            if (property.show === false) {
+              return null;
+            }
             return (
-              <div key={uniqueId} className="property-row">
-                <WidgetWrapper
-                  pluginProperty={{
-                    name: property.name,
-                    required: !!property.required,
-                    description: property.description,
-                  }}
-                  widgetProperty={property}
-                  value={objectQuery(properties, property.name, 'value')}
-                  onChange={updateProperty.bind(null, property.name)}
-                  extraConfig={extraConfig}
-                  size={objectQuery(property, 'widget-attributes', 'size')}
-                />
-                <PropertyLock propertyName={property.name} />
-              </div>
+              <PropertyRow
+                key={property.name}
+                property={property}
+                properties={properties}
+                onChange={this.onUpdateProperty.bind(this, property.name)}
+                extraConfig={extraConfig}
+              />
             );
           })}
         </div>
@@ -220,17 +264,10 @@ class ProfileCreateView extends Component {
   };
 
   renderGroups = () => {
-    let { selectedProvisioner } = this.state;
-    let configurationGroups = objectQuery(
-      this.props,
-      'provisionerJsonSpecMap',
-      selectedProvisioner,
-      'configuration-groups'
-    );
-    if (!configurationGroups) {
+    if (this.state.filteredConfigurationGroup.length === 0) {
       return null;
     }
-    return configurationGroups.map((group) => this.renderGroup(group));
+    return this.state.filteredConfigurationGroup.map((group) => this.renderGroup(group));
   };
 
   render() {


### PR DESCRIPTION
Adds dynamic fields in create compute profile page

## Description
Until now compute profile page has only static rendered widgets, adding support for dynamic fields which work based on the [Filters](https://cdap.atlassian.net/wiki/spaces/DOCS/pages/480379311/Plugin+Presentation#Dynamic-Plugin-Filters) 

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [18753](https://cdap.atlassian.net/browse/CDAP-18753)

## Screenshots
![image](https://user-images.githubusercontent.com/81957712/151647604-238354db-32fe-43c9-9add-822c526498d3.png)

![image](https://user-images.githubusercontent.com/81957712/151647609-5f03c670-3bfe-47fe-bb8a-e438e38cfc78.png)



