### PR TITLE
CDAP-18170: Add manual check for MySQL JDBC

### DIFF
--- a/app/cdap/components/Connections/Create/index.tsx
+++ b/app/cdap/components/Connections/Create/index.tsx
@@ -204,25 +204,30 @@ export function CreateConnection({
     setConfigurationErrors(null);
     setTestInProgress(true);
 
-    try {
-      const testResult = await testConnection(connectionConfiguration);
-      setTestResponseMessages(testResult);
-      setTestSucceeded(!testResult);
-
-      if (testResult) {
-        const configErrors = constructErrors(testResult);
-        // All test errors will be shown next to the test button,
-        // so don't repeat orphaned errors
-        const { orphanErrors, ...assignedErrors } = configErrors.propertyErrors;
-        setConfigurationErrors(assignedErrors);
-      } else {
-        setConfigurationErrors(null);
-      }
-    } catch (e) {
-      const errorMsg = extractErrorMessage(e);
-      setError(`A server error occurred when testing the connection. Error: ${errorMsg}`);
-    } finally {
+    if (selectedConnector.name === 'MySQL' && !('jdbcPluginName' in properties)) {
+      setError('MySQL connection requires a JDBC Driver');
       setTestInProgress(false);
+    } else {
+      try {
+        const testResult = await testConnection(connectionConfiguration);
+        setTestResponseMessages(testResult);
+        setTestSucceeded(!testResult);
+
+        if (testResult) {
+          const configErrors = constructErrors(testResult);
+          // All test errors will be shown next to the test button,
+          // so don't repeat orphaned errors
+          const { orphanErrors, ...assignedErrors } = configErrors.propertyErrors;
+          setConfigurationErrors(assignedErrors);
+        } else {
+          setConfigurationErrors(null);
+        }
+      } catch (e) {
+        const errorMsg = extractErrorMessage(e);
+        setError(`A server error occurred when testing the connection. Error: ${errorMsg}`);
+      } finally {
+        setTestInProgress(false);
+      }
     }
   };
 

--- a/app/cdap/components/Connections/Create/index.tsx
+++ b/app/cdap/components/Connections/Create/index.tsx
@@ -207,27 +207,27 @@ export function CreateConnection({
     if (selectedConnector.name === 'MySQL' && !('jdbcPluginName' in properties)) {
       setError('MySQL connection requires a JDBC Driver');
       setTestInProgress(false);
-    } else {
-      try {
-        const testResult = await testConnection(connectionConfiguration);
-        setTestResponseMessages(testResult);
-        setTestSucceeded(!testResult);
+      return;
+    }
+    try {
+      const testResult = await testConnection(connectionConfiguration);
+      setTestResponseMessages(testResult);
+      setTestSucceeded(!testResult);
 
-        if (testResult) {
-          const configErrors = constructErrors(testResult);
-          // All test errors will be shown next to the test button,
-          // so don't repeat orphaned errors
-          const { orphanErrors, ...assignedErrors } = configErrors.propertyErrors;
-          setConfigurationErrors(assignedErrors);
-        } else {
-          setConfigurationErrors(null);
-        }
-      } catch (e) {
-        const errorMsg = extractErrorMessage(e);
-        setError(`A server error occurred when testing the connection. Error: ${errorMsg}`);
-      } finally {
-        setTestInProgress(false);
+      if (testResult) {
+        const configErrors = constructErrors(testResult);
+        // All test errors will be shown next to the test button,
+        // so don't repeat orphaned errors
+        const { orphanErrors, ...assignedErrors } = configErrors.propertyErrors;
+        setConfigurationErrors(assignedErrors);
+      } else {
+        setConfigurationErrors(null);
       }
+    } catch (e) {
+      const errorMsg = extractErrorMessage(e);
+      setError(`A server error occurred when testing the connection. Error: ${errorMsg}`);
+    } finally {
+      setTestInProgress(false);
     }
   };
 


### PR DESCRIPTION
# CDAP-18170: Add manual check for MySQL JDBC

## Description
Add a manual check to see if user has input JDBC plugin for MySQL connection when clicking test connection, preventing unnecessary api call

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-18170](https://cdap.atlassian.net/browse/CDAP-18170)

## Test Plan
manual test


