### PR TITLE
[CDAP-18795] Use preview max limit setting from cConf

### DIFF
--- a/app/hydrator/services/create/stores/config-store.js
+++ b/app/hydrator/services/create/stores/config-store.js
@@ -582,7 +582,11 @@ class HydratorPlusPlusConfigStore {
   }
   setNumRecordsPreview(val = this.HYDRATOR_DEFAULT_VALUES.numOfRecordsPreview) {
     if (this.GLOBALS.etlBatchPipelines.includes(this.state.artifact.name)) {
-      this.state.config.numOfRecordsPreview = val;
+      // Cap preview at configured max, if there is one
+      this.state.config.numOfRecordsPreview = Math.min(
+        window.CDAP_CONFIG.cdap.maxRecordsPreview || Infinity,
+        val
+      );
     }
   }
   getRangeRecordsPreview() {
@@ -592,7 +596,11 @@ class HydratorPlusPlusConfigStore {
     if (this.GLOBALS.etlBatchPipelines.includes(this.state.artifact.name)) {
       this.state.config.rangeRecordsPreview = {
         min: minRecordsPreview,
-        max: maxRecordsPreview,
+        // Cap range max at configured max, if there is one
+        max: Math.min(
+          window.CDAP_CONFIG.cdap.maxRecordsPreview || Infinity,
+          maxRecordsPreview
+        ),
       };
     }
   }

--- a/server/express.js
+++ b/server/express.js
@@ -189,6 +189,7 @@ function makeApp(authAddress, cdapConfig, uiSettings) {
         uiDebugEnabled: uiSettings['ui.debug.enabled'] === 'true' || false,
         mode: process.env.NODE_ENV,
         proxyBaseUrl: cdapConfig['dashboard.proxy.base.url'],
+        maxRecordsPreview: cdapConfig['preview.max.num.records'],
       },
       hydrator: {
         previewEnabled: cdapConfig['enable.preview'] === 'true',


### PR DESCRIPTION
# [CDAP-18795] Use preview max limit setting from cConf

## Description

This caps the maximum preview rows based on the `preview.max.num.records` configuration. The maximum row count will be the setting or `5000`, whichever is lower.

## PR Type
- [ ] Bug Fix
- [X] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-18795](https://cdap.atlassian.net/browse/CDAP-18795)

## Test Plan

Testing done:
* Setting less than hard-coded max (5000) and default row setting (100)
* Setting more than default row setting and less than hard-coded max
* No setting present
* Open preview config
* Don't open preview config; just run preview

## Screenshots

![image](https://user-images.githubusercontent.com/2728821/152258247-244ad886-a82b-48f6-aeb8-6fe97853d547.png)
`"preview.max.num.records": 50`




[CDAP-18795]: https://cdap.atlassian.net/browse/CDAP-18795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ