### PR TITLE
Auto-Scaling as an alternative compute Profile

### DIFF
--- a/app/cdap/components/Cloud/Profiles/AutoScaleBadge/index.tsx
+++ b/app/cdap/components/Cloud/Profiles/AutoScaleBadge/index.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React from 'react';
+import T from 'i18n-react';
+import styled from 'styled-components';
+import Tooltip from '@material-ui/core/Tooltip';
+import withStyles from '@material-ui/core/styles/withStyles';
+
+const PREFIX = 'features.Cloud.Profiles';
+
+const Badge = styled.span`
+  color: #fff;
+  font-size: 0.85rem;
+  background: var(--brand-primary-color);
+  padding: 2px 6px;
+  display: inline-block;
+  border-radius: 20px;
+  margin-left: 6px;
+  cursor: pointer;
+`;
+
+const BadgeTooltip = withStyles(() => {
+  return {
+    tooltip: {
+      backgroundColor: '#999',
+      fontSize: '1rem',
+    },
+  };
+})(Tooltip);
+
+interface IProfile {
+  autoScalingPolicy: string;
+  enablePredefinedAutoScaling: boolean;
+}
+
+interface IAutoScaleBadgeProps {
+  profile: IProfile;
+}
+
+const AutoScaleBadge = ({ profile }: IAutoScaleBadgeProps) => {
+  const hasAutoScaling =
+    (profile.autoScalingPolicy && profile.autoScalingPolicy !== '') ||
+    profile.enablePredefinedAutoScaling;
+  if (!hasAutoScaling) {
+    return null;
+  }
+  return (
+    <BadgeTooltip title={T.translate(`${PREFIX}.common.autoScaleTooltip`)}>
+      <Badge>{T.translate(`${PREFIX}.common.autoScaleBadge`)}</Badge>
+    </BadgeTooltip>
+  );
+};
+
+export default AutoScaleBadge;

--- a/app/cdap/components/Cloud/Profiles/CreateView/CreateProfileActionCreator.js
+++ b/app/cdap/components/Cloud/Profiles/CreateView/CreateProfileActionCreator.js
@@ -40,19 +40,22 @@ function initializeProperties(provisionerJson = {}) {
   }
   let configs = provisionerJson['configuration-groups'] || [];
   let properties = {};
+  const values = {};
   configs.forEach((config) => {
     config.properties.forEach((prop) => {
       let widgetAttributes = prop['widget-attributes'] || {};
+      const value = widgetAttributes.default || '';
       properties[prop.name] = {
-        value: widgetAttributes.default || '',
+        value,
         isEditable: true,
         required: prop.required || false,
       };
+      values[prop.name] = value;
     });
   });
   CreateProfileStore.dispatch({
     type: ACTIONS.initializeProperties,
-    payload: { properties },
+    payload: { properties, values },
   });
 }
 

--- a/app/cdap/components/Cloud/Profiles/CreateView/CreateProfileStore.js
+++ b/app/cdap/components/Cloud/Profiles/CreateView/CreateProfileStore.js
@@ -30,6 +30,7 @@ const STORE_DEFAULT = {
   name: '',
   description: '',
   properties: {},
+  values: {},
 };
 const createProfileStore = (state = STORE_DEFAULT, action = defaultAction) => {
   switch (action.type) {
@@ -50,6 +51,7 @@ const createProfileStore = (state = STORE_DEFAULT, action = defaultAction) => {
       return {
         ...state,
         properties: action.payload.properties,
+        values: action.payload.values,
       };
     case ACTIONS.updateProperty:
       return {
@@ -60,6 +62,10 @@ const createProfileStore = (state = STORE_DEFAULT, action = defaultAction) => {
             ...state.properties[action.payload.propName],
             value: action.payload.propValue,
           },
+        },
+        values: {
+          ...state.values,
+          [action.payload.propName]: action.payload.propValue,
         },
       };
     case ACTIONS.togglePropertyLock:

--- a/app/cdap/components/Cloud/Profiles/CreateView/PropertyRow/index.tsx
+++ b/app/cdap/components/Cloud/Profiles/CreateView/PropertyRow/index.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React from 'react';
+import PropertyLock from 'components/Cloud/Profiles/CreateView/PropertyLock';
+import WidgetWrapper from 'components/shared/ConfigurationGroup/WidgetWrapper';
+import { isEmpty, isEqual, xorWith } from 'lodash';
+import { objectQuery } from 'services/helpers';
+import { IPluginProperty } from 'components/shared/ConfigurationGroup/types';
+import { IErrorObj } from 'components/shared/ConfigurationGroup/utilities';
+
+interface IPropertyRowProps {
+  properties: { [key: string]: any };
+  property: IPluginProperty;
+  onChange: (values, params?: { [key: string]: any }) => void;
+  extraConfig: any;
+  errors?: IErrorObj[];
+}
+
+const PropertyRowWrapper = ({ properties, property, onChange, extraConfig }: IPropertyRowProps) => {
+  return (
+    <div className="property-row">
+      <WidgetWrapper
+        pluginProperty={{
+          name: property.name,
+          required: !!property.required,
+          description: property.description,
+        }}
+        widgetProperty={property}
+        value={objectQuery(properties, property.name, 'value')}
+        onChange={onChange}
+        extraConfig={extraConfig}
+        size={objectQuery(property, 'widget-attributes', 'size')}
+      />
+      <PropertyLock propertyName={property.name} />
+    </div>
+  );
+};
+
+const PropertyRow = React.memo(PropertyRowWrapper, (prevProps, nextProps) => {
+  const prevVal = objectQuery(prevProps.properties, prevProps.property.name, 'value');
+  const curVal = objectQuery(nextProps.properties, nextProps.property.name, 'value');
+  const rule =
+    prevVal === curVal &&
+    nextProps.property['widget-type'] === prevProps.property['widget-type'] &&
+    prevProps.extraConfig.properties === nextProps.extraConfig.properties;
+  // Comparison of array of objects
+  const isArrayEqual = (x: IErrorObj[], y: IErrorObj[]) => isEmpty(xorWith(x, y, isEqual));
+  const errorChange = isArrayEqual(nextProps.errors, prevProps.errors);
+  return rule && errorChange;
+});
+
+export default PropertyRow;

--- a/app/cdap/components/Cloud/Profiles/CreateView/PropertyRow/index.tsx
+++ b/app/cdap/components/Cloud/Profiles/CreateView/PropertyRow/index.tsx
@@ -16,11 +16,11 @@
 
 import React from 'react';
 import PropertyLock from 'components/Cloud/Profiles/CreateView/PropertyLock';
-import WidgetWrapper from 'components/shared/ConfigurationGroup/WidgetWrapper';
+import WidgetWrapper from 'components/ConfigurationGroup/WidgetWrapper';
 import { isEmpty, isEqual, xorWith } from 'lodash';
 import { objectQuery } from 'services/helpers';
-import { IPluginProperty } from 'components/shared/ConfigurationGroup/types';
-import { IErrorObj } from 'components/shared/ConfigurationGroup/utilities';
+import { IPluginProperty } from 'components/ConfigurationGroup/types';
+import { IErrorObj } from 'components/ConfigurationGroup/utilities';
 
 interface IPropertyRowProps {
   properties: { [key: string]: any };

--- a/app/cdap/components/Cloud/Profiles/CreateView/index.js
+++ b/app/cdap/components/Cloud/Profiles/CreateView/index.js
@@ -45,8 +45,8 @@ import Helmet from 'react-helmet';
 import T from 'i18n-react';
 import { SCOPES, SYSTEM_NAMESPACE } from 'services/global-constants';
 import { Theme } from 'services/ThemeHelper';
-import If from 'components/shared/If';
-import { filterByCondition } from 'components/shared/ConfigurationGroup/utilities/DynamicPluginFilters';
+import If from 'components/If';
+import { filterByCondition } from 'components/ConfigurationGroup/utilities/DynamicPluginFilters';
 
 const PREFIX = 'features.Cloud.Profiles.CreateView';
 

--- a/app/cdap/components/Cloud/Profiles/CreateView/index.js
+++ b/app/cdap/components/Cloud/Profiles/CreateView/index.js
@@ -27,7 +27,6 @@ import ProvisionerInfoStore from 'components/Cloud/Store';
 import { fetchProvisionerSpec } from 'components/Cloud/Store/ActionCreator';
 import { ADMIN_CONFIG_ACCORDIONS } from 'components/Administration/AdminConfigTabContent';
 import { EntityTopPanel } from 'components/EntityTopPanel';
-import PropertyLock from 'components/Cloud/Profiles/CreateView/PropertyLock';
 import {
   ConnectedProfileName,
   ConnectedProfileDescription,
@@ -39,15 +38,15 @@ import {
   resetCreateProfileStore,
 } from 'components/Cloud/Profiles/CreateView/CreateProfileActionCreator';
 import CreateProfileBtn from 'components/Cloud/Profiles/CreateView/CreateProfileBtn';
-import uuidV4 from 'uuid/v4';
 import CreateProfileStore from 'components/Cloud/Profiles/CreateView/CreateProfileStore';
+import PropertyRow from 'components/Cloud/Profiles/CreateView/PropertyRow';
 import { highlightNewProfile } from 'components/Cloud/Profiles/Store/ActionCreator';
 import Helmet from 'react-helmet';
 import T from 'i18n-react';
 import { SCOPES, SYSTEM_NAMESPACE } from 'services/global-constants';
 import { Theme } from 'services/ThemeHelper';
-import WidgetWrapper from 'components/ConfigurationGroup/WidgetWrapper';
-import If from 'components/If';
+import If from 'components/shared/If';
+import { filterByCondition } from 'components/shared/ConfigurationGroup/utilities/DynamicPluginFilters';
 
 const PREFIX = 'features.Cloud.Profiles.CreateView';
 
@@ -70,11 +69,13 @@ class ProfileCreateView extends Component {
     creatingProfile: false,
     isSystem: objectQuery(this.props.match, 'params', 'namespace') === SYSTEM_NAMESPACE,
     selectedProvisioner: objectQuery(this.props.match, 'params', 'provisionerId'),
+    filteredConfigurationGroup: [],
   };
 
   componentWillReceiveProps(nextProps) {
     let { selectedProvisioner } = this.state;
     initializeProperties(nextProps.provisionerJsonSpecMap[selectedProvisioner]);
+    this.setFilteredConfigurationGroup(nextProps);
   }
 
   componentDidMount() {
@@ -109,18 +110,27 @@ class ProfileCreateView extends Component {
     if (properties['projectId'] && properties['projectId'].value === '') {
       delete properties['projectId'];
     }
+    // Add only fields that are shown to the users.
+    const visibilityMap = {};
+    for (const groupInfo of this.state.filteredConfigurationGroup) {
+      for (const propertyInfo of groupInfo.properties) {
+        visibilityMap[propertyInfo.name] = propertyInfo.show !== false;
+      }
+    }
     let jsonBody = {
       description,
       label,
       provisioner: {
         name: this.state.selectedProvisioner,
-        properties: Object.entries(properties).map(([property, propObj]) => {
-          return {
-            name: property,
-            value: propObj.value,
-            isEditable: propObj.isEditable,
-          };
-        }),
+        properties: Object.entries(properties)
+          .filter(([property]) => visibilityMap[property])
+          .map(([property, propObj]) => {
+            return {
+              name: property,
+              value: propObj.value,
+              isEditable: propObj.isEditable,
+            };
+          }),
       },
     };
     let apiObservable$ = MyCloudApi.create;
@@ -157,6 +167,44 @@ class ProfileCreateView extends Component {
     );
   };
 
+  setFilteredConfigurationGroup(props) {
+    const { selectedProvisioner } = this.state;
+    const { values } = CreateProfileStore.getState();
+    const configurationGroups = objectQuery(
+      props,
+      'provisionerJsonSpecMap',
+      selectedProvisioner,
+      'configuration-groups'
+    );
+    const filters = objectQuery(props, 'provisionerJsonSpecMap', selectedProvisioner, 'filters');
+    if (!configurationGroups) {
+      this.setState({
+        filteredConfigurationGroup: [],
+      });
+    } else {
+      let filteredConfigurationGroup = configurationGroups;
+      if (filters && filters.length > 0) {
+        filteredConfigurationGroup = filterByCondition(
+          configurationGroups,
+          {
+            'configuration-groups': configurationGroups,
+            filters,
+          },
+          {},
+          values
+        );
+      }
+      this.setState({
+        filteredConfigurationGroup,
+      });
+    }
+  }
+
+  onUpdateProperty(property, value) {
+    updateProperty(property, value);
+    this.setFilteredConfigurationGroup(this.props);
+  }
+
   renderProfileName = () => {
     return (
       <div className="property-row">
@@ -182,6 +230,9 @@ class ProfileCreateView extends Component {
   };
 
   renderGroup = (group) => {
+    if (group.show === false) {
+      return null;
+    }
     let { properties } = CreateProfileStore.getState();
     const extraConfig = {
       namespace: this.state.isSystem ? SYSTEM_NAMESPACE : getCurrentNamespace(),
@@ -194,24 +245,17 @@ class ProfileCreateView extends Component {
         <div className="group-description">{group.description}</div>
         <div className="fields-container">
           {group.properties.map((property) => {
-            let uniqueId = `provisioner-${uuidV4()}`;
-
+            if (property.show === false) {
+              return null;
+            }
             return (
-              <div key={uniqueId} className="property-row">
-                <WidgetWrapper
-                  pluginProperty={{
-                    name: property.name,
-                    required: !!property.required,
-                    description: property.description,
-                  }}
-                  widgetProperty={property}
-                  value={objectQuery(properties, property.name, 'value')}
-                  onChange={updateProperty.bind(null, property.name)}
-                  extraConfig={extraConfig}
-                  size={objectQuery(property, 'widget-attributes', 'size')}
-                />
-                <PropertyLock propertyName={property.name} />
-              </div>
+              <PropertyRow
+                key={property.name}
+                property={property}
+                properties={properties}
+                onChange={this.onUpdateProperty.bind(this, property.name)}
+                extraConfig={extraConfig}
+              />
             );
           })}
         </div>
@@ -220,17 +264,10 @@ class ProfileCreateView extends Component {
   };
 
   renderGroups = () => {
-    let { selectedProvisioner } = this.state;
-    let configurationGroups = objectQuery(
-      this.props,
-      'provisionerJsonSpecMap',
-      selectedProvisioner,
-      'configuration-groups'
-    );
-    if (!configurationGroups) {
+    if (this.state.filteredConfigurationGroup.length === 0) {
       return null;
     }
-    return configurationGroups.map((group) => this.renderGroup(group));
+    return this.state.filteredConfigurationGroup.map((group) => this.renderGroup(group));
   };
 
   render() {

--- a/app/cdap/components/Cloud/Profiles/DetailView/Content/BasicInfo/index.js
+++ b/app/cdap/components/Cloud/Profiles/DetailView/Content/BasicInfo/index.js
@@ -31,6 +31,7 @@ import {
   deleteProfile,
 } from 'components/Cloud/Profiles/Store/ActionCreator';
 import ProfileStatusToggle from 'components/Cloud/Profiles/DetailView/Content/BasicInfo/ProfileStatusToggle';
+import AutoScaleBadge from 'components/Cloud/Profiles/AutoScaleBadge';
 import { CLOUD, SYSTEM_NAMESPACE } from 'services/global-constants';
 import { humanReadableDate } from 'services/helpers';
 import CopyableId from 'components/CopyableID';
@@ -150,6 +151,7 @@ export default class ProfileDetailViewBasicInfo extends Component {
           <div className="grid-header">
             <div className="grid-row">
               <strong>{T.translate(`${PREFIX}.common.provisioner`)}</strong>
+              <strong>{T.translate(`${PREFIX}.common.totalWorkerCores`)}</strong>
               <strong>{T.translate('commons.scope')}</strong>
               <strong>{T.translate(`${PREFIX}.common.last24HrRuns`)}</strong>
               <strong>{T.translate(`${PREFIX}.common.totalRuns`)}</strong>
@@ -163,6 +165,10 @@ export default class ProfileDetailViewBasicInfo extends Component {
               <div>
                 <IconSVG name="icon-cloud" />
                 <span>{this.state.provisionerLabel}</span>
+              </div>
+              <div>
+                {profile.provisioner.totalProcessingCpusLabel || '--'}
+                <AutoScaleBadge profile={profile} />
               </div>
               <div>{profile.scope}</div>
               <div>{this.state.oneDayMetrics.runs}</div>

--- a/app/cdap/components/Cloud/Profiles/ListView/ListView.scss
+++ b/app/cdap/components/Cloud/Profiles/ListView/ListView.scss
@@ -26,7 +26,7 @@ $disabled-color: $red-02;
   .grid.grid-container {
     max-height: none;
     .grid-row {
-      grid-template-columns: 70px 1.5fr 1.5fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 30px;
+      grid-template-columns: 70px 1.5fr 1.5fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 30px;
 
       .sortable-header {
         cursor: pointer;

--- a/app/cdap/components/Cloud/Profiles/ListView/index.js
+++ b/app/cdap/components/Cloud/Profiles/ListView/index.js
@@ -23,8 +23,9 @@ import classnames from 'classnames';
 import IconSVG from 'components/IconSVG';
 import LoadingSVG from 'components/LoadingSVG';
 import orderBy from 'lodash/orderBy';
-import ViewAllLabel from 'components/ViewAllLabel';
-import ConfirmationModal from 'components/ConfirmationModal';
+import ViewAllLabel from 'components/shared/ViewAllLabel';
+import ConfirmationModal from 'components/shared/ConfirmationModal';
+import AutoScaleBadge from 'components/Cloud/Profiles/AutoScaleBadge';
 import ProfilesStore, { PROFILE_STATUSES } from 'components/Cloud/Profiles/Store';
 import {
   getProfiles,
@@ -61,6 +62,10 @@ const PROFILES_TABLE_HEADERS = [
   {
     property: (profile) => profile.provisioner.label,
     label: T.translate(`${PREFIX}.common.provisioner`),
+  },
+  {
+    property: (profile) => profile.provisioner.totalProcessingCpusLabel,
+    label: T.translate(`${PREFIX}.common.totalWorkerCores`),
   },
   {
     property: 'scope',
@@ -357,6 +362,10 @@ class ProfilesListView extends Component {
           {profile.label || profile.name}
         </div>
         <div>{profile.provisioner.label}</div>
+        <div>
+          {profile.provisioner.totalProcessingCpusLabel || '--'}
+          <AutoScaleBadge profile={profile} />
+        </div>
         <div>{profile.scope}</div>
         {/*
           We should set the defaults in the metrics call but since it is not certain that we get metrics

--- a/app/cdap/components/Cloud/Profiles/ListView/index.js
+++ b/app/cdap/components/Cloud/Profiles/ListView/index.js
@@ -23,8 +23,8 @@ import classnames from 'classnames';
 import IconSVG from 'components/IconSVG';
 import LoadingSVG from 'components/LoadingSVG';
 import orderBy from 'lodash/orderBy';
-import ViewAllLabel from 'components/shared/ViewAllLabel';
-import ConfirmationModal from 'components/shared/ConfirmationModal';
+import ViewAllLabel from 'components/ViewAllLabel';
+import ConfirmationModal from 'components/ConfirmationModal';
 import AutoScaleBadge from 'components/Cloud/Profiles/AutoScaleBadge';
 import ProfilesStore, { PROFILE_STATUSES } from 'components/Cloud/Profiles/Store';
 import {

--- a/app/cdap/components/PipelineConfigurations/PipelineConfigurations.scss
+++ b/app/cdap/components/PipelineConfigurations/PipelineConfigurations.scss
@@ -16,7 +16,7 @@
 
 @import "../../styles/variables.scss";
 
-$modeless-width: 830px;
+$modeless-width: 980px;
 $modeless-height: 450px;
 $top-panel-height: 54px;
 $right-position: -360px;

--- a/app/cdap/components/PipelineConfigurations/index.js
+++ b/app/cdap/components/PipelineConfigurations/index.js
@@ -44,7 +44,7 @@ const TABS = {
     id: 1,
     name: T.translate(`${PREFIX}.ComputeConfig.title`),
     content: <ComputeTabContent />,
-    contentClassName: 'pipeline-configurations-body',
+    contentClassName: 'pipeline-configurations-body compute-profile-tab',
     paneClassName: 'configuration-content',
   },
   pipelineConfig: {

--- a/app/cdap/components/PipelineDetails/PipelineModeless/PipelineModeless.scss
+++ b/app/cdap/components/PipelineDetails/PipelineModeless/PipelineModeless.scss
@@ -16,7 +16,7 @@
 
 @import '../../../styles/variables.scss';
 
-$modeless-width: 730px;
+$modeless-width: 880px;
 $sidepanel-width: 170px;
 $modeless-header-height: 60px;
 $header-close-icon-size: 16px;
@@ -148,6 +148,13 @@ $header-close-icon-size: 16px;
               font-size: 14px;
               position: relative;
               text-align: left;
+            }
+          }
+          &.tab-content {
+            &.compute-profile-tab {
+              .tab-pane {
+                margin: 10px;
+              }
             }
           }
         }

--- a/app/cdap/components/PipelineDetails/ProfilesListView/ProfileCustomizePopover/ProfileCustomizeContent/index.js
+++ b/app/cdap/components/PipelineDetails/ProfilesListView/ProfileCustomizePopover/ProfileCustomizeContent/index.js
@@ -24,7 +24,7 @@ import IconSVG from 'components/IconSVG';
 import cloneDeep from 'lodash/cloneDeep';
 import classnames from 'classnames';
 import ProfilePropertyRow from 'components/PipelineDetails/ProfilesListView/ProfileCustomizePopover/ProfilePropertyRow';
-import { filterByCondition } from 'components/shared/ConfigurationGroup/utilities/DynamicPluginFilters';
+import { filterByCondition } from 'components/ConfigurationGroup/utilities/DynamicPluginFilters';
 import { objectQuery } from 'services/helpers';
 
 require('./ProfileCustomizeContent.scss');
@@ -79,15 +79,16 @@ export default class ProfileCustomizeContent extends PureComponent {
   }
 
   getDefaultValues() {
-    const { editablePropertiesFromProfile } = this.props;
     const values = {};
-    editablePropertiesFromProfile.forEach((property) => {
-      if (property.name in this.props.customizations) {
-        values[property.name] = this.props.customizations[property.name];
-      } else {
-        values[property.name] = property.value;
-      }
-    });
+    this.props.provisioner.properties
+      .filter((property) => property.isEditable !== false)
+      .forEach((property) => {
+        if (property.name in this.props.customizations) {
+          values[property.name] = this.props.customizations[property.name];
+        } else {
+          values[property.name] = property.value;
+        }
+      });
     return values;
   }
 
@@ -143,7 +144,6 @@ export default class ProfileCustomizeContent extends PureComponent {
   };
 
   render() {
-    const { editablePropertiesFromProfile } = this.props;
     if (this.state.loading) {
       return (
         <div className="profile-customize-content">
@@ -151,7 +151,10 @@ export default class ProfileCustomizeContent extends PureComponent {
         </div>
       );
     }
-    let groups = this.state.filteredConfigurationGroup;
+    const groups = this.state.filteredConfigurationGroup;
+    const editablePropertiesFromProfile = this.props.provisioner.properties.filter(
+      (property) => property.isEditable !== false
+    );
 
     const propertiesFromProfileMap = {};
     this.props.provisioner.properties.forEach((property) => {

--- a/app/cdap/components/PipelineDetails/ProfilesListView/ProfileCustomizePopover/ProfilePropertyRow/index.tsx
+++ b/app/cdap/components/PipelineDetails/ProfilesListView/ProfileCustomizePopover/ProfilePropertyRow/index.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React from 'react';
+import { WrappedWidgetWrapper } from 'components/shared/ConfigurationGroup/WidgetWrapper';
+import { IPluginProperty } from 'components/shared/ConfigurationGroup/types';
+
+interface IPropertyRowProps {
+  value: any;
+  property: IPluginProperty;
+  onChange: (values, params?: { [key: string]: any }) => void;
+}
+
+const PropertyRowWrapper = ({ property, value, onChange }: IPropertyRowProps) => {
+  return (
+    <div className="profile-group-content">
+      <div>
+        <WrappedWidgetWrapper
+          pluginProperty={{
+            name: property.name,
+            description: property.description,
+            required: property.required,
+          }}
+          widgetProperty={property}
+          value={value}
+          onChange={onChange}
+        />
+      </div>
+    </div>
+  );
+};
+
+const ProfilePropertyRow = React.memo(PropertyRowWrapper, (prevProps, nextProps) => {
+  return (
+    prevProps.value === nextProps.value &&
+    prevProps.property['widget-type'] === nextProps.property['widget-type']
+  );
+});
+
+export default ProfilePropertyRow;

--- a/app/cdap/components/PipelineDetails/ProfilesListView/ProfileCustomizePopover/ProfilePropertyRow/index.tsx
+++ b/app/cdap/components/PipelineDetails/ProfilesListView/ProfileCustomizePopover/ProfilePropertyRow/index.tsx
@@ -15,8 +15,8 @@
  */
 
 import React from 'react';
-import { WrappedWidgetWrapper } from 'components/shared/ConfigurationGroup/WidgetWrapper';
-import { IPluginProperty } from 'components/shared/ConfigurationGroup/types';
+import { WrappedWidgetWrapper } from 'components/ConfigurationGroup/WidgetWrapper';
+import { IPluginProperty } from 'components/ConfigurationGroup/types';
 
 interface IPropertyRowProps {
   value: any;

--- a/app/cdap/components/PipelineDetails/ProfilesListView/ProfilesListViewInPipeline.scss
+++ b/app/cdap/components/PipelineDetails/ProfilesListView/ProfilesListViewInPipeline.scss
@@ -49,8 +49,9 @@ $enabled-color: $green-02;
     max-height: calc(100% - 50px); // 100% - 17px (title) - 30px (profile count)
 
     .grid-row {
-      grid-template-columns: 30px 1.5fr 1.5fr 1fr 70px 1fr 50px;
-      align-items: start;
+      grid-template-columns: 30px 1.3fr 1fr 1.3fr 0.8fr 70px 1fr 50px;
+      align-items: center;
+      white-space: nowrap;
 
       &.enabled {
         .profile-status {

--- a/app/cdap/components/PipelineDetails/ProfilesListView/index.js
+++ b/app/cdap/components/PipelineDetails/ProfilesListView/index.js
@@ -25,6 +25,7 @@ import { MyPreferenceApi } from 'api/preference';
 import { Observable } from 'rxjs/Observable';
 import PipelineDetailStore from 'components/PipelineDetails/store';
 import ProfileCustomizePopover from 'components/PipelineDetails/ProfilesListView/ProfileCustomizePopover';
+import AutoScaleBadge from 'components/Cloud/Profiles/AutoScaleBadge';
 import { isNilOrEmpty } from 'services/helpers';
 import isEqual from 'lodash/isEqual';
 import { getCustomizationMap } from 'components/PipelineConfigurations/Store/ActionCreator';
@@ -174,6 +175,7 @@ export default class ProfilesListViewInPipeline extends Component {
           <div />
           <strong>{T.translate('features.Cloud.Profiles.ListView.profileName')}</strong>
           <strong>{T.translate('features.Cloud.Profiles.common.provisioner')}</strong>
+          <strong>{T.translate('features.Cloud.Profiles.common.totalWorkerCores')}</strong>
           <strong>{T.translate('commons.scope')}</strong>
           <strong>{T.translate('commons.status')}</strong>
           <strong />
@@ -243,6 +245,10 @@ export default class ProfilesListViewInPipeline extends Component {
           {profileLabel}
         </div>
         <div onClick={onProfileSelectHandler}>{provisionerLabel}</div>
+        <div onClick={onProfileSelectHandler}>
+          {profile.provisioner.totalProcessingCpusLabel || '--'}
+          <AutoScaleBadge profile={profile} />
+        </div>
         <div onClick={onProfileSelectHandler}>{profile.scope}</div>
         <div className="profile-status" onClick={onProfileSelectHandler}>
           {T.translate(`features.Cloud.Profiles.common.${profileStatus}`)}

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -246,6 +246,9 @@ features:
         provisioner: Provisioner
         totalNodeHr: Total node hours
         totalRuns: Total runs
+        totalWorkerCores: Total worker cores
+        autoScaleBadge: Auto
+        autoScaleTooltip: AutoScaling of worker nodes is enabled.
       CreateView:
         ProvisionerSelection:
           pageTitle: '{productName} | Profiles | Create'


### PR DESCRIPTION
# Auto-scaling as an alternative compute Profile

## Description
1) Adds total worker cores column in compute profile list.
2) Adds dynamic fields support in create compute profile page.
3) Adds dynamic fields support in pipeline level profile customisation page.

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [18753](https://cdap.atlassian.net/browse/CDAP-18753)


