### PR TITLE
remove extra white space in tethering connections tab

### DIFF
--- a/app/cdap/components/Administration/TetheringTabContent/index.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/index.tsx
@@ -35,10 +35,10 @@ const PREFIX = 'features.Administration';
 const I18NPREFIX = `${PREFIX}.Tethering`;
 
 const AdminTetheringTabContainer = styled.div`
-  width: 100vw;
   margin-left: calc(-50vw + 50%);
   margin-top: 10px;
   margin-bottom: 10px;
+  margin-right: -20px;
 `;
 
 const AdminTetheringTabContent = () => {


### PR DESCRIPTION
# Remove extra white space in tethering connections tab

## Description
This PR removes the extra whitespace in the right side of `tethering connections` tab that is added by the parent element. See screenshots below.

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [Jira issue #](fill-in.org)

## Test Plan

## Screenshots
![Screen Shot 2022-02-22 at 11 50 56 AM](https://user-images.githubusercontent.com/94018249/155209007-4b9d454d-827a-4910-b7cd-ade4e83148b5.png)

![Screen Shot 2022-02-22 at 11 57 03 AM](https://user-images.githubusercontent.com/94018249/155209107-08eab04d-a042-4557-b4c3-cbcbd7165d71.png)

