### PR TITLE
fix: add a clearer error message when database is not found

### DIFF
--- a/app/cdap/components/Replicator/Create/Content/SelectTables/index.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectTables/index.tsx
@@ -26,7 +26,7 @@ import orderBy from 'lodash/orderBy';
 import LoadingSVGCentered from 'components/shared/LoadingSVGCentered';
 import SelectColumns from 'components/Replicator/Create/Content/SelectColumns';
 import SelectColumnsWithTransforms from 'components/Replicator/Create/Content/SelectColumnsWithTransforms';
-import { extractErrorMessage } from 'services/helpers';
+import { extractErrorMessage, isUnknownDatabaseError } from 'services/helpers';
 import { generateTableKey, getTableDisplayName } from 'components/Replicator/utilities';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Heading, { HeadingTypes } from 'components/shared/Heading';
@@ -450,6 +450,14 @@ class SelectTablesView extends React.PureComponent<ISelectTablesProps, ISelectTa
         <div className="text-danger">
           <Heading type={HeadingTypes.h5} label="Error" />
           <span>{this.state.error}</span>
+          {isUnknownDatabaseError(this.state.error) && (
+            <div>
+              <span>
+                Please manually put in the correct database name and table name below, or go back to
+                "Configure source" tab and put in the correct "Database Name".
+              </span>
+            </div>
+          )}
         </div>
         <ManualSelectTable />
       </>

--- a/app/cdap/services/helpers.js
+++ b/app/cdap/services/helpers.js
@@ -506,6 +506,15 @@ function extractErrorMessage(errObj) {
   return objectQuery(errObj, 'response', 'message') || objectQuery(errObj, 'response');
 }
 
+/**
+ * Returns true if the error message indicates unknown database error
+ * @param err the error message
+ * @returns boolean
+ */
+function isUnknownDatabaseError(err) {
+  return typeof err === 'string' && err.toLowerCase().startsWith('unknown database');
+}
+
 function connectWithStore(store, WrappedComponent, ...args) {
   const ConnectedWrappedComponent = connect(...args)(WrappedComponent);
   // eslint-disable-next-line react/display-name
@@ -783,6 +792,7 @@ export {
   removeEmptyJsonValues,
   handlePageLevelError,
   extractErrorMessage,
+  isUnknownDatabaseError,
   connectWithStore,
   dumbestClone,
   categorizeGraphQlErrors,


### PR DESCRIPTION
# Issue when you create a replication job with incorrect database name

## Description
it’s actually more a bad UI pattern rather than a bug. When database is not found in the replication assessment, the UI needs users to manually put in the correct database name and table(s) name, once both fields are filled, users can proceed. We added a clearer message to mitigate the obscurity. The best solution should be assessing the draft right after the "Configure source" tab. Will be in a new ticket.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-18781](https://cdap.atlassian.net/browse/CDAP-18781)

## Test Plan

## Screenshots
![image](https://user-images.githubusercontent.com/20428112/155242645-04aefb06-ef3c-477d-85ba-5fb134cda000.png)