### PR TITLE
[CDAP-17955] Do not block draft deployment for warnings in assessment

### DIFF
--- a/app/cdap/components/Replicator/Create/Content/Assessment/index.tsx
+++ b/app/cdap/components/Replicator/Create/Content/Assessment/index.tsx
@@ -14,13 +14,12 @@
  * the License.
  */
 
-import * as React from 'react';
+import React, { useState } from 'react';
 import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
 import { createContextConnect, ICreateContext } from 'components/Replicator/Create';
 import { getCurrentNamespace } from 'services/NamespaceStore';
 import { MyReplicatorApi } from 'api/replicator';
 import TablesAssessment from 'components/Replicator/Create/Content/Assessment/TablesAssessment';
-import If from 'components/shared/If';
 import classnames from 'classnames';
 import LoadingSVGCentered from 'components/shared/LoadingSVGCentered';
 import ConnectivityAssessment from 'components/Replicator/Create/Content/Assessment/ConnectivityAssessment';
@@ -98,12 +97,12 @@ const AssessmentView: React.FC<ICreateContext & WithStyles<typeof styles>> = ({
   classes,
   draftId,
 }) => {
-  const [loading, setLoading] = React.useState(true);
-  const [error, setError] = React.useState(null);
-  const [schemaErrorCount, setSchemaErrorCount] = React.useState(0);
-  const [view, setView] = React.useState(VIEWS.tables);
-  const [errorFeaturesCount, setErrorFeaturesCount] = React.useState(0);
-  const [assessment, setAssessment] = React.useState({
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [schemaErrorCount, setSchemaErrorCount] = useState(0);
+  const [errorFeaturesCount, setErrorFeaturesCount] = useState(0);
+  const [view, setView] = useState(VIEWS.tables);
+  const [assessment, setAssessment] = useState({
     tables: [],
     features: [],
     connectivity: [],
@@ -164,7 +163,7 @@ const AssessmentView: React.FC<ICreateContext & WithStyles<typeof styles>> = ({
         </div>
       </div>
 
-      <If condition={error}>
+      {error && (
         <React.Fragment>
           <br />
           <div className="text-danger">
@@ -172,9 +171,9 @@ const AssessmentView: React.FC<ICreateContext & WithStyles<typeof styles>> = ({
             <span>{error}</span>
           </div>
         </React.Fragment>
-      </If>
+      )}
 
-      <If condition={!loading && !error}>
+      {!loading && !error && (
         <React.Fragment>
           <div className={classes.headerLinks}>
             <span
@@ -205,23 +204,21 @@ const AssessmentView: React.FC<ICreateContext & WithStyles<typeof styles>> = ({
               [classes.schemaContentContainer]: view === VIEWS.tables,
             })}
           >
-            <If condition={view === VIEWS.tables}>
+            {view === VIEWS.tables && (
               <TablesAssessment
                 assessmentTables={assessment.tables}
                 runAssessment={runAssessment}
               />
-            </If>
+            )}
 
-            <If condition={view === VIEWS.features}>
-              <FeaturesAssessment features={assessment.features} />
-            </If>
+            {view === VIEWS.features && <FeaturesAssessment features={assessment.features} />}
 
-            <If condition={view === VIEWS.connectivity}>
+            {view === VIEWS.connectivity && (
               <ConnectivityAssessment connectivity={assessment.connectivity} />
-            </If>
+            )}
           </div>
         </React.Fragment>
-      </If>
+      )}
 
       <StepButtons
         // only block proceeding if assessment API did not return an error and if assessment has error issues

--- a/app/cdap/components/Replicator/Create/Content/Assessment/index.tsx
+++ b/app/cdap/components/Replicator/Create/Content/Assessment/index.tsx
@@ -89,6 +89,11 @@ enum VIEWS {
   connectivity = 'connectivity',
 }
 
+enum SEVERITY {
+  error = 'ERROR',
+  warning = 'WARNING',
+}
+
 const AssessmentView: React.FC<ICreateContext & WithStyles<typeof styles>> = ({
   classes,
   draftId,
@@ -97,6 +102,7 @@ const AssessmentView: React.FC<ICreateContext & WithStyles<typeof styles>> = ({
   const [error, setError] = React.useState(null);
   const [schemaErrorCount, setSchemaErrorCount] = React.useState(0);
   const [view, setView] = React.useState(VIEWS.tables);
+  const [errorFeaturesCount, setErrorFeaturesCount] = React.useState(0);
   const [assessment, setAssessment] = React.useState({
     tables: [],
     features: [],
@@ -120,6 +126,11 @@ const AssessmentView: React.FC<ICreateContext & WithStyles<typeof styles>> = ({
             schemaError++;
           }
         });
+
+        // Calculate the ERROR type features
+        const errorFeatures = res.features.filter((feature) => feature.severity === SEVERITY.error)
+          .length;
+        setErrorFeaturesCount(errorFeatures);
 
         setSchemaErrorCount(schemaError);
         setAssessment(res);
@@ -213,10 +224,9 @@ const AssessmentView: React.FC<ICreateContext & WithStyles<typeof styles>> = ({
       </If>
 
       <StepButtons
-        // only block proceeding if assessment API did not return an error and if assessment has issues
+        // only block proceeding if assessment API did not return an error and if assessment has error issues
         nextDisabled={
-          !error &&
-          schemaErrorCount + assessment.features.length + assessment.connectivity.length !== 0
+          !error && schemaErrorCount + errorFeaturesCount + assessment.connectivity.length !== 0
         }
       />
     </div>


### PR DESCRIPTION
# Do not block draft deployment for warnings in assessment

## Description
Currently, if users have some database or table name that doesn't meet the requirement of Big Query, users will get a warning in assessment saying that those names will be normalized. However for such warning, we should not block the deployment of the draft.

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-17955](https://cdap.atlassian.net/browse/CDAP-17955)

## Test Plan

## Screenshots
![image](https://user-images.githubusercontent.com/20428112/155397363-bd53c0df-7f2a-48fa-b473-5f46a1761084.png)


