### PR TITLE
Fixes partial connection selection in BQ and database plugins

### DIFF
--- a/app/cdap/components/Connections/Browser/GenericBrowser/BrowserTable.tsx
+++ b/app/cdap/components/Connections/Browser/GenericBrowser/BrowserTable.tsx
@@ -171,6 +171,12 @@ export function BrowserTable({
   let headers = ['Name', 'Type'];
   headers = [...headers, ...propertyHeaders];
 
+  const onEntitySelect = (entity: IBrowseEntity, event: React.SyntheticEvent) => {
+    loadEntitySpec(entity);
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
   if (!loading && (!Array.isArray(entities) || (Array.isArray(entities) && !entities.length))) {
     return (
       <Heading
@@ -229,7 +235,7 @@ export function BrowserTable({
                 })}
                 {hasSelectable && entity.canBrowse && (
                   <TableCell>
-                    <Button variant="contained" onClick={loadEntitySpec.bind(null, entity)}>
+                    <Button variant="contained" onClick={onEntitySelect.bind(null, entity)}>
                       Select
                     </Button>
                   </TableCell>

--- a/app/cdap/components/DataPrepConnections/PluginConnectionBrowser/index.tsx
+++ b/app/cdap/components/DataPrepConnections/PluginConnectionBrowser/index.tsx
@@ -93,8 +93,9 @@ class PluginConnectionBrowser extends React.PureComponent<
       },
       { updateFilteredConfigurationGroups: true }
     );
-    this.eventEmitter.emit('schema.import', schema);
-
+    if (schema) {
+      this.eventEmitter.emit('schema.import', schema);
+    }
     this.setState({
       showBrowserModal: false,
       connectionName: null,


### PR DESCRIPTION
# Fixes partial connection selection in BQ and database plugins

## Description
Fixes partial connection selection in BQ and database plugins. 

1) Stops row selection
2) Adds null check for schema as it's empty for BQ & db plugins.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [18872](https://cdap.atlassian.net/browse/CDAP-18872)



