### PR TITLE
CDAP-18898 Clear stale error after canceling Parsing Options dialog

### DIFF
--- a/app/cdap/components/Connections/Browser/GenericBrowser/index.tsx
+++ b/app/cdap/components/Connections/Browser/GenericBrowser/index.tsx
@@ -206,6 +206,7 @@ export function GenericBrowser({ initialConnectionId, onEntityChange, selectedPa
 
   const onCancelParsingConfig = () => {
     setShowConfigModal(false);
+    setParsingConfigErrorMessage(null);
     setSelectedEntity(null);
   };
 


### PR DESCRIPTION
# TITLE
CDAP-18898 Clear stale error after canceling Parsing Options dialog

## Description
The error message state was not cleared when the dialog was canceled, so it was being passed in as a prop to the new dialog instance.

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-18898](https://cdap.atlassian.net/browse/CDAP-18898)

## Test Plan
Manual verification

## Screenshots
N/A


