### PR TITLE
Adds dynamic fields support in profile customisation page

### DIFF
--- a/app/cdap/components/PipelineDetails/ProfilesListView/ProfileCustomizePopover/ProfileCustomizeContent/index.js
+++ b/app/cdap/components/PipelineDetails/ProfilesListView/ProfileCustomizePopover/ProfileCustomizeContent/index.js
@@ -23,12 +23,13 @@ import Accordion, {
   AccordionPane,
 } from 'components/shared/Accordion';
 import { MyCloudApi } from 'api/cloud';
-import uuidV4 from 'uuid/v4';
 import { extractProfileName } from 'components/Cloud/Profiles/Store/ActionCreator';
 import IconSVG from 'components/shared/IconSVG';
 import cloneDeep from 'lodash/cloneDeep';
 import classnames from 'classnames';
-import { WrappedWidgetWrapper } from 'components/shared/ConfigurationGroup/WidgetWrapper';
+import ProfilePropertyRow from 'components/PipelineDetails/ProfilesListView/ProfileCustomizePopover/ProfilePropertyRow';
+import { filterByCondition } from 'components/shared/ConfigurationGroup/utilities/DynamicPluginFilters';
+import { objectQuery } from 'services/helpers';
 
 require('./ProfileCustomizeContent.scss');
 
@@ -50,18 +51,21 @@ export default class ProfileCustomizeContent extends PureComponent {
 
   state = {
     loading: true,
-    provisionerspec: null,
+    provisionerSpec: null,
+    filteredConfigurationGroup: [],
   };
 
   customization = cloneDeep(this.props.customizations);
+  latestValues = this.getDefaultValues();
 
   componentDidMount() {
     MyCloudApi.getProvisionerDetailSpec({
       provisioner: this.props.provisioner.name,
     }).subscribe(
-      (provisionerspec) => {
+      (provisionerSpec) => {
         this.setState({
-          provisionerspec,
+          provisionerSpec,
+          filteredConfigurationGroup: this.getFilteredConfigurationGroup(provisionerSpec),
           loading: false,
         });
       },
@@ -76,11 +80,60 @@ export default class ProfileCustomizeContent extends PureComponent {
 
   componentWillUnmount() {
     this.customization = {};
+    this.latestValues = {};
+  }
+
+  getDefaultValues() {
+    const { editablePropertiesFromProfile } = this.props;
+    const values = {};
+    editablePropertiesFromProfile.forEach((property) => {
+      if (property.name in this.props.customizations) {
+        values[property.name] = this.props.customizations[property.name];
+      } else {
+        values[property.name] = property.value;
+      }
+    });
+    return values;
+  }
+
+  getFilteredConfigurationGroup(provisionerSpec) {
+    const configurationGroups = provisionerSpec['configuration-groups'];
+    const filters = provisionerSpec.filters;
+    if (filters) {
+      return filterByCondition(
+        configurationGroups,
+        {
+          'configuration-groups': configurationGroups,
+          filters,
+        },
+        {},
+        this.latestValues
+      );
+    } else {
+      return configurationGroups;
+    }
   }
 
   onPropertyUpdate = (propertyName, value) => {
     this.customization[propertyName] = value.toString();
+    this.latestValues[propertyName] = value.toString();
+    // Re-render only when the updated property is part of the filters.
+    if (this.isFilteredProperty(propertyName)) {
+      const filteredConfigurationGroup = this.getFilteredConfigurationGroup(
+        this.state.provisionerSpec
+      );
+      this.setState({
+        filteredConfigurationGroup,
+      });
+    }
   };
+
+  isFilteredProperty(propertyName) {
+    const { provisionerSpec } = this.state;
+    return (provisionerSpec.filters || []).some(
+      (filter) => objectQuery(filter, 'condition', 'property') === propertyName
+    );
+  }
 
   onSave = () => {
     if (this.props.onSave) {
@@ -94,12 +147,8 @@ export default class ProfileCustomizeContent extends PureComponent {
     }
   };
 
-  getProfilePropValue = (property) => {
-    return this.customization[property.name] || property.value;
-  };
-
   render() {
-    const editablePropertiesFromProfile = this.props.editablePropertiesFromProfile;
+    const { editablePropertiesFromProfile } = this.props;
     if (this.state.loading) {
       return (
         <div className="profile-customize-content">
@@ -107,21 +156,13 @@ export default class ProfileCustomizeContent extends PureComponent {
         </div>
       );
     }
-    let groups = this.state.provisionerspec['configuration-groups'];
+    let groups = this.state.filteredConfigurationGroup;
 
     const propertiesFromProfileMap = {};
     this.props.provisioner.properties.forEach((property) => {
       propertiesFromProfileMap[property.name] = property;
     });
 
-    let editablePropertiesMap = {};
-    editablePropertiesFromProfile.forEach((property) => {
-      if (property.name in this.props.customizations) {
-        editablePropertiesMap[property.name] = this.props.customizations[property.name];
-      } else {
-        editablePropertiesMap[property.name] = property.value;
-      }
-    });
     let profileName = this.props.profileLabel || extractProfileName(this.props.profileName);
 
     return (
@@ -138,17 +179,21 @@ export default class ProfileCustomizeContent extends PureComponent {
           </div>
           <Accordion size="small" active="0">
             {groups.map((group, i) => {
+              if (group.show === false) {
+                return null;
+              }
               const editableProperties = group.properties
-                .filter(
-                  (property) =>
+                .filter((property) => {
+                  const isEditable =
                     !propertiesFromProfileMap[property.name] ||
-                    propertiesFromProfileMap[property.name].isEditable !== false
-                )
+                    propertiesFromProfileMap[property.name].isEditable !== false;
+                  return isEditable && property.show !== false;
+                })
                 .map((property) => {
                   if (property['widget-type'] === 'select') {
                     return {
                       ...property,
-                      value: editablePropertiesMap[property.name],
+                      value: this.latestValues[property.name],
                       ['widget-attributes']: {
                         ...(property['widget-attributes'] || {}),
                         MenuProps: {
@@ -159,11 +204,11 @@ export default class ProfileCustomizeContent extends PureComponent {
                   }
                   return {
                     ...property,
-                    value: editablePropertiesMap[property.name],
+                    value: this.latestValues[property.name],
                   };
                 });
               return (
-                <AccordionPane id={i}>
+                <AccordionPane id={i} key={i}>
                   <AccordionTitle>
                     <strong>
                       {group.label} ({group.properties.length})
@@ -171,22 +216,13 @@ export default class ProfileCustomizeContent extends PureComponent {
                   </AccordionTitle>
                   <AccordionContent>
                     {editableProperties.map((property) => {
-                      let uniqueId = `provisioner-${uuidV4()}`;
                       return (
-                        <div key={uniqueId} className="profile-group-content">
-                          <div>
-                            <WrappedWidgetWrapper
-                              pluginProperty={{
-                                name: property.name,
-                                description: property.description,
-                                required: property.required,
-                              }}
-                              widgetProperty={property}
-                              value={this.getProfilePropValue.bind(this, property)}
-                              onChange={this.onPropertyUpdate.bind(this, property.name)}
-                            />
-                          </div>
-                        </div>
+                        <ProfilePropertyRow
+                          key={property.name}
+                          property={property}
+                          value={property.value}
+                          onChange={this.onPropertyUpdate.bind(this, property.name)}
+                        />
                       );
                     })}
                     {!editableProperties.length ? (

--- a/app/cdap/components/PipelineDetails/ProfilesListView/ProfileCustomizePopover/ProfilePropertyRow/index.tsx
+++ b/app/cdap/components/PipelineDetails/ProfilesListView/ProfileCustomizePopover/ProfilePropertyRow/index.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React from 'react';
+import { WrappedWidgetWrapper } from 'components/shared/ConfigurationGroup/WidgetWrapper';
+import { IPluginProperty } from 'components/shared/ConfigurationGroup/types';
+
+interface IPropertyRowProps {
+  value: any;
+  property: IPluginProperty;
+  onChange: (values, params?: { [key: string]: any }) => void;
+}
+
+const PropertyRowWrapper = ({ property, value, onChange }: IPropertyRowProps) => {
+  return (
+    <div className="profile-group-content">
+      <div>
+        <WrappedWidgetWrapper
+          pluginProperty={{
+            name: property.name,
+            description: property.description,
+            required: property.required,
+          }}
+          widgetProperty={property}
+          value={value}
+          onChange={onChange}
+        />
+      </div>
+    </div>
+  );
+};
+
+const ProfilePropertyRow = React.memo(PropertyRowWrapper, (prevProps, nextProps) => {
+  return (
+    prevProps.value === nextProps.value &&
+    prevProps.property['widget-type'] === nextProps.property['widget-type']
+  );
+});
+
+export default ProfilePropertyRow;


### PR DESCRIPTION
# Adds dynamic fields support in pipeline level profile customisation page

## Description
Until now profile customisation page allows only static set of fields, added support for dynamic fields which are based on the [FILTERS](https://cdap.atlassian.net/wiki/spaces/DOCS/pages/480379311/Plugin+Presentation#Dynamic-Plugin-Filters).

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [18756](https://cdap.atlassian.net/browse/CDAP-18756)

## Screenshots
![image](https://user-images.githubusercontent.com/81957712/152011695-7daac6c0-c611-45cb-a622-ab1424fe451f.png)

![image](https://user-images.githubusercontent.com/81957712/152011854-1be2afa0-f25b-4445-b3e7-be1c3da8fe93.png)


