### PR TITLE
CDAP-18425 Stale default port value for connections

### DIFF
--- a/app/cdap/components/Connections/Create/index.tsx
+++ b/app/cdap/components/Connections/Create/index.tsx
@@ -124,10 +124,10 @@ export function CreateConnection({
   }
 
   const onConnectorSelection = async (selectedConnector) => {
-    navigateToConfigStep(dispatch, selectedConnector);
     setLoading(true);
     const connDetails = await fetchConnectionDetails(selectedConnector);
     setConnectionDetails(connDetails);
+    navigateToConfigStep(dispatch, selectedConnector);
     setLoading(false);
     setTestResponseMessages(undefined);
     setTestSucceeded(false);


### PR DESCRIPTION
# [CDAP-18425](https://cdap.atlassian.net/browse/CDAP-18425) Stale default port value for connections

## Description
Move navigateToConfigStep after setConnectionDetails to avoid rendering the page with stale data

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-18425](https://cdap.atlassian.net/browse/CDAP-18425)


