### PR TITLE
confirmation modal for rejecting requests and more visual changes

### DIFF
--- a/app/cdap/components/Administration/TetheringTabContent/CdfTetheringConnections/NewReqLastColumn.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/CdfTetheringConnections/NewReqLastColumn.tsx
@@ -14,7 +14,8 @@
  * the License.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
+import ConfirmationModal from 'components/shared/ConfirmationModal';
 import { StyledButton } from '../shared.styles';
 import T from 'i18n-react';
 import styled from 'styled-components';
@@ -39,15 +40,39 @@ interface INewReqLastColumnProps {
 }
 
 const NewReqLastColumn = ({ instanceName, handleAcceptOrReject }: INewReqLastColumnProps) => {
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const toggleModalOpen = () => {
+    setModalOpen((prevState) => !prevState);
+  };
+
+  const confirmReject = () => {
+    toggleModalOpen();
+    handleAcceptOrReject('reject', instanceName);
+  };
+  const confirmRejectElem = (
+    <div>{T.translate(`${PREFIX}.ConfirmationModal.rejectRequestCopy`)}</div>
+  );
+
   return (
-    <ButtonsContainer>
-      <GridCellButton onClick={() => handleAcceptOrReject('accept', instanceName)}>
-        {T.translate(`${PREFIX}.PendingRequests.acceptButton`)}
-      </GridCellButton>
-      <GridCellButton onClick={() => handleAcceptOrReject('reject', instanceName)}>
-        {T.translate(`${PREFIX}.PendingRequests.rejectButton`)}
-      </GridCellButton>
-    </ButtonsContainer>
+    <>
+      <ButtonsContainer>
+        <GridCellButton onClick={() => handleAcceptOrReject('accept', instanceName)}>
+          {T.translate(`${PREFIX}.PendingRequests.acceptButton`)}
+        </GridCellButton>
+        <GridCellButton onClick={confirmReject}>
+          {T.translate(`${PREFIX}.PendingRequests.rejectButton`)}
+        </GridCellButton>
+      </ButtonsContainer>
+      <ConfirmationModal
+        isOpen={modalOpen}
+        headerTitle={T.translate(`${PREFIX}.ConfirmationModal.rejectRequestHeader`)}
+        confirmationElem={confirmRejectElem}
+        confirmButtonText={T.translate(`${PREFIX}.PendingRequests.rejectButton`)}
+        confirmFn={confirmReject}
+        cancelFn={toggleModalOpen}
+      />
+    </>
   );
 };
 

--- a/app/cdap/components/Administration/TetheringTabContent/CdfTetheringConnections/NewRequests.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/CdfTetheringConnections/NewRequests.tsx
@@ -14,15 +14,29 @@
  * the License.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import TetheringTable from '../TetheringTable';
 import T from 'i18n-react';
-import { HeaderContainer, HeaderTitle, BodyContainer, NoDataText } from '../shared.styles';
+import styled from 'styled-components';
+import {
+  HeaderContainer,
+  HeaderTitle,
+  BodyContainer,
+  NoDataText,
+  StyledAlert,
+} from '../shared.styles';
 import NewReqLastColumn from './NewReqLastColumn';
 import { IConnection } from '../types';
 
 const PREFIX = 'features.Administration.Tethering';
 const I18NPREFIX = `${PREFIX}.NewRequests`;
+const ACCEPT_ACTION = 'accept';
+
+const CustomAlert = styled(StyledAlert)`
+  width: 100%;
+  margin-top: 10px;
+  margin-bottom: -20px;
+`;
 
 interface INewRequestsProps {
   newRequests: IConnection[];
@@ -30,9 +44,23 @@ interface INewRequestsProps {
 }
 
 const NewRequests = ({ newRequests, handleAcceptOrReject }: INewRequestsProps) => {
+  const [showAlert, setShowAlert] = useState(false);
   const renderLastColumn = (instanceName: string) => (
-    <NewReqLastColumn instanceName={instanceName} handleAcceptOrReject={handleAcceptOrReject} />
+    <NewReqLastColumn
+      instanceName={instanceName}
+      handleAcceptOrReject={handleChangeRequestStatus}
+    />
   );
+
+  const handleChangeRequestStatus = (action: string, peer: string) => {
+    if (action === ACCEPT_ACTION) {
+      setShowAlert(true);
+      setTimeout(() => {
+        setShowAlert(false);
+      }, 3000);
+    }
+    handleAcceptOrReject(action, peer);
+  };
 
   return (
     <>
@@ -40,6 +68,11 @@ const NewRequests = ({ newRequests, handleAcceptOrReject }: INewRequestsProps) =
         <HeaderTitle>{T.translate(`${I18NPREFIX}.newRequestsHeader`)}</HeaderTitle>
       </HeaderContainer>
       <BodyContainer>
+        {showAlert && (
+          <CustomAlert severity="success">
+            {T.translate(`${PREFIX}.PendingRequests.acceptSuccess`)}
+          </CustomAlert>
+        )}
         {newRequests.length > 0 ? (
           <TetheringTable tableData={newRequests} renderLastColumn={renderLastColumn} />
         ) : (

--- a/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/index.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/index.tsx
@@ -28,10 +28,9 @@ import {
   createTethering,
   fetchNamespaceList,
 } from './reducer';
-import Alert from 'components/shared/Alert';
 import OmniNamespaces from './OmniNamespaces';
 import CdfInfo from './CdfInfo';
-import { HeaderContainer, HeaderTitle, StyledButton } from '../shared.styles';
+import { HeaderContainer, HeaderTitle, StyledButton, StyledAlert } from '../shared.styles';
 import { Container, BackButton, Divider, StyledBodyContainer, ButtonsContainer } from './styles';
 import { areInputsValid } from '../utils';
 
@@ -71,6 +70,7 @@ const NewTetheringRequest = () => {
   };
 
   const handleSend = async () => {
+    reset(dispatch, true);
     const { errors, allValid: inputsAreValid } = areInputsValid({
       selectedNamespaces,
       inputFields,
@@ -108,13 +108,9 @@ const NewTetheringRequest = () => {
       : T.translate(`${I18NPREFIX}.success`);
     const type = hasError ? 'error' : 'success';
     return (
-      <Alert
-        message={message}
-        type={type}
-        showAlert={showAlert}
-        canEditPageWhileOpen={true}
-        onClose={() => reset(dispatch, hasError)}
-      />
+      <StyledAlert severity={type} onClose={() => reset(dispatch, hasError)}>
+        {message}
+      </StyledAlert>
     );
   };
 
@@ -139,6 +135,7 @@ const NewTetheringRequest = () => {
           broadcastChange={handleInputChange}
           validationErrors={validationErrors}
         />
+        {showAlert && renderAlert()}
         <ButtonsContainer>
           <StyledButton onClick={handleSend}>
             {T.translate(`${I18NPREFIX}.sendButton`)}
@@ -148,7 +145,6 @@ const NewTetheringRequest = () => {
           </StyledButton>
         </ButtonsContainer>
       </StyledBodyContainer>
-      {showAlert && renderAlert()}
     </Container>
   );
 };

--- a/app/cdap/components/Administration/TetheringTabContent/TetheringTable/utils.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/TetheringTable/utils.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import T from 'i18n-react';
+import { IConnection } from '../types';
+import { dateTimeFormat } from 'services/DataFormatter';
+import { StyledIcon, GridRow, GridCell, LinedSpan } from '../shared.styles';
+import { ICONS, PREFIX, DESC_COLUMN_TEMPLATE } from './constants';
+
+export const getIconForStatus = (status: string, isForPendingReqs: boolean) => {
+  switch (status) {
+    case 'ACTIVE':
+      return (
+        <StyledIcon
+          name={ICONS.active.name}
+          color={ICONS.active.color}
+          tooltip={ICONS.active.tooltip}
+        />
+      );
+    case 'INACTIVE':
+      return (
+        <StyledIcon
+          name={ICONS.inactive.name}
+          color={ICONS.inactive.color}
+          tooltip={isForPendingReqs ? ICONS.inactive.pendingReqTooltip : ICONS.inactive.tooltip}
+        />
+      );
+    default:
+      return <StyledIcon name={ICONS.default.name} color={ICONS.default.color} />;
+  }
+};
+
+export const getTransformedTableData = (tableData: IConnection[]) => {
+  return tableData.map((conn) => ({
+    requestTime: dateTimeFormat(conn.requestTime, {
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+    }),
+    description: conn.metadata?.description,
+    gcloudProject: conn.metadata?.metadata?.project,
+    instanceName: conn.name,
+    region: conn.metadata?.metadata?.location,
+    allocationData: conn.metadata?.namespaceAllocations,
+    status: conn.connectionStatus,
+    highlighted: false,
+  }));
+};
+
+export const renderAllocationsHeader = () => (
+  <GridRow columnTemplate={DESC_COLUMN_TEMPLATE}>
+    <GridCell />
+    <GridCell />
+    <GridCell />
+    <GridCell />
+    <GridCell />
+    <GridCell>
+      <LinedSpan>{T.translate(`${PREFIX}.Connections.allocation`)}</LinedSpan>
+    </GridCell>
+    <GridCell />
+  </GridRow>
+);
+
+export const getTotalTableRows = (tableData: IConnection[]) =>
+  tableData.reduce((acc, row) => {
+    acc += row.metadata.namespaceAllocations.length;
+    return acc;
+  }, 0);

--- a/app/cdap/components/Administration/TetheringTabContent/shared.styles.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/shared.styles.tsx
@@ -18,6 +18,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import { Button, Checkbox } from '@material-ui/core';
+import Alert from '@material-ui/lab/Alert';
 import IconSVG from 'components/shared/IconSVG';
 
 export const HeaderContainer = styled.div`
@@ -36,8 +37,10 @@ export const HeaderTitle = styled.h5`
 
 export const BodyContainer = styled.div`
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  padding: 0 30px;
   width: 100%;
 `;
 
@@ -51,7 +54,6 @@ export const Grid = styled.div`
   width: 100%;
   margin-top: 30px;
   margin-bottom: 30px;
-  padding: 0 30px;
   max-height: none;
 `;
 
@@ -66,7 +68,9 @@ export const GridBody = styled.div`
   border-bottom: 1px solid var(--grey11);
 `;
 
-export const GridRow = styled(({ border, columnTemplate, ...props }) => <div {...props} />)`
+export const GridRow = styled(({ border, highlighted, columnTemplate, ...props }) => (
+  <div {...props} />
+))`
   display: grid;
   height: 30px;
   padding: 5px 5px 5px 20px;
@@ -76,6 +80,13 @@ export const GridRow = styled(({ border, columnTemplate, ...props }) => <div {..
     props.border &&
     css`
       border-bottom: 1px solid var(--grey11);
+    `}
+
+  ${(props) =>
+    props.highlighted &&
+    css`
+      border: 1px solid ${(p) => p.theme.palette.green[200]};
+      background-color: rgba(138, 243, 2, 0.1);
     `}
 `;
 
@@ -181,4 +192,9 @@ export const StyledCheckbox = styled(Checkbox)`
 
 export const ErrorText = styled.span`
   color: ${(props) => props.theme.palette.red[50]};
+`;
+
+export const StyledAlert = styled(Alert)`
+  font-size: inherit;
+  margin-bottom: 20px;
 `;

--- a/app/cdap/components/Administration/TetheringTabContent/types.ts
+++ b/app/cdap/components/Administration/TetheringTabContent/types.ts
@@ -45,6 +45,7 @@ export interface ITableData {
   region: string;
   status: string;
   allocationData: INamespaceAllocations[];
+  highlighted?: boolean;
 }
 
 export interface IConnectionsProps {

--- a/app/cdap/components/Administration/TetheringTabContent/utils.ts
+++ b/app/cdap/components/Administration/TetheringTabContent/utils.ts
@@ -15,7 +15,6 @@
  */
 
 import T from 'i18n-react';
-import { IConnection } from './types';
 
 const I18NPREFIX = 'features.Administration.Tethering.CreateRequest';
 const SCROLLER_WIDTH = '16px';
@@ -56,9 +55,3 @@ export const areInputsValid = ({ selectedNamespaces, inputFields }) => {
 };
 
 export const getScrollableColTemplate = (template: string) => `${template} ${SCROLLER_WIDTH}`;
-
-export const getTotalTableRows = (tableData: IConnection[]) =>
-  tableData.reduce((acc, row) => {
-    acc += row.metadata.namespaceAllocations.length;
-    return acc;
-  }, 0);

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -186,7 +186,8 @@ features:
         pendingRequestHistory: VIEW REQUEST HISTORY
         noPendingRequests: There are no requests pending
         acceptButton: Accept
-        rejectButton: reject
+        rejectButton: Reject
+        acceptSuccess: Request has been accepted.
       Connections:
         connectionsHeader: Connections
         noConnections: There are no connections
@@ -256,6 +257,8 @@ features:
         deleteRequestCopy: Are you sure you want to delete this request?
         deleteConnectionHeader: Delete Tethering Connection
         deleteConnectionCopy: Are you sure you want to delete this connection?
+        rejectRequestHeader: Reject Tethering Request
+        rejectRequestCopy: Are you sure you want to reject this request?
       pageTitle: '{productName} | Administration | Tethering Connections'
     Services:
       title: Services


### PR DESCRIPTION
# Confirmation modal for rejecting requests.

## Description
This PR adds a confirmation when rejecting tethering requests (on cdf side). The `Alert` component is replaced with `MUI Alert` component. It also adds some visual effects when a request has been accepted (see screenshot below). And some refactoring to split up `index.tsx` in `TetheringTable` directory.

## PR Type
- [ ] Bug Fix
- [X] Feature
- [ ] Build Fix
- [ ] Testing
- [X] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-18861](https://cdap.atlassian.net/browse/CDAP-18861)

## Test Plan

## Screenshots
![Screen Shot 2022-02-14 at 10 56 19 AM](https://user-images.githubusercontent.com/94018249/154133337-3c7b8f74-10d7-4af0-b0ce-c8f6c6278062.png)


