### PR TITLE
Automatically fetch and load namespaces data

### DIFF
--- a/app/cdap/components/Administration/TetheringTabContent/Connections/ConnectionsTable.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/Connections/ConnectionsTable.tsx
@@ -27,7 +27,6 @@ import {
 } from '../shared.styles';
 import { ICONS, CONNECTIONS_TABLE_HEADERS, PREFIX, DESC_COLUMN_TEMPLATE } from './constants';
 import { IConnection, IConnectionsTableData } from '../types';
-import { formatAsPercentage } from 'services/DataFormatter';
 
 const getIconForStatus = (status: string) => {
   switch (status) {
@@ -99,8 +98,8 @@ const ConnectionsTable = ({
           <GridCell>{isFirst ? region : ''}</GridCell>
           <GridCell border={!isLast}>{namespace}</GridCell>
           <GridCell border={!isLast}>{pods}</GridCell>
-          <GridCell border={!isLast}>{cpuLimit && formatAsPercentage(cpuLimit)}</GridCell>
-          <GridCell border={!isLast}>{memoryLimit && formatAsPercentage(memoryLimit)}</GridCell>
+          <GridCell border={!isLast}>{cpuLimit}</GridCell>
+          <GridCell border={!isLast}>{memoryLimit}</GridCell>
           {isFirst && <GridCell lastCol={true}>{renderLastColumn(instanceName)}</GridCell>}
         </GridRow>
       );

--- a/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/CdfInfo.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/CdfInfo.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import T from 'i18n-react';
 import NewReqTextField from './NewReqTextField';
 import { NewReqContainer, HeaderTitle } from '../shared.styles';
-import { IErrorObj } from 'components/shared/ConfigurationGroup/utilities';
+import { IValidationErrors } from '../types';
 
 const I18NPREFIX = 'features.Administration.Tethering.CreateRequest';
 const I18N_CDF_PREFIX = `${I18NPREFIX}.CDFInformation`;
@@ -76,11 +76,7 @@ interface ICdfInfoProps {
   region?: string;
   instanceName?: string;
   broadcastChange: (target: string, value: string) => void;
-  validationErrors?: {
-    instanceName?: IErrorObj;
-    projectName?: IErrorObj;
-    region?: IErrorObj;
-  };
+  validationErrors?: IValidationErrors;
 }
 
 const CdfInfo = ({

--- a/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/NamespacesTable.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/NamespacesTable.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React from 'react';
+import styled from 'styled-components';
+import { Grid, GridHeader, GridBody, GridRow, GridCell, StyledCheckbox } from '../shared.styles';
+import { INamespace } from '../types';
+import {
+  OMNI_NS_COLUMN_TEMPLATE,
+  OMNI_NS_COLUMN_TEMPLATE_SCROLLABLE,
+  OMNI_NS_TABLE_HEADERS,
+} from './constants';
+
+interface INameSpacesTableProps {
+  tableData: INamespace[];
+  selectedNamespaces: string[];
+  broadcastChange: (ns: string) => void;
+}
+
+const StyledGrid = styled(Grid)`
+  padding: 0;
+  margin-bottom: 10px;
+`;
+
+const StyledGridBody = styled(GridBody)`
+  max-height: 150px;
+  overflow: auto;
+`;
+
+const renderTableHeader = (tableData: INamespace[]) => {
+  const columnTemplate =
+    tableData.length > 5 ? OMNI_NS_COLUMN_TEMPLATE_SCROLLABLE : OMNI_NS_COLUMN_TEMPLATE;
+  return (
+    <GridHeader>
+      <GridRow columnTemplate={columnTemplate}>
+        {OMNI_NS_TABLE_HEADERS.map((header, i) => {
+          return <GridCell key={i}>{header.label}</GridCell>;
+        })}
+      </GridRow>
+    </GridHeader>
+  );
+};
+
+const renderTableBody = (
+  data: INamespace[],
+  renderRowFn: (req: INamespace, idx: number) => React.ReactNode
+) => <StyledGridBody>{data.map((req, idx) => renderRowFn(req, idx))}</StyledGridBody>;
+
+const NameSpacesTable = ({
+  tableData,
+  selectedNamespaces,
+  broadcastChange,
+}: INameSpacesTableProps) => {
+  const renderRow = (req: INamespace, idx: number) => {
+    const { namespace, cpuLimit, memoryLimit } = req;
+
+    const handleCheckboxChange = (event) => {
+      broadcastChange(event.target.value);
+    };
+
+    return (
+      <GridRow columnTemplate={OMNI_NS_COLUMN_TEMPLATE} border={true} key={idx}>
+        <GridCell>
+          <StyledCheckbox
+            checked={selectedNamespaces.includes(namespace)}
+            color="primary"
+            value={namespace}
+            onChange={handleCheckboxChange}
+          />
+        </GridCell>
+        <GridCell>{namespace}</GridCell>
+        <GridCell>{cpuLimit}</GridCell>
+        <GridCell>{memoryLimit}</GridCell>
+      </GridRow>
+    );
+  };
+
+  return (
+    <StyledGrid>
+      {renderTableHeader(tableData)}
+      {renderTableBody(tableData, renderRow)}
+    </StyledGrid>
+  );
+};
+
+export default NameSpacesTable;

--- a/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/NewReqTextField.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/NewReqTextField.tsx
@@ -16,15 +16,12 @@
 
 import React from 'react';
 import styled from 'styled-components';
+import { ErrorText } from '../shared.styles';
 import WidgetWrapper from 'components/shared/ConfigurationGroup/WidgetWrapper';
 import { IErrorObj } from 'components/shared/ConfigurationGroup/utilities';
 
 const WidgetContainer = styled.div`
   margin-top: 40px;
-`;
-
-const ErrorText = styled.span`
-  color: ${(props) => props.theme.palette.red[50]};
 `;
 
 interface ITextboxProps {

--- a/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/OmniNamespaces.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/OmniNamespaces.tsx
@@ -16,76 +16,36 @@
 
 import React from 'react';
 import T from 'i18n-react';
-import NewReqTextField from './NewReqTextField';
-import { NewReqContainer, HeaderTitle } from '../shared.styles';
-
-const I18NPREFIX = 'features.Administration.Tethering.CreateRequest';
-const I18N_OMNI_PREFIX = `${I18NPREFIX}.OmniNamespaces`;
-
-const WIDGET_TYPE = 'widget-type';
-const WIDGET_ATTRIBUTES = 'widget-attributes';
-
-const ITEMS = [
-  {
-    widgetProperty: {
-      label: `${T.translate(`${I18N_OMNI_PREFIX}.Name.label`)}`,
-      name: `${T.translate(`${I18N_OMNI_PREFIX}.Name.name`)}`,
-      [WIDGET_TYPE]: 'textbox',
-    },
-  },
-  {
-    widgetProperty: {
-      label: `${T.translate(`${I18N_OMNI_PREFIX}.CpuLimit.label`)}`,
-      name: `${T.translate(`${I18N_OMNI_PREFIX}.CpuLimit.name`)}`,
-      [WIDGET_TYPE]: 'number',
-      [WIDGET_ATTRIBUTES]: {
-        min: 1,
-        max: 100,
-      },
-    },
-  },
-  {
-    widgetProperty: {
-      label: `${T.translate(`${I18N_OMNI_PREFIX}.MemoryLimit.label`)}`,
-      name: `${T.translate(`${I18N_OMNI_PREFIX}.MemoryLimit.name`)}`,
-      [WIDGET_TYPE]: 'number',
-      [WIDGET_ATTRIBUTES]: {
-        min: 1,
-        max: 100,
-      },
-    },
-  },
-];
-
-/*
- * Most of the code in this component will change once the backend server provides resources info
- * about available namespaces when creating new requests. The temp solution is to have users manually
- * enter that information
- */
+import { INamespace } from '../types';
+import { NewReqContainer, HeaderTitle, ErrorText } from '../shared.styles';
+import { I18N_OMNI_PREFIX } from './constants';
+import { IErrorObj } from 'components/shared/ConfigurationGroup/utilities';
+import NamespacesTable from './NamespacesTable';
 
 interface IOmniNamespacesProps {
-  name?: string;
-  cpuLimit?: string;
-  memoryLimit?: string;
-  broadcastChange: (target: string, value: string) => void;
+  namespaces: INamespace[];
+  selectedNamespaces: string[];
+  validationError: IErrorObj;
+  broadcastChange: (ns: string) => void;
 }
 
-const OmniNamespaces = ({ name, cpuLimit, memoryLimit, broadcastChange }: IOmniNamespacesProps) => {
-  const values = [name, cpuLimit, memoryLimit];
-
+const OmniNamespaces = ({
+  namespaces,
+  selectedNamespaces,
+  validationError,
+  broadcastChange,
+}: IOmniNamespacesProps) => {
   return (
     <NewReqContainer>
       <HeaderTitle>{T.translate(`${I18N_OMNI_PREFIX}.title`)}</HeaderTitle>
       <hr />
       <span>{T.translate(`${I18N_OMNI_PREFIX}.description`)}</span>
-      {ITEMS.map((item, idx) => (
-        <NewReqTextField
-          key={idx}
-          widgetProperty={item.widgetProperty}
-          value={values[idx]}
-          broadcastChange={broadcastChange}
-        />
-      ))}
+      <NamespacesTable
+        tableData={namespaces}
+        selectedNamespaces={selectedNamespaces}
+        broadcastChange={broadcastChange}
+      />
+      {validationError && <ErrorText>{validationError.msg}</ErrorText>}
     </NewReqContainer>
   );
 };

--- a/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/constants.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/constants.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React from 'react';
+import T from 'i18n-react';
+import { StyledCheckbox } from '../shared.styles';
+
+export const DEFAULT_NS = 'default';
+export const K8S_NS_NAME = 'k8s.namespace';
+export const K8S_NS_CPU_LIMITS = 'k8s.namespace.cpu.limits';
+export const K8S_NS_MEMORY_LIMITS = 'k8s.namespace.memory.limits';
+
+const I18NPREFIX = 'features.Administration.Tethering.CreateRequest';
+export const I18N_OMNI_PREFIX = `${I18NPREFIX}.OmniNamespaces`;
+export const OMNI_NS_COLUMN_TEMPLATE = '50px 4fr 2fr 3fr';
+export const OMNI_NS_COLUMN_TEMPLATE_SCROLLABLE = '50px 4fr 2fr 3fr 16px';
+
+export const OMNI_NS_TABLE_HEADERS = [
+  {
+    label: <StyledCheckbox checked={false} />,
+  },
+  {
+    property: 'namespace',
+    label: T.translate(`${I18N_OMNI_PREFIX}.Name.label`),
+  },
+  {
+    property: 'cpuLimit',
+    label: T.translate(`${I18N_OMNI_PREFIX}.CpuLimit.label`),
+  },
+  {
+    property: 'memoryLimit',
+    label: T.translate(`${I18N_OMNI_PREFIX}.MemoryLimit.label`),
+  },
+];

--- a/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/utils.ts
+++ b/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/utils.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import T from 'i18n-react';
+const I18NPREFIX = 'features.Administration.Tethering.CreateRequest';
+
+/**
+ * Function to ensure all user provided inputs are valid before submitting new thethering request
+ *
+ * @param selectedNamespaces - list of selected namespaces by user (at least one is required)
+ * @param projectName - Project Name of the CDF Instance (required)
+ * @param region - Region of the CDF Instance (required)
+ * @param instanceName - Instance Name of the CDF Instance (required)
+ * @returns { [{object}], boolean } - list of error objects to update UI with errors and whether all checks passed
+ */
+export const areInputsValid = ({ selectedNamespaces, projectName, region, instanceName }) => {
+  const requiredFields = [
+    { name: 'namespaces', val: selectedNamespaces.length },
+    { name: 'projectName', val: projectName },
+    { name: 'region', val: region },
+    { name: 'instanceName', val: instanceName },
+  ];
+  let allValid = true;
+  const errors = {};
+
+  requiredFields.forEach((field) => {
+    let errObj = {};
+    if (!field.val) {
+      const msg =
+        field.name === 'namespaces'
+          ? T.translate(`${I18NPREFIX}.nsValidationError`)
+          : T.translate(`${I18NPREFIX}.inputValidationError`, { fieldName: field.name });
+      errObj = {
+        msg,
+      };
+      allValid = false;
+    }
+    errors[field.name] = errObj;
+  });
+
+  return { errors, allValid };
+};

--- a/app/cdap/components/Administration/TetheringTabContent/RequestsTable/index.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/RequestsTable/index.tsx
@@ -18,7 +18,6 @@ import React from 'react';
 import T from 'i18n-react';
 import { Grid, GridHeader, GridBody, GridRow, GridCell, StyledButton } from '../shared.styles';
 import { IConnection, IReqsTableData } from '../types';
-import { formatAsPercentage } from 'services/DataFormatter';
 import { humanReadableDate } from 'services/helpers';
 
 const PREFIX = 'features.Administration.Tethering';
@@ -101,8 +100,8 @@ const RequestsTable = ({ tableData, columnTemplate, renderLastColumn }: IReqsTab
           <GridCell>{isFirst ? instanceName : ''}</GridCell>
           <GridCell>{isFirst ? region : ''}</GridCell>
           <GridCell border={!isLast}>{namespace}</GridCell>
-          <GridCell border={!isLast}>{cpuLimit && formatAsPercentage(cpuLimit)}</GridCell>
-          <GridCell border={!isLast}>{memoryLimit && formatAsPercentage(memoryLimit)}</GridCell>
+          <GridCell border={!isLast}>{cpuLimit}</GridCell>
+          <GridCell border={!isLast}>{memoryLimit}</GridCell>
           {isFirst && <GridCell lastCol={true}>{renderLastColumn(instanceName)}</GridCell>}
         </GridRow>
       );

--- a/app/cdap/components/Administration/TetheringTabContent/shared.styles.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/shared.styles.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import styled, { css } from 'styled-components';
-import Button from '@material-ui/core/Button';
+import { Button, Checkbox } from '@material-ui/core';
 import IconSVG from 'components/shared/IconSVG';
 
 export const HeaderContainer = styled.div`
@@ -172,4 +172,13 @@ export const LinedSpan = styled.span`
   &:after {
     margin-left: 15px;
   }
+`;
+
+export const StyledCheckbox = styled(Checkbox)`
+  padding: 0;
+  margin-top: -2px;
+`;
+
+export const ErrorText = styled.span`
+  color: ${(props) => props.theme.palette.red[50]};
 `;

--- a/app/cdap/components/Administration/TetheringTabContent/types.ts
+++ b/app/cdap/components/Administration/TetheringTabContent/types.ts
@@ -73,7 +73,14 @@ export interface IApiError {
 }
 
 export interface IValidationErrors {
+  namespaces?: IErrorObj;
   instanceName?: IErrorObj;
   projectName?: IErrorObj;
   region?: IErrorObj;
+}
+
+export interface INamespace {
+  namespace: string;
+  cpuLimit: number;
+  memoryLimit: number;
 }

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -202,7 +202,8 @@ features:
         cancelButton: Cancel
         success: Your request was created successfully
         failure: Failed to create request
-        validationError: Required field {fieldName} has no value
+        inputValidationError: Required field {fieldName} has no value
+        nsValidationError: At least one namespace must be selected
         OmniNamespaces:
           title: Omni Namespaces
           description: Select the namespaces that will be tethered to the cloud instance


### PR DESCRIPTION
# Auto Fetch Namespaces Data

## Description
This PR finishes the Omni namespace portion of creating a new tethering connection request. It fetches the list of available namespaces from a backend api instead asking the user to provide input.

## PR Type
- [ ] Bug Fix
- [X] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
N/A

## Test Plan

## Screenshots

![Screen Shot 2022-02-04 at 4 33 35 PM](https://user-images.githubusercontent.com/94018249/152620765-8300317f-f339-473b-8595-2ba548108895.png)

