### PR TITLE
Remove transformations when table is removed and other fixes

### DIFF
--- a/app/cdap/components/Replicator/Create/Content/Assessment/TablesAssessment/index.tsx
+++ b/app/cdap/components/Replicator/Create/Content/Assessment/TablesAssessment/index.tsx
@@ -14,7 +14,7 @@
  * the License.
  */
 
-import * as React from 'react';
+import React, { useEffect } from 'react';
 import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
 import If from 'components/shared/If';
 import Mappings from './Mappings';
@@ -55,7 +55,7 @@ const TablesAssessmentView: React.FC<ITablesAssessmentProps> = ({
   const [tablesNoIssues, setTablesNoIssues] = React.useState([]);
   const [haveMissingTables, setHaveMissingTables] = React.useState(0);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const updatedTablesWithIssues = [];
     const updatedTablesNoIssues = [];
 

--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/addToTransforms.ts
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/addToTransforms.ts
@@ -18,7 +18,7 @@ import { IColumnTransformation } from 'components/Replicator/types';
 
 export const addTinkToTransforms = (transform: IColumnTransformation): string => {
   const { columnName, directive } = transform;
-  return `TINK ${columnName} ${directive}`;
+  return `tink ${columnName} ${directive}`;
 };
 
 export const addRenameToTransforms = (transform: IColumnTransformation): string => {

--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/index.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/index.tsx
@@ -49,7 +49,7 @@ import { IconButton } from '@material-ui/core';
 
 const I18N_PREFIX = 'features.Replication.Create.Content.SelectColumns';
 
-const SelectColumnsView: React.FC<ISelectColumnsProps> = (props) => {
+const SelectColumnsView = (props: ISelectColumnsProps) => {
   const [state, dispatch] = useReducer(reducer, initialState);
 
   const getInitialSelectedColumns = (columns): Map<string, IColumnImmutable> => {

--- a/app/cdap/components/Replicator/Create/Content/SelectTables/ManualSelectTable/index.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectTables/ManualSelectTable/index.tsx
@@ -23,12 +23,14 @@ import { generateTableKey } from 'components/Replicator/utilities';
 import Heading, { HeadingTypes } from 'components/shared/Heading';
 import StepButtons from 'components/Replicator/Create/Content/StepButtons';
 import { List, Map } from 'immutable';
+import { useFeatureFlagDefaultTrue } from 'services/react/customHooks/useFeatureFlag';
 import {
   IDMLStore,
   IColumnsStore,
   ITableImmutable,
   ITablesStore,
 } from 'components/Replicator/types';
+import { useOnUnmount } from 'services/react/customHooks/useOnUnmount';
 
 const styles = (): StyleRules => {
   return {
@@ -83,6 +85,15 @@ const ManualSelectTableView: React.FC<IManualSelectTableProps> = ({
   const [database, setDatabase] = useState('');
   const [values, setValues] = useState([]);
   const [isInitFinished, setIsInitFinished] = useState(false);
+  const useReplicationTransformation = useFeatureFlagDefaultTrue(
+    'replication.transformations.enabled'
+  );
+
+  useOnUnmount(() => {
+    if (useReplicationTransformation) {
+      handleNext();
+    }
+  });
 
   useEffect(() => {
     const formattedValues = [];

--- a/app/cdap/components/Replicator/Create/Content/SelectTables/index.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectTables/index.tsx
@@ -27,7 +27,10 @@ import LoadingSVGCentered from 'components/shared/LoadingSVGCentered';
 import SelectColumns from 'components/Replicator/Create/Content/SelectColumns';
 import SelectColumnsWithTransforms from 'components/Replicator/Create/Content/SelectColumnsWithTransforms';
 import { extractErrorMessage } from 'services/helpers';
-import { generateTableKey, getTableDisplayName } from 'components/Replicator/utilities';
+import {
+  generateTableKey,
+  getTableDisplayName,
+} from 'components/Replicator/utilities';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Heading, { HeadingTypes } from 'components/shared/Heading';
 import ManualSelectTable from 'components/Replicator/Create/Content/SelectTables/ManualSelectTable';
@@ -457,7 +460,12 @@ class SelectTablesView extends React.PureComponent<ISelectTablesProps, ISelectTa
   };
 
   public handleSave = () => {
-    this.props.setTables(this.state.selectedTables, this.state.columns, this.state.dmlBlacklist);
+    this.props.setTables(
+      this.state.selectedTables,
+      this.state.columns,
+      this.state.dmlBlacklist,
+      this.props.useReplicationTransformation
+    );
   };
 
   private isTableSelected = (row) => {

--- a/app/cdap/components/Replicator/Create/Content/StepButtons/index.tsx
+++ b/app/cdap/components/Replicator/Create/Content/StepButtons/index.tsx
@@ -21,7 +21,7 @@ import { returnSteps } from 'components/Replicator/Create/steps';
 import Button from '@material-ui/core/Button';
 import If from 'components/shared/If';
 import LoadingSVG from 'components/shared/LoadingSVG';
-import { useFeatureFlagDefaultFalse } from 'services/react/customHooks/useFeatureFlag';
+import { useFeatureFlagDefaultTrue } from 'services/react/customHooks/useFeatureFlag';
 
 const styles = (theme): StyleRules => {
   return {
@@ -52,7 +52,7 @@ const StepButtonsView: React.FC<IStepButtonProps> = ({
   onComplete,
   completeLoading,
 }) => {
-  const transformationsEnabled = useFeatureFlagDefaultFalse('replication.transformations.enabled');
+  const transformationsEnabled = useFeatureFlagDefaultTrue('replication.transformations.enabled');
   const STEPS = returnSteps(transformationsEnabled);
   function handleNextClick() {
     if (activeStep === STEPS.length - 1) {

--- a/app/cdap/components/Replicator/Create/Content/index.tsx
+++ b/app/cdap/components/Replicator/Create/Content/index.tsx
@@ -17,14 +17,14 @@
 import * as React from 'react';
 import { returnSteps } from 'components/Replicator/Create/steps';
 import { createContextConnect } from 'components/Replicator/Create';
-import { useFeatureFlagDefaultFalse } from 'services/react/customHooks/useFeatureFlag';
+import { useFeatureFlagDefaultTrue } from 'services/react/customHooks/useFeatureFlag';
 
 interface IContentProps {
   activeStep: number;
 }
 
 const ContentView: React.FC<IContentProps> = ({ activeStep }) => {
-  const transformationsEnabled = useFeatureFlagDefaultFalse('replication.transformations.enabled');
+  const transformationsEnabled = useFeatureFlagDefaultTrue('replication.transformations.enabled');
   const STEPS = returnSteps(transformationsEnabled);
   if (!STEPS[activeStep] || !STEPS[activeStep].component) {
     return null;

--- a/app/cdap/components/Replicator/Create/LeftPanel/index.tsx
+++ b/app/cdap/components/Replicator/Create/LeftPanel/index.tsx
@@ -21,7 +21,7 @@ import Chip from '@material-ui/core/Chip';
 import { returnSteps } from 'components/Replicator/Create/steps';
 import classnames from 'classnames';
 import Check from '@material-ui/icons/Check';
-import { useFeatureFlagDefaultFalse } from 'services/react/customHooks/useFeatureFlag';
+import { useFeatureFlagDefaultTrue } from 'services/react/customHooks/useFeatureFlag';
 
 const styles = (theme): StyleRules => {
   return {
@@ -76,7 +76,7 @@ const LeftPanelView: React.FC<ILeftPanelProps> = ({
   activeStep,
   isStateFilled,
 }) => {
-  const transformationsEnabled = useFeatureFlagDefaultFalse('replication.transformations.enabled');
+  const transformationsEnabled = useFeatureFlagDefaultTrue('replication.transformations.enabled');
   const STEPS = returnSteps(transformationsEnabled);
   function handleStepClick(step) {
     if (!isRowFinished(step)) {

--- a/app/cdap/components/Replicator/Create/TopPanel/index.tsx
+++ b/app/cdap/components/Replicator/Create/TopPanel/index.tsx
@@ -28,7 +28,7 @@ import ChevronRight from '@material-ui/icons/ChevronRight';
 import PluginInfo from 'components/Replicator/Create/TopPanel/PluginInfo';
 import If from 'components/shared/If';
 import { returnSteps } from 'components/Replicator/Create/steps';
-import { useFeatureFlagDefaultFalse } from 'services/react/customHooks/useFeatureFlag';
+import { useFeatureFlagDefaultTrue } from 'services/react/customHooks/useFeatureFlag';
 
 const styles = (theme): StyleRules => {
   return {
@@ -87,7 +87,7 @@ const TopPanelView: React.FC<ICreateContext & WithStyles<typeof styles>> = ({
   targetPluginWidget,
   activeStep,
 }) => {
-  const transformationsEnabled = useFeatureFlagDefaultFalse('replication.transformations.enabled');
+  const transformationsEnabled = useFeatureFlagDefaultTrue('replication.transformations.enabled');
   const STEPS = returnSteps(transformationsEnabled);
   const reviewDisplayCondition = activeStep === STEPS.length - 1;
 

--- a/app/cdap/components/Replicator/Create/index.tsx
+++ b/app/cdap/components/Replicator/Create/index.tsx
@@ -26,6 +26,7 @@ import {
   constructTablesSelection,
   convertConfigToState,
   generateTableKey,
+  getTableInfoFromImmutable,
 } from 'components/Replicator/utilities';
 
 import LoadingSVGCentered from 'components/shared/LoadingSVGCentered';
@@ -113,7 +114,12 @@ export interface ICreateState {
   setTargetPluginInfo: (targetPluginInfo: IPluginInfo) => void;
   setTargetPluginWidget: (targetPluginWidget: IWidgetJson) => void;
   setTargetConfig: (targetConfig: IPluginConfig) => void;
-  setTables: (tables: ITablesStore, columns: IColumnsStore, dmlBlacklist: IDMLStore) => void;
+  setTables: (
+    tables: ITablesStore,
+    columns: IColumnsStore,
+    dmlBlacklist: IDMLStore,
+    checkTransformations?: boolean
+  ) => void;
   setAdvanced: (numInstances) => void;
   getReplicatorConfig: () => any;
   saveDraft: () => Observable<any>;
@@ -194,8 +200,21 @@ class CreateView extends React.PureComponent<ICreateProps, ICreateContext> {
     this.setState({ targetConfig });
   };
 
-  public setTables = (tables, columns, dmlBlacklist) => {
-    this.setState({ tables, columns, dmlBlacklist });
+  public setTables = (tables, columns, dmlBlacklist, checkTransformations = false) => {
+    if (checkTransformations) {
+      // if you remove a table from the selected tables, also remove its transformations
+      const transformations = {};
+      tables.forEach((table) => {
+        const tableInfo = getTableInfoFromImmutable(table);
+        if (this.state.transformations[tableInfo.table]) {
+          transformations[tableInfo.table] = this.state.transformations[tableInfo.table];
+        }
+      });
+
+      this.setState({ tables, columns, dmlBlacklist, transformations });
+    } else {
+      this.setState({ tables, columns, dmlBlacklist });
+    }
   };
 
   public setTable = (table, cb) => {

--- a/app/cdap/components/Replicator/utilities/index.ts
+++ b/app/cdap/components/Replicator/utilities/index.ts
@@ -28,6 +28,8 @@ import {
   IColumnsStore,
   IDMLStore,
   ITable,
+  ITableImmutable,
+  ITableInfo,
 } from 'components/Replicator/types';
 import { fetchPluginWidget } from 'services/PluginUtilities';
 import { ICreateState } from 'components/Replicator/Create';
@@ -154,6 +156,22 @@ export function generateTableKey(row) {
     return `db-${database}-table-${table}`;
   }
 }
+
+/**
+ * Gets the table Info from the immutable table row
+ * @param row
+ * @returns tableInfo
+ */
+export const getTableInfoFromImmutable = (row: ITableImmutable): ITableInfo => {
+  const database = row.get('database');
+  const table = row.get('table');
+  const schema = row.get('schema');
+  return {
+    database,
+    table,
+    schema,
+  };
+};
 
 export function constructTablesSelection(tables, columns, dmlBlacklist) {
   if (!tables) {


### PR DESCRIPTION

# Fixes for 6.6 transformations

## Description
Changed some flags to be default true - (will need to not cherry pick those changes for 6.6)
If you remove a table, also remove its transformations
`tink` instead of `TINK`

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [18807](https://cdap.atlassian.net/browse/CDAP-18807)



