### PR TITLE
[CDAP-18795] Use preview max limit setting from cConf for 6.6

### DIFF
--- a/app/hydrator/services/create/stores/config-store.js
+++ b/app/hydrator/services/create/stores/config-store.js
@@ -570,7 +570,11 @@ class HydratorPlusPlusConfigStore {
   }
   setNumRecordsPreview(val = this.HYDRATOR_DEFAULT_VALUES.numOfRecordsPreview) {
     if (this.GLOBALS.etlBatchPipelines.includes(this.state.artifact.name)) {
-      this.state.config.numOfRecordsPreview = val;
+      // Cap preview at configured max, if there is one
+      this.state.config.numOfRecordsPreview = Math.min(
+        window.CDAP_CONFIG.cdap.maxRecordsPreview || Infinity,
+        val
+      );
     }
   }
   getRangeRecordsPreview() {
@@ -580,7 +584,11 @@ class HydratorPlusPlusConfigStore {
     if (this.GLOBALS.etlBatchPipelines.includes(this.state.artifact.name)) {
       this.state.config.rangeRecordsPreview = {
         min: minRecordsPreview,
-        max: maxRecordsPreview,
+        // Cap range max at configured max, if there is one
+        max: Math.min(
+          window.CDAP_CONFIG.cdap.maxRecordsPreview || Infinity,
+          maxRecordsPreview
+        ),
       };
     }
   }

--- a/server/express.js
+++ b/server/express.js
@@ -186,6 +186,7 @@ function makeApp(authAddress, cdapConfig, uiSettings) {
         uiDebugEnabled: uiSettings['ui.debug.enabled'] === 'true' || false,
         mode: process.env.NODE_ENV,
         proxyBaseUrl: cdapConfig['dashboard.proxy.base.url'],
+        maxRecordsPreview: cdapConfig['preview.max.num.records'],
       },
       hydrator: {
         previewEnabled: cdapConfig['enable.preview'] === 'true',


### PR DESCRIPTION
# [CDAP-18795] Use preview max limit setting from cConf. Cherry pick of #332 

## Description
This caps the maximum preview rows based on the preview.max.num.records configuration. The maximum row count will be the setting or 5000, whichever is lower.

## PR Type
- [ ] Bug Fix
- [X] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-18795](https://cdap.atlassian.net/browse/CDAP-18795)

## Test Plan
See #332 

## Screenshots
See #332 




[CDAP-18795]: https://cdap.atlassian.net/browse/CDAP-18795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ