### PR TITLE
[CDAP-18816] Allow max preview rows config to override hard-coded limit

### DIFF
--- a/app/hydrator/services/create/stores/config-store.js
+++ b/app/hydrator/services/create/stores/config-store.js
@@ -108,8 +108,8 @@ class HydratorPlusPlusConfigStore {
         this.setServiceAccountPath(this.state.config.serviceAccountPath || '');
       } else {
         this.setEngine(this.state.config.engine);
-        this.setNumRecordsPreview(this.state.config.numOfRecordsPreview);
         this.setRangeRecordsPreview(this.state.artifact.config || {});
+        this.setNumRecordsPreview(this.state.config.numOfRecordsPreview);
         this.setMaxConcurrentRuns(this.state.config.maxConcurrentRuns);
       }
     }
@@ -583,8 +583,9 @@ class HydratorPlusPlusConfigStore {
   setNumRecordsPreview(val = this.HYDRATOR_DEFAULT_VALUES.numOfRecordsPreview) {
     if (this.GLOBALS.etlBatchPipelines.includes(this.state.artifact.name)) {
       // Cap preview at configured max, if there is one
+      const { max } = this.getRangeRecordsPreview();
       this.state.config.numOfRecordsPreview = Math.min(
-        window.CDAP_CONFIG.cdap.maxRecordsPreview || Infinity,
+        max,
         val
       );
     }
@@ -592,15 +593,14 @@ class HydratorPlusPlusConfigStore {
   getRangeRecordsPreview() {
     return this.getConfig().rangeRecordsPreview;
   }
-  setRangeRecordsPreview({minRecordsPreview = this.HYDRATOR_DEFAULT_VALUES.minRecordsPreview, maxRecordsPreview = this.HYDRATOR_DEFAULT_VALUES.maxRecordsPreview}) {
+  setRangeRecordsPreview({
+    minRecordsPreview = this.HYDRATOR_DEFAULT_VALUES.minRecordsPreview,
+    maxRecordsPreview = window.CDAP_CONFIG.cdap.maxRecordsPreview || this.HYDRATOR_DEFAULT_VALUES.maxRecordsPreview
+  }) {
     if (this.GLOBALS.etlBatchPipelines.includes(this.state.artifact.name)) {
       this.state.config.rangeRecordsPreview = {
         min: minRecordsPreview,
-        // Cap range max at configured max, if there is one
-        max: Math.min(
-          window.CDAP_CONFIG.cdap.maxRecordsPreview || Infinity,
-          maxRecordsPreview
-        ),
+        max: maxRecordsPreview,
       };
     }
   }


### PR DESCRIPTION
# [CDAP-18816] Allow max preview rows config to override hard-coded limit

## Description
Previously, a configured limit higher than 5000 was ignored. Now the configured limit can be greater than 5000.

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-18816](https://cdap.atlassian.net/browse/CDAP-18816)

## Test Plan
Tested with values: 50, 500, 6000, and not set.

## Screenshots
See #332 




[CDAP-18816]: https://cdap.atlassian.net/browse/CDAP-18816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ