### PR TITLE
CDAP-17765: add colon prefix to column name references

### DIFF
--- a/app/cdap/components/DataPrep/Directives/Calculate/index.js
+++ b/app/cdap/components/DataPrep/Directives/Calculate/index.js
@@ -537,7 +537,7 @@ export default class Calculate extends Component {
     ) {
       destinationColumn = this.state.newColumnInput;
     }
-    let directive = `set-column ${destinationColumn} ${expression}`;
+    let directive = `set-column :${destinationColumn} ${expression}`;
 
     execute([directive]).subscribe(
       () => {

--- a/app/cdap/components/DataPrep/Directives/CopyColumn/index.js
+++ b/app/cdap/components/DataPrep/Directives/CopyColumn/index.js
@@ -80,7 +80,7 @@ export default class CopyColumnDirective extends Component {
     let source = this.props.column;
     let destination = this.state.input;
 
-    let directive = `copy ${source} ${destination} true`;
+    let directive = `copy :${source} :${destination} true`;
 
     execute([directive]).subscribe(
       () => {

--- a/app/cdap/components/DataPrep/Directives/CustomTransform/index.js
+++ b/app/cdap/components/DataPrep/Directives/CustomTransform/index.js
@@ -70,7 +70,7 @@ export default class CustomTransform extends Component {
       return;
     }
 
-    let directive = `set-column ${this.props.column} ${this.state.input}`;
+    let directive = `set-column :${this.props.column} ${this.state.input}`;
 
     execute([directive]).subscribe(
       () => {

--- a/app/cdap/components/DataPrep/Directives/Decode/index.js
+++ b/app/cdap/components/DataPrep/Directives/Decode/index.js
@@ -25,19 +25,19 @@ const PREFIX = 'features.DataPrep.Directives.Decode';
 const DECODEOPTIONS = [
   {
     label: T.translate(`${PREFIX}.base64`),
-    getDirective: (column) => `decode base64 ${column}`,
+    getDirective: (column) => `decode base64 :${column}`,
   },
   {
     label: T.translate(`${PREFIX}.base32`),
-    getDirective: (column) => `decode base32 ${column}`,
+    getDirective: (column) => `decode base32 :${column}`,
   },
   {
     label: T.translate(`${PREFIX}.hex`),
-    getDirective: (column) => `decode hex ${column}`,
+    getDirective: (column) => `decode hex :${column}`,
   },
   {
     label: T.translate(`${PREFIX}.urldecode`),
-    getDirective: (column) => `url-decode ${column}`,
+    getDirective: (column) => `url-decode :${column}`,
   },
 ];
 export default function Decode({ onComplete, column, isOpen }) {

--- a/app/cdap/components/DataPrep/Directives/EncodeDecode/index.js
+++ b/app/cdap/components/DataPrep/Directives/EncodeDecode/index.js
@@ -31,19 +31,19 @@ const PREFIX = 'features.DataPrep.Directives.Encode';
 const ENCODEOPTIONS = [
   {
     label: T.translate(`${PREFIX}.base64`),
-    getDirective: (column) => `encode base64 ${column}`,
+    getDirective: (column) => `encode base64 :${column}`,
   },
   {
     label: T.translate(`${PREFIX}.base32`),
-    getDirective: (column) => `encode base32 ${column}`,
+    getDirective: (column) => `encode base32 :${column}`,
   },
   {
     label: T.translate(`${PREFIX}.hex`),
-    getDirective: (column) => `encode hex ${column}`,
+    getDirective: (column) => `encode hex :${column}`,
   },
   {
     label: T.translate(`${PREFIX}.url`),
-    getDirective: (column) => `url-encode ${column}`,
+    getDirective: (column) => `url-encode :${column}`,
   },
 ];
 export default class EncodeDecode extends Component {

--- a/app/cdap/components/DataPrep/Directives/Explode/index.js
+++ b/app/cdap/components/DataPrep/Directives/Explode/index.js
@@ -72,7 +72,7 @@ export default class Explode extends Component {
   }
 
   handleUsingFilters(delimiter) {
-    const directive = `split-to-rows ${this.props.column} ${delimiter}`;
+    const directive = `split-to-rows :${this.props.column} ${delimiter}`;
     this.execute([directive]);
   }
 
@@ -89,12 +89,20 @@ export default class Explode extends Component {
   }
 
   explodeByFlattening() {
-    const directive = `flatten ${this.props.column.toString()}`;
+    let column = `:${this.props.column.toString()}`;
+    if (Array.isArray(this.props.column) && this.props.column.length > 1) {
+      column = this.props.column.map(c => `:${c}`).join(',');
+    }
+    const directive = `flatten ${column}`;
     this.execute([directive]);
   }
 
   explodeRecordByFlattening() {
-    const directive = `flatten-record :${this.props.column.toString()}`;
+    let column = `:${this.props.column.toString()}`;
+    if (Array.isArray(this.props.column) && this.props.column.length > 1) {
+      column = this.props.column.map(c => `:${c}`).join(',');
+    }
+    const directive = `flatten-record ${column}`;
     this.execute([directive]);
   }
 

--- a/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPatternsModal/index.js
+++ b/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPatternsModal/index.js
@@ -200,7 +200,7 @@ export default class UsingPatternsModal extends Component {
     if (!this.state.pattern) {
       return;
     }
-    let directive = `extract-regex-groups ${this.props.column} ${this.state.pattern}`;
+    let directive = `extract-regex-groups :${this.props.column} ${this.state.pattern}`;
     execute([directive]).subscribe(
       () => {
         this.props.onComplete();

--- a/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPositions/CutDirective.js
+++ b/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPositions/CutDirective.js
@@ -61,7 +61,7 @@ export default class CutDirective extends Component {
     }
     let { start, end } = this.state.textSelectionRange;
     if (!isNil(start) && !isNil(end)) {
-      let directive = `cut-character ${this.props.columns[0]} ${this.newColName} ${start +
+      let directive = `cut-character :${this.props.columns[0]} :${this.newColName} ${start +
         1}-${end}`;
       execute([directive]).subscribe(
         () => {

--- a/app/cdap/components/DataPrep/Directives/ExtractFields/index.js
+++ b/app/cdap/components/DataPrep/Directives/ExtractFields/index.js
@@ -129,7 +129,7 @@ export default class ExtractFields extends Component {
 
   handleUsingDelimiters(delimiter) {
     let column = this.props.column;
-    let directive = `split-to-columns ${column} ${delimiter}`;
+    let directive = `split-to-columns :${column} ${delimiter}`;
     this.execute([directive]);
   }
 

--- a/app/cdap/components/DataPrep/Directives/FindAndReplace/index.js
+++ b/app/cdap/components/DataPrep/Directives/FindAndReplace/index.js
@@ -122,7 +122,7 @@ export default class FindAndReplaceDirective extends Component {
     if (this.state.exactMatch) {
       findInput = `^${findInput}$`;
     }
-    let directive = `find-and-replace ${column} s/${findInput}/${replaceInput}`;
+    let directive = `find-and-replace :${column} s/${findInput}/${replaceInput}`;
 
     if (this.state.ignoreCase) {
       directive = `${directive}/Ig`;

--- a/app/cdap/components/DataPrep/Directives/Format/index.js
+++ b/app/cdap/components/DataPrep/Directives/Format/index.js
@@ -120,17 +120,17 @@ export default class Format extends Component {
     },
     {
       name: 'UPPERCASE',
-      onClick: this.applyDirective.bind(this, `uppercase ${this.props.column}`),
+      onClick: this.applyDirective.bind(this, `uppercase :${this.props.column}`),
       validColTypes: ['string'],
     },
     {
       name: 'LOWERCASE',
-      onClick: this.applyDirective.bind(this, `lowercase ${this.props.column}`),
+      onClick: this.applyDirective.bind(this, `lowercase :${this.props.column}`),
       validColTypes: ['string'],
     },
     {
       name: 'TITLECASE',
-      onClick: this.applyDirective.bind(this, `titlecase ${this.props.column}`),
+      onClick: this.applyDirective.bind(this, `titlecase :${this.props.column}`),
       validColTypes: ['string'],
     },
     {
@@ -140,17 +140,17 @@ export default class Format extends Component {
     },
     {
       name: 'TRIM_WHITESPACE',
-      onClick: this.applyDirective.bind(this, `trim ${this.props.column}`),
+      onClick: this.applyDirective.bind(this, `trim :${this.props.column}`),
       validColTypes: ['string'],
     },
     {
       name: 'TRIM_LEADING_WHITESPACE',
-      onClick: this.applyDirective.bind(this, `ltrim ${this.props.column}`),
+      onClick: this.applyDirective.bind(this, `ltrim :${this.props.column}`),
       validColTypes: ['string'],
     },
     {
       name: 'TRIM_TRAILING_WHITESPACE',
-      onClick: this.applyDirective.bind(this, `rtrim ${this.props.column}`),
+      onClick: this.applyDirective.bind(this, `rtrim :${this.props.column}`),
       validColTypes: ['string'],
     },
   ];
@@ -241,7 +241,7 @@ export default class Format extends Component {
     } else {
       expression = `${this.props.column} + '${this.state.formatInput}'`;
     }
-    let directive = `set-column ${destinationColumn} ${expression}`;
+    let directive = `set-column :${destinationColumn} ${expression}`;
 
     this.applyDirective(directive);
   };

--- a/app/cdap/components/DataPrep/Directives/Hash/index.tsx
+++ b/app/cdap/components/DataPrep/Directives/Hash/index.tsx
@@ -145,7 +145,7 @@ export default class Hash extends Component<IHashProps> {
     const column = this.props.column;
     const hashAlgorithm = this.state.selectedHashAlgorithm;
     const encode = this.state.encode;
-    directive = `hash ${column} ${hashAlgorithm} ${encode}`;
+    directive = `hash :${column} ${hashAlgorithm} ${encode}`;
 
     this.execute([directive]);
   };

--- a/app/cdap/components/DataPrep/Directives/KeepColumn/index.js
+++ b/app/cdap/components/DataPrep/Directives/KeepColumn/index.js
@@ -30,7 +30,10 @@ export default class KeepColumnDirective extends Component {
   }
 
   applyDirective() {
-    let column = this.props.column.toString();
+    let column = `:${this.props.column.toString()}`;
+    if (Array.isArray(this.props.column) && this.props.column.length > 1) {
+      column = this.props.column.map(c => `:${c}`).join(',');
+    }
     let directive = `keep ${column}`;
 
     execute([directive]).subscribe(

--- a/app/cdap/components/DataPrep/Directives/MaskData/MaskSelection/index.js
+++ b/app/cdap/components/DataPrep/Directives/MaskData/MaskSelection/index.js
@@ -69,7 +69,7 @@ export default class MaskSelection extends Component {
   }
   applyDirective() {
     let pattern = this.getPattern();
-    let directive = [`mask-number ${this.props.columns.toString()} ${pattern}`];
+    let directive = [`mask-number :${this.props.columns.toString()} ${pattern}`];
     execute(directive).subscribe(
       () => {
         this.props.onClose();

--- a/app/cdap/components/DataPrep/Directives/MaskData/index.js
+++ b/app/cdap/components/DataPrep/Directives/MaskData/index.js
@@ -63,7 +63,7 @@ export default class MaskData extends Component {
     this.props.onComplete();
   }
   maskByShuffling() {
-    this.applyDirective(`mask-shuffle ${this.props.column}`);
+    this.applyDirective(`mask-shuffle :${this.props.column}`);
   }
   applyDirective(directive) {
     execute([directive]).subscribe(
@@ -101,11 +101,11 @@ export default class MaskData extends Component {
   }
   maskLast4Digits() {
     let pattern = this.maskLastNDigits(4);
-    this.applyDirective(`mask-number ${this.props.column} ${pattern}`);
+    this.applyDirective(`mask-number :${this.props.column} ${pattern}`);
   }
   maskLast2Digits() {
     let pattern = this.maskLastNDigits(2);
-    this.applyDirective(`mask-number ${this.props.column} ${pattern}`);
+    this.applyDirective(`mask-number :${this.props.column} ${pattern}`);
   }
   renderSubMenu() {
     if (!this.props.isOpen || !this.isDirectiveEnabled()) {

--- a/app/cdap/components/DataPrep/Directives/MergeColumns/index.js
+++ b/app/cdap/components/DataPrep/Directives/MergeColumns/index.js
@@ -129,9 +129,9 @@ export default class MergeColumnsDirective extends Component {
       delimiterSymbol = this.state.customDelimiter;
     }
 
-    let directive = `merge ${this.state.firstColumn} ${
+    let directive = `merge :${this.state.firstColumn} :${
       this.state.secondColumn
-    } ${newColumnInput} ${delimiterSymbol}`;
+    } :${newColumnInput} ${delimiterSymbol}`;
 
     execute([directive]).subscribe(
       () => {

--- a/app/cdap/components/DataPrep/Directives/SetCharacterEncoding/index.js
+++ b/app/cdap/components/DataPrep/Directives/SetCharacterEncoding/index.js
@@ -26,27 +26,27 @@ const PREFIX = 'features.DataPrep.Directives.SetCharEncoding';
 const CHARENCODINGOPTIONS = [
   {
     label: T.translate(`${PREFIX}.utf8`),
-    getDirective: (column) => `set-charset ${column} 'utf-8'`,
+    getDirective: (column) => `set-charset :${column} 'utf-8'`,
   },
   {
     label: T.translate(`${PREFIX}.utf16`),
-    getDirective: (column) => `set-charset ${column} 'utf-16'`,
+    getDirective: (column) => `set-charset :${column} 'utf-16'`,
   },
   {
     label: T.translate(`${PREFIX}.usascii`),
-    getDirective: (column) => `set-charset ${column} 'us-ascii'`,
+    getDirective: (column) => `set-charset :${column} 'us-ascii'`,
   },
   {
     label: T.translate(`${PREFIX}.iso88591`),
-    getDirective: (column) => `set-charset ${column} 'iso-8859-1'`,
+    getDirective: (column) => `set-charset :${column} 'iso-8859-1'`,
   },
   {
     label: T.translate(`${PREFIX}.utf16be`),
-    getDirective: (column) => `set-charset ${column} 'utf-16be'`,
+    getDirective: (column) => `set-charset :${column} 'utf-16be'`,
   },
   {
     label: T.translate(`${PREFIX}.utf16le`),
-    getDirective: (column) => `set-charset ${column} 'utf-16le'`,
+    getDirective: (column) => `set-charset :${column} 'utf-16le'`,
   },
 ];
 

--- a/app/cdap/components/DataPrep/Directives/SwapColumns/index.js
+++ b/app/cdap/components/DataPrep/Directives/SwapColumns/index.js
@@ -30,7 +30,7 @@ export default class SwapColumnsDirective extends Component {
 
   applyDirective() {
     let columns = this.props.column;
-    let directive = `swap ${columns[0]} ${columns[1]}`;
+    let directive = `swap :${columns[0]} :${columns[1]}`;
 
     execute([directive]).subscribe(
       () => {


### PR DESCRIPTION
# CDAP-17765: add colon prefix to column name references

## Description
Add preceding colon for column names that are NOT in an expression in transformation steps commands from Wrangler UI. 

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-17765](https://cdap.atlassian.net/browse/CDAP-17765)

## Test Plan
tested each changed command manually


