### PR TITLE
Feat/add description and instance url fields

### DIFF
--- a/app/cdap/components/AbstractWidget/FormInputs/TextBox/index.tsx
+++ b/app/cdap/components/AbstractWidget/FormInputs/TextBox/index.tsx
@@ -45,6 +45,11 @@ const TextBoxComponent: React.FC<ITextBoxProps> = ({
   onKeyPress,
   className,
 }) => {
+  const defaultProps = {
+    maxRows: 5,
+    minRows: 5,
+  };
+
   const onChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
     const v = event.target.value;
     if (typeof onChange === 'function') {
@@ -60,6 +65,9 @@ const TextBoxComponent: React.FC<ITextBoxProps> = ({
 
   const placeholder = objectQuery(widgetProps, 'placeholder');
   const enableUnderline = objectQuery(widgetProps, 'enableUnderline');
+  const multiline = objectQuery(widgetProps, 'multiline');
+  const customMaxRows = objectQuery(widgetProps, 'maxRows');
+  const customMinRows = objectQuery(widgetProps, 'minRows');
 
   const InputComponent = enableUnderline ? Input : InputBase;
 
@@ -72,6 +80,9 @@ const TextBoxComponent: React.FC<ITextBoxProps> = ({
       onKeyPress={onKeyPress}
       placeholder={placeholder}
       readOnly={disabled}
+      multiline={multiline}
+      minRows={customMinRows ? customMinRows : defaultProps.minRows}
+      maxRows={customMaxRows ? customMaxRows : defaultProps.maxRows}
       inputProps={{
         'data-cy': dataCy,
       }}

--- a/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/CdfInfo.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/CdfInfo.tsx
@@ -18,81 +18,24 @@ import React from 'react';
 import T from 'i18n-react';
 import NewReqTextField from './NewReqTextField';
 import { NewReqContainer, HeaderTitle } from '../shared.styles';
-import { IValidationErrors } from '../types';
-
-const I18NPREFIX = 'features.Administration.Tethering.CreateRequest';
-const I18N_CDF_PREFIX = `${I18NPREFIX}.CDFInformation`;
-
-const WIDGET_TYPE = 'widget-type';
-const WIDGET_ATTRIBUTES = 'widget-attributes';
-
-const ITEMS = [
-  {
-    widgetProperty: {
-      label: `${T.translate(`${I18N_CDF_PREFIX}.ProjectName.label`)}`,
-      name: `${T.translate(`${I18N_CDF_PREFIX}.ProjectName.name`)}`,
-      [WIDGET_TYPE]: 'textbox',
-      [WIDGET_ATTRIBUTES]: {
-        placeholder: T.translate(`${I18N_CDF_PREFIX}.ProjectName.placeholder`),
-      },
-    },
-    pluginProperty: {
-      type: 'string',
-      required: true,
-    },
-  },
-  {
-    widgetProperty: {
-      label: `${T.translate(`${I18N_CDF_PREFIX}.Region.label`)}`,
-      name: `${T.translate(`${I18N_CDF_PREFIX}.Region.name`)}`,
-      [WIDGET_TYPE]: 'textbox',
-      [WIDGET_ATTRIBUTES]: {
-        placeholder: T.translate(`${I18N_CDF_PREFIX}.Region.placeholder`),
-      },
-    },
-    pluginProperty: {
-      type: 'string',
-      required: true,
-    },
-  },
-  {
-    widgetProperty: {
-      label: `${T.translate(`${I18N_CDF_PREFIX}.InstanceName.label`)}`,
-      name: `${T.translate(`${I18N_CDF_PREFIX}.InstanceName.name`)}`,
-      [WIDGET_TYPE]: 'textbox',
-      [WIDGET_ATTRIBUTES]: {
-        placeholder: T.translate(`${I18N_CDF_PREFIX}.InstanceName.placeholder`),
-      },
-    },
-    pluginProperty: {
-      type: 'string',
-      required: true,
-    },
-  },
-];
+import { IValidationErrors, INewReqInputFields } from '../types';
+import { I18N_CDF_PREFIX, CDF_ITEMS } from './constants';
 
 interface ICdfInfoProps {
-  projectName?: string;
-  region?: string;
-  instanceName?: string;
+  inputFields: INewReqInputFields;
   broadcastChange: (target: string, value: string) => void;
   validationErrors?: IValidationErrors;
 }
 
-const CdfInfo = ({
-  projectName,
-  region,
-  instanceName,
-  broadcastChange,
-  validationErrors,
-}: ICdfInfoProps) => {
-  const values = [projectName, region, instanceName];
+const CdfInfo = ({ inputFields, broadcastChange, validationErrors }: ICdfInfoProps) => {
+  const { projectName, region, instanceName, instanceUrl, description } = inputFields;
+  const values = [projectName, region, instanceName, instanceUrl, description];
 
   return (
     <NewReqContainer>
       <HeaderTitle>{T.translate(`${I18N_CDF_PREFIX}.title`)}</HeaderTitle>
       <hr />
-      {ITEMS.map((item, idx) => {
+      {CDF_ITEMS.map((item, idx) => {
         const errArr = [];
         if (
           validationErrors.hasOwnProperty(item.widgetProperty.name) &&

--- a/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/constants.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/constants.tsx
@@ -25,8 +25,13 @@ export const K8S_NS_MEMORY_LIMITS = 'k8s.namespace.memory.limits';
 
 const I18NPREFIX = 'features.Administration.Tethering.CreateRequest';
 export const I18N_OMNI_PREFIX = `${I18NPREFIX}.OmniNamespaces`;
+export const I18N_CDF_PREFIX = `${I18NPREFIX}.CDFInformation`;
+
 export const OMNI_NS_COLUMN_TEMPLATE = '50px 4fr 2fr 3fr';
 export const OMNI_NS_COLUMN_TEMPLATE_SCROLLABLE = '50px 4fr 2fr 3fr 16px';
+
+const WIDGET_TYPE = 'widget-type';
+const WIDGET_ATTRIBUTES = 'widget-attributes';
 
 export const OMNI_NS_TABLE_HEADERS = [
   {
@@ -43,5 +48,78 @@ export const OMNI_NS_TABLE_HEADERS = [
   {
     property: 'memoryLimit',
     label: T.translate(`${I18N_OMNI_PREFIX}.MemoryLimit.label`),
+  },
+];
+
+export const CDF_ITEMS = [
+  {
+    widgetProperty: {
+      label: `${T.translate(`${I18N_CDF_PREFIX}.ProjectName.label`)}`,
+      name: `${T.translate(`${I18N_CDF_PREFIX}.ProjectName.name`)}`,
+      [WIDGET_TYPE]: 'textbox',
+      [WIDGET_ATTRIBUTES]: {
+        placeholder: T.translate(`${I18N_CDF_PREFIX}.ProjectName.placeholder`),
+      },
+    },
+    pluginProperty: {
+      type: 'string',
+      required: true,
+    },
+  },
+  {
+    widgetProperty: {
+      label: `${T.translate(`${I18N_CDF_PREFIX}.Region.label`)}`,
+      name: `${T.translate(`${I18N_CDF_PREFIX}.Region.name`)}`,
+      [WIDGET_TYPE]: 'textbox',
+      [WIDGET_ATTRIBUTES]: {
+        placeholder: T.translate(`${I18N_CDF_PREFIX}.Region.placeholder`),
+      },
+    },
+    pluginProperty: {
+      type: 'string',
+      required: true,
+    },
+  },
+  {
+    widgetProperty: {
+      label: `${T.translate(`${I18N_CDF_PREFIX}.InstanceName.label`)}`,
+      name: `${T.translate(`${I18N_CDF_PREFIX}.InstanceName.name`)}`,
+      [WIDGET_TYPE]: 'textbox',
+      [WIDGET_ATTRIBUTES]: {
+        placeholder: T.translate(`${I18N_CDF_PREFIX}.InstanceName.placeholder`),
+      },
+    },
+    pluginProperty: {
+      type: 'string',
+      required: true,
+    },
+  },
+  {
+    widgetProperty: {
+      label: `${T.translate(`${I18N_CDF_PREFIX}.InstanceUrl.label`)}`,
+      name: `${T.translate(`${I18N_CDF_PREFIX}.InstanceUrl.name`)}`,
+      [WIDGET_TYPE]: 'textbox',
+      [WIDGET_ATTRIBUTES]: {
+        placeholder: T.translate(`${I18N_CDF_PREFIX}.InstanceUrl.placeholder`),
+      },
+    },
+    pluginProperty: {
+      type: 'string',
+      required: true,
+    },
+  },
+  {
+    widgetProperty: {
+      label: `${T.translate(`${I18N_CDF_PREFIX}.Description.label`)}`,
+      name: `${T.translate(`${I18N_CDF_PREFIX}.Description.name`)}`,
+      [WIDGET_TYPE]: 'textbox',
+      [WIDGET_ATTRIBUTES]: {
+        placeholder: T.translate(`${I18N_CDF_PREFIX}.Description.placeholder`),
+        multiline: true,
+      },
+    },
+    pluginProperty: {
+      type: 'string',
+    },
   },
 ];

--- a/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/index.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/index.tsx
@@ -47,7 +47,6 @@ const NewTetheringRequest = () => {
     apiError,
     validationErrors,
   } = state;
-  const { projectName, region, instanceName } = inputFields;
   const history = useHistory();
 
   const fetchNamespaces = async () => {
@@ -74,16 +73,16 @@ const NewTetheringRequest = () => {
   const handleSend = async () => {
     const { errors, allValid: inputsAreValid } = areInputsValid({
       selectedNamespaces,
-      projectName,
-      region,
-      instanceName,
+      inputFields,
     });
     updateError(dispatch, { errType: 'validationErrors', errVal: errors });
     if (inputsAreValid) {
+      const { projectName, region, instanceName, instanceUrl, description } = inputFields;
       const connectionInfo = {
         peer: instanceName,
-        endpoint: `${instanceName}-${projectName}-${region}.datafusion.googleusercontent.com`, // TODO: needs clarification on how to obtain
+        endpoint: instanceUrl,
         namespaceAllocations: namespaces.filter((ns) => selectedNamespaces.includes(ns.namespace)),
+        description,
         metadata: {
           project: projectName,
           location: region,
@@ -135,9 +134,7 @@ const NewTetheringRequest = () => {
           broadcastChange={handleNamespaceChange}
         />
         <CdfInfo
-          projectName={projectName}
-          region={region}
-          instanceName={instanceName}
+          inputFields={inputFields}
           broadcastChange={handleInputChange}
           validationErrors={validationErrors}
         />

--- a/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/reducer.ts
+++ b/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/reducer.ts
@@ -27,6 +27,8 @@ export interface INewTetheringReqState {
     projectName: string;
     region: string;
     instanceName: string;
+    instanceUrl: string;
+    description: string;
   };
   showAlert: boolean;
   apiError: IApiError;
@@ -51,6 +53,8 @@ export const initialState: INewTetheringReqState = {
     projectName: '',
     region: '',
     instanceName: '',
+    instanceUrl: '',
+    description: '',
   },
   showAlert: false,
   apiError: {},

--- a/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/utils.ts
+++ b/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/utils.ts
@@ -21,17 +21,16 @@ const I18NPREFIX = 'features.Administration.Tethering.CreateRequest';
  * Function to ensure all user provided inputs are valid before submitting new thethering request
  *
  * @param selectedNamespaces - list of selected namespaces by user (at least one is required)
- * @param projectName - Project Name of the CDF Instance (required)
- * @param region - Region of the CDF Instance (required)
- * @param instanceName - Instance Name of the CDF Instance (required)
+ * @param inputFields - user provided values for cdf information
  * @returns { [{object}], boolean } - list of error objects to update UI with errors and whether all checks passed
  */
-export const areInputsValid = ({ selectedNamespaces, projectName, region, instanceName }) => {
+export const areInputsValid = ({ selectedNamespaces, inputFields }) => {
   const requiredFields = [
     { name: 'namespaces', val: selectedNamespaces.length },
-    { name: 'projectName', val: projectName },
-    { name: 'region', val: region },
-    { name: 'instanceName', val: instanceName },
+    { name: 'projectName', val: inputFields.projectName },
+    { name: 'region', val: inputFields.region },
+    { name: 'instanceName', val: inputFields.instanceName },
+    { name: 'instanceUrl', val: inputFields.instanceUrl },
   ];
   let allValid = true;
   const errors = {};

--- a/app/cdap/components/Administration/TetheringTabContent/types.ts
+++ b/app/cdap/components/Administration/TetheringTabContent/types.ts
@@ -84,3 +84,11 @@ export interface INamespace {
   cpuLimit: number;
   memoryLimit: number;
 }
+
+export interface INewReqInputFields {
+  projectName: string;
+  region: string;
+  instanceName: string;
+  instanceUrl: string;
+  description: string;
+}

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -230,6 +230,14 @@ features:
             name: instanceName
             label: Instance Name
             placeholder: Specify the Cloud Data Fusion instance name
+          InstanceUrl:
+            name: instanceUrl
+            label: Instance Url
+            placeholder: Specify the Cloud Data Fusion instance url
+          Description:
+            name: description
+            label: Description
+            placeholder: Describe the rationale for the tethering request
       ColumnHeaders:
          requestTime: Request Time
          gcp: Google cloud project


### PR DESCRIPTION
# Add Description and Instance URL to create new request page

## Description
This PR adds two new fields to the `create new request` page (i.e., description which is optional, and instance URL)

## PR Type
- [ ] Bug Fix
- [X] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links

## Test Plan

## Screenshots

![Screen Shot 2022-02-08 at 2 41 54 PM](https://user-images.githubusercontent.com/94018249/153087908-af8fef6b-178c-4f24-b65c-0a978fc399ac.png)

