### PR TITLE
if the table already exists, still call the callback

### DIFF
--- a/app/cdap/components/Replicator/Create/index.tsx
+++ b/app/cdap/components/Replicator/Create/index.tsx
@@ -221,6 +221,7 @@ class CreateView extends React.PureComponent<ICreateProps, ICreateContext> {
     const key = generateTableKey(table);
 
     if (this.state.tables.get(key)) {
+      cb();
       return;
     }
 


### PR DESCRIPTION
# Save transformation if table already exists

## Description
forgot to add callback if table already exists

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [18855](https://cdap.atlassian.net/browse/CDAP-18855)


