### PR TITLE
Adds plugin type & name to fetch plugin properties contextually

### DIFF
--- a/app/cdap/components/Connections/Browser/GenericBrowser/apiHelpers.ts
+++ b/app/cdap/components/Connections/Browser/GenericBrowser/apiHelpers.ts
@@ -61,7 +61,7 @@ export function createWorkspace({ entity, connection, limit = 1000 }) {
     });
 }
 
-export function getPluginSpec(entity, connection) {
+export function getPluginSpec(entity, connection, plugin = null) {
   const { path } = entity;
   const params = {
     context: getCurrentNamespace(),
@@ -72,6 +72,10 @@ export function getPluginSpec(entity, connection) {
     path,
     properties: {},
   };
+
+  if (plugin) {
+    Object.assign(body, { pluginName: plugin.name, pluginType: plugin.type });
+  }
 
   return ConnectionsApi.getSpecification(params, body).toPromise();
 }

--- a/app/cdap/components/Connections/Browser/GenericBrowser/index.tsx
+++ b/app/cdap/components/Connections/Browser/GenericBrowser/index.tsx
@@ -82,7 +82,7 @@ export function GenericBrowser({ initialConnectionId, onEntityChange, selectedPa
   const [searchStringDisplay, setSearchStringDisplay] = useState('');
   const [workspaceId, setWorkspaceId] = useState(null);
   const classes = useStyle();
-  const { onWorkspaceCreate, onEntitySelect } = useContext(ConnectionsContext);
+  const { onWorkspaceCreate, onEntitySelect, selectedPlugin } = useContext(ConnectionsContext);
   const isSelectMode = typeof onEntitySelect === 'function';
   const fetchEntities = async () => {
     setLoading(true);
@@ -167,7 +167,7 @@ export function GenericBrowser({ initialConnectionId, onEntityChange, selectedPa
 
   const loadEntitySpec = async (entity) => {
     try {
-      const spec = await getPluginSpec(entity, currentConnection);
+      const spec = await getPluginSpec(entity, currentConnection, selectedPlugin);
       const plugin = spec?.relatedPlugins?.[0];
       const properties = plugin?.properties;
       const schema = plugin?.schema;

--- a/app/cdap/components/Connections/ConnectionsContext/index.tsx
+++ b/app/cdap/components/Connections/ConnectionsContext/index.tsx
@@ -52,8 +52,10 @@ export interface IConnections {
   hideAddConnection?: boolean;
   connectorType?: string;
   allowDefaultConnection?: boolean;
+  selectedPlugin?: Record<string, string>;
 }
 export const ConnectionsContext = React.createContext<IConnections>({
   mode: IConnectionMode.ROUTED,
   disabledTypes: {},
+  selectedPlugin: null,
 });

--- a/app/cdap/components/Connections/index.tsx
+++ b/app/cdap/components/Connections/index.tsx
@@ -23,6 +23,8 @@ import { ConnectionRoutes } from 'components/Connections/Routes';
 import { MemoryRouter, Redirect } from 'react-router';
 import { Route } from 'react-router-dom';
 import { getCurrentNamespace } from 'services/NamespaceStore';
+import PipelineMetricsStore from 'services/PipelineMetricsStore';
+
 const DATAPREP_I18N_PREFIX = 'features.DataPrep.pageTitle';
 import {
   IConnectionMode,
@@ -87,6 +89,7 @@ export default function Connections({
     connectorType,
     hideSidePanel,
     hideAddConnection,
+    selectedPlugin: PipelineMetricsStore.getState().plugin,
   });
   const classes = useStyle();
   const [loading, setLoading] = useState(true);

--- a/app/cdap/services/PipelineMetricsStore/ActionCreator.js
+++ b/app/cdap/services/PipelineMetricsStore/ActionCreator.js
@@ -139,10 +139,20 @@ const setMetricsTabActive = (metricsTabActive, portsToShow) => {
   });
 };
 
+const setSelectedPlugin = (pluginType, pluginName) => {
+  PipelineMetricsStore.dispatch({
+    type: PipelineMetricsActions.SET_SELECTED_PLUGIN,
+    payload: {
+      pluginType,
+      pluginName,
+    },
+  });
+};
+
 const reset = () => {
   PipelineMetricsStore.dispatch({
     type: PipelineMetricsActions.RESET,
   });
 };
 
-export { getMetrics, pollForMetrics, setMetricsTabActive, reset };
+export { getMetrics, pollForMetrics, setMetricsTabActive, reset, setSelectedPlugin };

--- a/app/cdap/services/PipelineMetricsStore/index.js
+++ b/app/cdap/services/PipelineMetricsStore/index.js
@@ -24,12 +24,14 @@ const DEFAULT_METRICS_STATE = {
   // for now as the old metrics store had these info. Can come back and move these later
   metricsTabActive: false,
   portsToShow: [],
+  plugin: null,
 };
 
 const PipelineMetricsActions = {
   SET_METRICS: 'SET_METRICS',
   SET_LOGS_METRICS: 'SET_LOGS_METRICS',
   SET_ACTIVE_TAB: 'SET_ACTIVE_TAB',
+  SET_SELECTED_PLUGIN: 'SET_SELECTED_PLUGIN',
   RESET: 'RESET',
 };
 
@@ -50,6 +52,14 @@ const metrics = (state = DEFAULT_METRICS_STATE, action = defaultAction) => {
         ...state,
         metricsTabActive: action.payload.metricsTabActive,
         portsToShow: action.payload.portsToShow ? [action.payload.portsToShow] : state.portsToShow,
+      };
+    case PipelineMetricsActions.SET_SELECTED_PLUGIN:
+      return {
+        ...state,
+        plugin: {
+          type: action.payload.pluginType,
+          name: action.payload.pluginName,
+        },
       };
     case PipelineMetricsActions.RESET:
       return DEFAULT_METRICS_STATE;

--- a/app/directives/dag-plus/my-dag-ctrl.js
+++ b/app/directives/dag-plus/my-dag-ctrl.js
@@ -1344,6 +1344,7 @@ angular.module(PKG.name + '.commons')
       closeMetricsPopover(node);
 
       window.CaskCommon.PipelineMetricsActionCreator.setMetricsTabActive(false);
+      window.CaskCommon.PipelineMetricsActionCreator.setSelectedPlugin(node.type, node.plugin.name);
       DAGPlusPlusNodesActionsFactory.selectNode(node.name);
     };
 


### PR DESCRIPTION
# Adds plugin type & name to fetch plugin properties contextually

## Description
In pipeline studio page while fetching plugin properties for connection toggle, by default API returns the plugin properties for sink. But it needs to be contextual based on where the plugin is accessed from (either sink/source/transform). Hence passing plugin name and type info as part "/specification" API call.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [975](https://cdap.atlassian.net/browse/PLUGIN-975)

## Screenshots
![image](https://user-images.githubusercontent.com/81957712/153572556-aaafcb00-c026-4c8a-a328-7be27ea676d3.png)



