### PR TITLE
Add confirmation modal when deleting connections/requests

### DIFF
--- a/app/cdap/components/Administration/TetheringTabContent/ActionPopover/index.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/ActionPopover/index.tsx
@@ -14,8 +14,9 @@
  * the License.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import styled, { css } from 'styled-components';
+import ConfirmationModal from 'components/shared/ConfirmationModal';
 import Popover from 'components/shared/Popover';
 import T from 'i18n-react';
 
@@ -70,35 +71,65 @@ const ListItem = styled.li`
 
 interface IActionsPopoverProps {
   target: React.ReactNode | (() => void);
+  confirmationTitle: React.ReactNode;
+  confirmationText: React.ReactNode;
   onEditClick: () => void;
   onDeleteClick: () => void;
 }
 
-const ActionsPopover = ({ target, onDeleteClick, onEditClick }: IActionsPopoverProps) => {
+const ActionsPopover = ({
+  target,
+  confirmationTitle,
+  confirmationText,
+  onDeleteClick,
+  onEditClick,
+}: IActionsPopoverProps) => {
+  const [modalOpen, setModalOpen] = useState(false);
   const canEdit = false; // TODO: should update when edit functionality is enabled
 
+  const toggleModalOpen = () => {
+    setModalOpen((prevState) => !prevState);
+  };
+
+  const confirmDelete = () => {
+    toggleModalOpen();
+    onDeleteClick();
+  };
+
+  const confirmDeleteElem = <div>{confirmationText}</div>;
+
   return (
-    <StyledPopover
-      target={target}
-      placement="bottom"
-      bubbleEvent={false}
-      enableInteractionInPopover={true}
-      showPopover={false}
-    >
-      <ul>
-        {canEdit && (
-          <>
-            <ListItem disabled={!canEdit} onClick={onEditClick}>
-              {T.translate(`${PREFIX}.Actions.edit`)}
-            </ListItem>
-            <hr />
-          </>
-        )}
-        <ListItem red={true} onClick={onDeleteClick}>
-          {T.translate(`${PREFIX}.Actions.delete`)}
-        </ListItem>
-      </ul>
-    </StyledPopover>
+    <>
+      <StyledPopover
+        target={target}
+        placement="bottom"
+        bubbleEvent={false}
+        enableInteractionInPopover={true}
+        showPopover={false}
+      >
+        <ul>
+          {canEdit && (
+            <>
+              <ListItem disabled={!canEdit} onClick={onEditClick}>
+                {T.translate(`${PREFIX}.Actions.edit`)}
+              </ListItem>
+              <hr />
+            </>
+          )}
+          <ListItem red={true} onClick={toggleModalOpen}>
+            {T.translate(`${PREFIX}.Actions.delete`)}
+          </ListItem>
+        </ul>
+      </StyledPopover>
+      <ConfirmationModal
+        isOpen={modalOpen}
+        headerTitle={confirmationTitle}
+        confirmationElem={confirmDeleteElem}
+        confirmButtonText={T.translate(`${PREFIX}.Actions.delete`)}
+        confirmFn={confirmDelete}
+        cancelFn={toggleModalOpen}
+      />
+    </>
   );
 };
 

--- a/app/cdap/components/Administration/TetheringTabContent/Connections/index.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/Connections/index.tsx
@@ -37,6 +37,8 @@ const Connections = ({ connections, handleEdit, handleDelete }: IConnectionsProp
   const renderLastColumn = (instanceName: string) => (
     <ActionsPopover
       target={() => <IconSVG name="icon-more" />}
+      confirmationTitle={T.translate(`${PREFIX}.ConfirmationModal.deleteConnectionHeader`)}
+      confirmationText={T.translate(`${PREFIX}.ConfirmationModal.deleteConnectionCopy`)}
       onDeleteClick={() => handleDelete(CONNECTION_STATUS, instanceName)}
       onEditClick={() => handleEdit(CONNECTION_STATUS, instanceName)}
     />

--- a/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/PendingRequests.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/OdfTetheringConnections/PendingRequests.tsx
@@ -44,6 +44,8 @@ const PendingRequests = ({ pendingRequests, handleEdit, handleDelete }: IPending
   const renderLastColumn = (instanceName: string) => (
     <ActionsPopover
       target={() => <IconSVG name="icon-more" />}
+      confirmationTitle={T.translate(`${PREFIX}.ConfirmationModal.deleteRequestHeader`)}
+      confirmationText={T.translate(`${PREFIX}.ConfirmationModal.deleteRequestCopy`)}
       onDeleteClick={() => handleDelete(CONNECTION_STATUS, instanceName)}
       onEditClick={() => handleEdit(CONNECTION_STATUS, instanceName)}
     />

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -250,6 +250,11 @@ features:
       Actions:
         edit: Edit
         delete: Delete
+      ConfirmationModal:
+        deleteRequestHeader: Delete Tethering Request
+        deleteRequestCopy: Are you sure you want to delete this request?
+        deleteConnectionHeader: Delete Tethering Connection
+        deleteConnectionCopy: Are you sure you want to delete this connection?
       pageTitle: '{productName} | Administration | Tethering Connections'
     Services:
       title: Services


### PR DESCRIPTION
# Delete Confirmation Modal for Connections/Requests

## Description
This PR adds a confirmation modal when a user wants to delete a connection/request.

## PR Type
- [ ] Bug Fix
- [X] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
[CDAP-18840](https://cdap.atlassian.net/browse/CDAP-18840)

## Test Plan

## Screenshots
![Screen Shot 2022-02-09 at 11 28 13 AM](https://user-images.githubusercontent.com/94018249/153276722-42aae90a-5a2b-41aa-a2a7-82ec305d41a5.png)
![Screen Shot 2022-02-09 at 11 34 25 AM](https://user-images.githubusercontent.com/94018249/153276741-3b96f49a-2634-4ac4-82cb-c48948b614cf.png)





