### PR TITLE
Fixes the logic to show auto scale badge in profile list/details page

### DIFF
--- a/app/cdap/components/Cloud/Profiles/AutoScaleBadge/index.tsx
+++ b/app/cdap/components/Cloud/Profiles/AutoScaleBadge/index.tsx
@@ -42,19 +42,22 @@ const BadgeTooltip = withStyles(() => {
   };
 })(Tooltip);
 
-interface IProfile {
-  autoScalingPolicy: string;
-  enablePredefinedAutoScaling: boolean;
+interface IProperty {
+  name: string;
+  value: string;
+  isEditable: boolean;
 }
 
 interface IAutoScaleBadgeProps {
-  profile: IProfile;
+  properties: IProperty[];
 }
 
-const AutoScaleBadge = ({ profile }: IAutoScaleBadgeProps) => {
-  const hasAutoScaling =
-    (profile.autoScalingPolicy && profile.autoScalingPolicy !== '') ||
-    profile.enablePredefinedAutoScaling;
+const AutoScaleBadge = ({ properties = [] }: IAutoScaleBadgeProps) => {
+  const hasAutoScaling = properties.some(
+    (property) =>
+      (property.name === 'autoScalingPolicy' && property.value !== '') ||
+      (property.name === 'enablePredefinedAutoScaling' && property.value === 'true')
+  );
   if (!hasAutoScaling) {
     return null;
   }

--- a/app/cdap/components/Cloud/Profiles/DetailView/Content/BasicInfo/index.js
+++ b/app/cdap/components/Cloud/Profiles/DetailView/Content/BasicInfo/index.js
@@ -168,7 +168,7 @@ export default class ProfileDetailViewBasicInfo extends Component {
               </div>
               <div>
                 {profile.provisioner.totalProcessingCpusLabel || '--'}
-                <AutoScaleBadge profile={profile} />
+                <AutoScaleBadge properties={profile.provisioner.properties} />
               </div>
               <div>{profile.scope}</div>
               <div>{this.state.oneDayMetrics.runs}</div>

--- a/app/cdap/components/Cloud/Profiles/ListView/index.js
+++ b/app/cdap/components/Cloud/Profiles/ListView/index.js
@@ -364,7 +364,7 @@ class ProfilesListView extends Component {
         <div>{profile.provisioner.label}</div>
         <div>
           {profile.provisioner.totalProcessingCpusLabel || '--'}
-          <AutoScaleBadge profile={profile} />
+          <AutoScaleBadge properties={profile.provisioner.properties} />
         </div>
         <div>{profile.scope}</div>
         {/*

--- a/app/cdap/components/PipelineDetails/ProfilesListView/index.js
+++ b/app/cdap/components/PipelineDetails/ProfilesListView/index.js
@@ -247,7 +247,7 @@ export default class ProfilesListViewInPipeline extends Component {
         <div onClick={onProfileSelectHandler}>{provisionerLabel}</div>
         <div onClick={onProfileSelectHandler}>
           {profile.provisioner.totalProcessingCpusLabel || '--'}
-          <AutoScaleBadge profile={profile} />
+          <AutoScaleBadge properties={profile.provisioner.properties} />
         </div>
         <div onClick={onProfileSelectHandler}>{profile.scope}</div>
         <div className="profile-status" onClick={onProfileSelectHandler}>


### PR DESCRIPTION
# Fixes the logic to show auto scale badge in profile list/details page

## Description
Fetches properties from provisioner.properties array instead of profile level.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [18818](https://cdap.atlassian.net/browse/CDAP-18818)



