### PR TITLE
CDAP-17765 add colon prefix to column names for Wrangler directives

### DIFF
--- a/app/cdap/components/DataPrep/Directives/Calculate/index.js
+++ b/app/cdap/components/DataPrep/Directives/Calculate/index.js
@@ -74,52 +74,52 @@ export default class Calculate extends Component {
       {
         name: 'ADD',
         validColTypes: NATIVE_NUMBER_TYPES,
-        expression: () => `${this.props.column} + ${this.state.operationInput}`,
+        expression: () => `:${this.props.column} + ${this.state.operationInput}`,
       },
       {
         name: 'SUBTRACT',
         validColTypes: NATIVE_NUMBER_TYPES,
-        expression: () => `${this.props.column} - ${this.state.operationInput}`,
+        expression: () => `:${this.props.column} - ${this.state.operationInput}`,
       },
       {
         name: 'MULTIPLY',
         validColTypes: NATIVE_NUMBER_TYPES,
-        expression: () => `${this.props.column} * ${this.state.operationInput}`,
+        expression: () => `:${this.props.column} * ${this.state.operationInput}`,
       },
       {
         name: 'DIVIDE',
         validColTypes: NATIVE_NUMBER_TYPES,
-        expression: () => `${this.props.column} / ${this.state.operationInput}`,
+        expression: () => `:${this.props.column} / ${this.state.operationInput}`,
       },
       {
         name: 'MODULO',
         validColTypes: NATIVE_NUMBER_TYPES,
-        expression: () => `${this.props.column} % ${this.state.operationInput}`,
+        expression: () => `:${this.props.column} % ${this.state.operationInput}`,
       },
       {
         name: 'DECIMALADD',
         validColTypes: ['bigdecimal'],
-        expression: () => `decimal:add(${this.props.column}, ${this.state.operationInput})`,
+        expression: () => `decimal:add(:${this.props.column}, ${this.state.operationInput})`,
       },
       {
         name: 'DECIMALSUBTRACT',
         validColTypes: ['bigdecimal'],
-        expression: () => `decimal:subtract(${this.props.column}, ${this.state.operationInput})`,
+        expression: () => `decimal:subtract(:${this.props.column}, ${this.state.operationInput})`,
       },
       {
         name: 'DECIMALMULTIPLY',
         validColTypes: ['bigdecimal'],
-        expression: () => `decimal:multiply(${this.props.column}, ${this.state.operationInput})`,
+        expression: () => `decimal:multiply(:${this.props.column}, ${this.state.operationInput})`,
       },
       {
         name: 'DECIMALDIVIDEQ',
         validColTypes: ['bigdecimal'],
-        expression: () => `decimal:divideq(${this.props.column}, ${this.state.operationInput})`,
+        expression: () => `decimal:divideq(:${this.props.column}, ${this.state.operationInput})`,
       },
       {
         name: 'DECIMALDIVIDER',
         validColTypes: ['bigdecimal'],
-        expression: () => `decimal:divider(${this.props.column}, ${this.state.operationInput})`,
+        expression: () => `decimal:divider(:${this.props.column}, ${this.state.operationInput})`,
       },
       {
         name: 'divider',
@@ -128,37 +128,37 @@ export default class Calculate extends Component {
       {
         name: 'POWEROF',
         validColTypes: NATIVE_NUMBER_TYPES,
-        expression: () => `math:pow(${this.props.column}, ${this.state.operationInput})`,
+        expression: () => `math:pow(:${this.props.column}, ${this.state.operationInput})`,
       },
       {
         name: 'SQUARE',
         validColTypes: NATIVE_NUMBER_TYPES,
-        expression: () => `math:pow(${this.props.column}, 2)`,
+        expression: () => `math:pow(:${this.props.column}, 2)`,
       },
       {
         name: 'SQUAREROOT',
         validColTypes: NATIVE_NUMBER_TYPES,
-        expression: () => `math:sqrt(${this.props.column})`,
+        expression: () => `math:sqrt(:${this.props.column})`,
       },
       {
         name: 'CUBE',
         validColTypes: NATIVE_NUMBER_TYPES,
-        expression: () => `math:pow(${this.props.column}, 3)`,
+        expression: () => `math:pow(:${this.props.column}, 3)`,
       },
       {
         name: 'CUBEROOT',
         validColTypes: NATIVE_NUMBER_TYPES,
-        expression: () => `math:cbrt(${this.props.column})`,
+        expression: () => `math:cbrt(:${this.props.column})`,
       },
       {
         name: 'LOG',
         validColTypes: NATIVE_NUMBER_TYPES,
-        expression: () => `math:log10(${this.props.column})`,
+        expression: () => `math:log10(:${this.props.column})`,
       },
       {
         name: 'NATURALLOG',
         validColTypes: NATIVE_NUMBER_TYPES,
-        expression: () => `math:log(${this.props.column})`,
+        expression: () => `math:log(:${this.props.column})`,
       },
       {
         name: 'divider',
@@ -167,17 +167,17 @@ export default class Calculate extends Component {
       {
         name: 'ABSVALUE',
         validColTypes: NATIVE_NUMBER_TYPES,
-        expression: () => `math:abs(${this.props.column})`,
+        expression: () => `math:abs(:${this.props.column})`,
       },
       {
         name: 'CEIL',
         validColTypes: NATIVE_NUMBER_TYPES,
-        expression: () => `math:ceil(${this.props.column})`,
+        expression: () => `math:ceil(:${this.props.column})`,
       },
       {
         name: 'FLOOR',
         validColTypes: NATIVE_NUMBER_TYPES,
-        expression: () => `math:floor(${this.props.column})`,
+        expression: () => `math:floor(:${this.props.column})`,
       },
       {
         name: 'divider',
@@ -186,32 +186,32 @@ export default class Calculate extends Component {
       {
         name: 'SIN',
         validColTypes: NATIVE_NUMBER_TYPES,
-        expression: () => `math:sin(${this.props.column})`,
+        expression: () => `math:sin(:${this.props.column})`,
       },
       {
         name: 'COS',
         validColTypes: NATIVE_NUMBER_TYPES,
-        expression: () => `math:cos(${this.props.column})`,
+        expression: () => `math:cos(:${this.props.column})`,
       },
       {
         name: 'TAN',
         validColTypes: NATIVE_NUMBER_TYPES,
-        expression: () => `math:tan(${this.props.column})`,
+        expression: () => `math:tan(:${this.props.column})`,
       },
       {
         name: 'ARCCOS',
         validColTypes: NATIVE_NUMBER_TYPES,
-        expression: () => `math:acos(${this.props.column})`,
+        expression: () => `math:acos(:${this.props.column})`,
       },
       {
         name: 'ARCSIN',
         validColTypes: NATIVE_NUMBER_TYPES,
-        expression: () => `math:asin(${this.props.column})`,
+        expression: () => `math:asin(:${this.props.column})`,
       },
       {
         name: 'ARCTAN',
         validColTypes: NATIVE_NUMBER_TYPES,
-        expression: () => `math:atan(${this.props.column})`,
+        expression: () => `math:atan(:${this.props.column})`,
       },
       {
         name: 'divider',
@@ -220,7 +220,7 @@ export default class Calculate extends Component {
       {
         name: 'ROUND',
         validColTypes: NATIVE_NUMBER_TYPES,
-        expression: () => `math:round(${this.props.column})`,
+        expression: () => `math:round(:${this.props.column})`,
       },
       {
         name: 'RANDOM',
@@ -230,67 +230,67 @@ export default class Calculate extends Component {
       {
         name: 'CHARCOUNT',
         validColTypes: ['string'],
-        expression: () => `string:length(${this.props.column})`,
+        expression: () => `string:length(:${this.props.column})`,
       },
       {
         name: 'PRECISION',
         validColTypes: ['bigdecimal'],
-        expression: () => `decimal:precision(${this.props.column})`,
+        expression: () => `decimal:precision(:${this.props.column})`,
       },
       {
         name: 'SCALE',
         validColTypes: ['bigdecimal'],
-        expression: () => `decimal:scale(${this.props.column})`,
+        expression: () => `decimal:scale(:${this.props.column})`,
       },
       {
         name: 'UNSCALED',
         validColTypes: ['bigdecimal'],
-        expression: () => `decimal:unscaled(${this.props.column})`,
+        expression: () => `decimal:unscaled(:${this.props.column})`,
       },
       {
         name: 'DECIMALLEFT',
         validColTypes: ['bigdecimal'],
-        expression: () => `decimal:decimal_left(${this.props.column}, ${this.state.operationInput})`,
+        expression: () => `decimal:decimal_left(:${this.props.column}, ${this.state.operationInput})`,
       },
       {
         name: 'DECIMALRIGHT',
         validColTypes: ['bigdecimal'],
-        expression: () => `decimal:decimal_right(${this.props.column}, ${this.state.operationInput})`,
+        expression: () => `decimal:decimal_right(:${this.props.column}, ${this.state.operationInput})`,
       },
       {
         name: 'DECIMALABSVALUE',
         validColTypes: ['bigdecimal'],
-        expression: () => `decimal:abs(${this.props.column})`,
+        expression: () => `decimal:abs(:${this.props.column})`,
       },
       {
         name: 'DECIMALPOWEROF',
         validColTypes: ['bigdecimal'],
-        expression: () => `decimal:pow(${this.props.column}, ${this.state.operationInput})`,
+        expression: () => `decimal:pow(:${this.props.column}, ${this.state.operationInput})`,
       },
       {
         name: 'DECIMALSQUARE',
         validColTypes: ['bigdecimal'],
-        expression: () => `decimal:pow(${this.props.column}, 2)`,
+        expression: () => `decimal:pow(:${this.props.column}, 2)`,
       },
       {
         name: 'DECIMALCUBE',
         validColTypes: ['bigdecimal'],
-        expression: () => `decimal:pow(${this.props.column}, 3)`,
+        expression: () => `decimal:pow(:${this.props.column}, 3)`,
       },
       {
         name: 'NEGATE',
         validColTypes: ['bigdecimal'],
-        expression: () => `decimal:negate(${this.props.column})`,
+        expression: () => `decimal:negate(:${this.props.column})`,
       },
       {
         name: 'STRIPZERO',
         validColTypes: ['bigdecimal'],
-        expression: () => `decimal:strip_zero(${this.props.column})`,
+        expression: () => `decimal:strip_zero(:${this.props.column})`,
       },
       {
         name: 'SIGN',
         validColTypes: ['bigdecimal'],
-        expression: () => `decimal:sign(${this.props.column})`,
+        expression: () => `decimal:sign(:${this.props.column})`,
       },
     ];
 

--- a/app/cdap/components/DataPrep/Directives/CustomTransform/index.js
+++ b/app/cdap/components/DataPrep/Directives/CustomTransform/index.js
@@ -70,7 +70,7 @@ export default class CustomTransform extends Component {
       return;
     }
 
-    let directive = `set-column ${this.props.column} ${this.state.input}`;
+    let directive = `set-column :${this.props.column} ${this.state.input}`;
 
     execute([directive]).subscribe(
       () => {

--- a/app/cdap/components/DataPrep/Directives/Explode/index.js
+++ b/app/cdap/components/DataPrep/Directives/Explode/index.js
@@ -72,7 +72,7 @@ export default class Explode extends Component {
   }
 
   handleUsingFilters(delimiter) {
-    const directive = `split-to-rows ${this.props.column} ${delimiter}`;
+    const directive = `split-to-rows :${this.props.column} ${delimiter}`;
     this.execute([directive]);
   }
 

--- a/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPatternsModal/index.js
+++ b/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPatternsModal/index.js
@@ -200,7 +200,7 @@ export default class UsingPatternsModal extends Component {
     if (!this.state.pattern) {
       return;
     }
-    let directive = `extract-regex-groups ${this.props.column} ${this.state.pattern}`;
+    let directive = `extract-regex-groups :${this.props.column} ${this.state.pattern}`;
     execute([directive]).subscribe(
       () => {
         this.props.onComplete();

--- a/app/cdap/components/DataPrep/Directives/Format/index.js
+++ b/app/cdap/components/DataPrep/Directives/Format/index.js
@@ -120,17 +120,17 @@ export default class Format extends Component {
     },
     {
       name: 'UPPERCASE',
-      onClick: this.applyDirective.bind(this, `uppercase ${this.props.column}`),
+      onClick: this.applyDirective.bind(this, `uppercase :${this.props.column}`),
       validColTypes: ['string'],
     },
     {
       name: 'LOWERCASE',
-      onClick: this.applyDirective.bind(this, `lowercase ${this.props.column}`),
+      onClick: this.applyDirective.bind(this, `lowercase :${this.props.column}`),
       validColTypes: ['string'],
     },
     {
       name: 'TITLECASE',
-      onClick: this.applyDirective.bind(this, `titlecase ${this.props.column}`),
+      onClick: this.applyDirective.bind(this, `titlecase :${this.props.column}`),
       validColTypes: ['string'],
     },
     {
@@ -140,17 +140,17 @@ export default class Format extends Component {
     },
     {
       name: 'TRIM_WHITESPACE',
-      onClick: this.applyDirective.bind(this, `trim ${this.props.column}`),
+      onClick: this.applyDirective.bind(this, `trim :${this.props.column}`),
       validColTypes: ['string'],
     },
     {
       name: 'TRIM_LEADING_WHITESPACE',
-      onClick: this.applyDirective.bind(this, `ltrim ${this.props.column}`),
+      onClick: this.applyDirective.bind(this, `ltrim :${this.props.column}`),
       validColTypes: ['string'],
     },
     {
       name: 'TRIM_TRAILING_WHITESPACE',
-      onClick: this.applyDirective.bind(this, `rtrim ${this.props.column}`),
+      onClick: this.applyDirective.bind(this, `rtrim :${this.props.column}`),
       validColTypes: ['string'],
     },
   ];
@@ -237,9 +237,9 @@ export default class Format extends Component {
     }
     let expression;
     if (this.state.concatOption === 'BEGINNING') {
-      expression = `'${this.state.formatInput}' + ${this.props.column}`;
+      expression = `'${this.state.formatInput}' + :${this.props.column}`;
     } else {
-      expression = `${this.props.column} + '${this.state.formatInput}'`;
+      expression = `:${this.props.column} + '${this.state.formatInput}'`;
     }
     let directive = `set-column ${destinationColumn} ${expression}`;
 

--- a/app/cdap/components/DataPrep/Directives/MarkAsError/index.js
+++ b/app/cdap/components/DataPrep/Directives/MarkAsError/index.js
@@ -106,7 +106,7 @@ export default class MarkAsError extends Component {
   state = {
     selectedCondition: conditionsOptions[0],
     conditionValue: '',
-    customCondition: `${this.props.column} == 0`,
+    customCondition: `:${this.props.column} == 0`,
     ignoreCase: false,
   };
 

--- a/app/cdap/components/DataPrep/Directives/MaskData/index.js
+++ b/app/cdap/components/DataPrep/Directives/MaskData/index.js
@@ -63,7 +63,7 @@ export default class MaskData extends Component {
     this.props.onComplete();
   }
   maskByShuffling() {
-    this.applyDirective(`mask-shuffle ${this.props.column}`);
+    this.applyDirective(`mask-shuffle :${this.props.column}`);
   }
   applyDirective(directive) {
     execute([directive]).subscribe(
@@ -101,11 +101,11 @@ export default class MaskData extends Component {
   }
   maskLast4Digits() {
     let pattern = this.maskLastNDigits(4);
-    this.applyDirective(`mask-number ${this.props.column} ${pattern}`);
+    this.applyDirective(`mask-number :${this.props.column} ${pattern}`);
   }
   maskLast2Digits() {
     let pattern = this.maskLastNDigits(2);
-    this.applyDirective(`mask-number ${this.props.column} ${pattern}`);
+    this.applyDirective(`mask-number :${this.props.column} ${pattern}`);
   }
   renderSubMenu() {
     if (!this.props.isOpen || !this.isDirectiveEnabled()) {


### PR DESCRIPTION
# [CDAP-17765] add colon prefix to column names for Wrangler directives

## Description
modified the components under wrangler directives, add ':' prefix to all '${this.props.column}'

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-17765](https://cdap.atlassian.net/browse/CDAP-17765)




[CDAP-17765]: https://cdap.atlassian.net/browse/CDAP-17765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ