### PR TITLE
CDAP-17954: add dynamic hiding overflow values for multiSelect

### DIFF
--- a/app/cdap/components/AbstractWidget/FormInputs/MultiSelect/index.tsx
+++ b/app/cdap/components/AbstractWidget/FormInputs/MultiSelect/index.tsx
@@ -20,6 +20,8 @@ import Checkbox from '@material-ui/core/Checkbox';
 import { IWidgetProps } from 'components/AbstractWidget';
 import ListItemText from '@material-ui/core/ListItemText';
 import MenuItem from '@material-ui/core/MenuItem';
+import Box from '@material-ui/core/Box';
+import Chip from '@material-ui/core/Chip';
 import Select from '@material-ui/core/Select';
 import { WIDGET_PROPTYPES } from 'components/AbstractWidget/constants';
 import { objectQuery } from 'services/helpers';
@@ -41,6 +43,9 @@ const styles = (theme) => {
   return {
     root: {
       margin: theme.Spacing(2),
+    },
+    chip: {
+      margin: 1,
     },
   };
 };
@@ -74,7 +79,7 @@ function MultiSelectBase({
 
   // Get the width of the select box for different window size
   const ref = useRef(null);
-  const [selectWidth, setSelectWidth] = useState(500);
+  const [selectWidth, setSelectWidth] = useState(600);
 
   //  onChangeHandler takes array, turns it into string w/delimiter, and calls onChange on the string
   const onChangeHandler = (event: React.ChangeEvent<HTMLSelectElement>) => {
@@ -106,27 +111,40 @@ function MultiSelectBase({
     }
 
     if (!showSelectionCount) {
-      const selectionText = selections
-        .map((sel) => {
-          const element = options.find((op) => op.id === sel);
-          return element ? element.label : '';
-        })
-        .join(', ');
-      return selectionText;
+      return (
+        <Box>
+          {selections.map((item) => (
+            <Chip className={classes.chip} variant="outlined" key={item} label={item} />
+          ))}
+        </Box>
+      );
     }
-    let selectionLabel = '';
+    const shownSelections = [];
     let additionalSelectionCount = '';
     for (let i = 0; i < selections.length; i++) {
-      // 10 is some magic number that I think will be able to render all options
-      if (selectionLabel.length * 10 < selectWidth) {
+      // 50 is some magic number that I think will be able to render all options
+      if (shownSelections.length * 100 < selectWidth) {
         // can show more
-        selectionLabel += selections[i] + ', ';
+        shownSelections.push(selections[i]);
       } else {
-        additionalSelectionCount = `+${selections.length - i}`;
+        additionalSelectionCount = `...${selections.length - i} more`;
         break;
       }
     }
-    return `${selectionLabel} ${additionalSelectionCount}`;
+    return (
+      <Box>
+        {shownSelections.map((value) => (
+          <Chip className={classes.chip} variant="outlined" key={value} label={value} />
+        ))}
+        {additionalSelectionCount != '' && (
+          <Chip
+            className={classes.chip}
+            key={additionalSelectionCount}
+            label={additionalSelectionCount}
+          />
+        )}
+      </Box>
+    );
   }
   const selectionsSet = new Set(selections);
   return (

--- a/app/cdap/components/AbstractWidget/FormInputs/MultiSelect/index.tsx
+++ b/app/cdap/components/AbstractWidget/FormInputs/MultiSelect/index.tsx
@@ -40,10 +40,11 @@ const styles = (theme) => {
       margin: theme.Spacing(2),
     },
     chip: {
-      margin: 1,
+      margin: 2,
+      backgroundColor: 'white',
     },
     hyperlink: {
-      margin: 1,
+      margin: 2,
       color: '#0000EE',
     },
   };
@@ -131,7 +132,7 @@ function MultiSelectBase({
     let additionalSelectionCount = '';
     let additionalSelectionText = '';
     for (let i = 0; i < selections.length; i++) {
-      // 50 is some magic number that I think will be able to render all options
+      // 100 is some magic number that I think will be able to render all options
       if (shownSelections.length * 100 < selectWidth) {
         // can show more
         shownSelections.push(selections[i]);

--- a/app/cdap/components/AbstractWidget/FormInputs/MultiSelect/index.tsx
+++ b/app/cdap/components/AbstractWidget/FormInputs/MultiSelect/index.tsx
@@ -46,17 +46,14 @@ const styles = (theme) => {
       margin: 2,
       color: '#0000EE',
     },
+    tooltip: {
+      backgroundColor: theme.palette.common.white,
+      color: 'rgba(0, 0, 0, 0.87)',
+      boxShadow: theme.shadows[1],
+      fontSize: 11,
+    },
   };
 };
-
-const LightTooltip = withStyles((theme) => ({
-  tooltip: {
-    backgroundColor: theme.palette.common.white,
-    color: 'rgba(0, 0, 0, 0.87)',
-    boxShadow: theme.shadows[1],
-    fontSize: 11,
-  },
-}))(Tooltip);
 
 interface IMultiSelectProps
   extends IWidgetProps<IMultiSelectWidgetProps>,
@@ -147,9 +144,13 @@ function MultiSelectBase({
           <Chip className={classes.chip} variant="outlined" key={item} label={item} />
         ))}
         {additionalSelectionCount !== '' && (
-          <LightTooltip title={additionalSelectionText} placement="right-start">
+          <Tooltip
+            classes={{ tooltip: classes.tooltip }}
+            title={additionalSelectionText}
+            placement="right-start"
+          >
             <a className={classes.hyperlink}>{additionalSelectionCount}</a>
-          </LightTooltip>
+          </Tooltip>
         )}
       </Box>
     );

--- a/app/cdap/components/AbstractWidget/FormInputs/MultiSelect/index.tsx
+++ b/app/cdap/components/AbstractWidget/FormInputs/MultiSelect/index.tsx
@@ -16,13 +16,8 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 
-import Checkbox from '@material-ui/core/Checkbox';
 import { IWidgetProps } from 'components/AbstractWidget';
-import ListItemText from '@material-ui/core/ListItemText';
-import MenuItem from '@material-ui/core/MenuItem';
-import Box from '@material-ui/core/Box';
-import Chip from '@material-ui/core/Chip';
-import Select from '@material-ui/core/Select';
+import { Tooltip, Checkbox, ListItemText, MenuItem, Box, Chip, Select } from '@material-ui/core';
 import { WIDGET_PROPTYPES } from 'components/AbstractWidget/constants';
 import { objectQuery } from 'services/helpers';
 import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
@@ -47,8 +42,21 @@ const styles = (theme) => {
     chip: {
       margin: 1,
     },
+    hyperlink: {
+      margin: 1,
+      color: '#0000EE',
+    },
   };
 };
+
+const LightTooltip = withStyles((theme) => ({
+  tooltip: {
+    backgroundColor: theme.palette.common.white,
+    color: 'rgba(0, 0, 0, 0.87)',
+    boxShadow: theme.shadows[1],
+    fontSize: 11,
+  },
+}))(Tooltip);
 
 interface IMultiSelectProps
   extends IWidgetProps<IMultiSelectWidgetProps>,
@@ -121,6 +129,7 @@ function MultiSelectBase({
     }
     const shownSelections = [];
     let additionalSelectionCount = '';
+    let additionalSelectionText = '';
     for (let i = 0; i < selections.length; i++) {
       // 50 is some magic number that I think will be able to render all options
       if (shownSelections.length * 100 < selectWidth) {
@@ -128,6 +137,7 @@ function MultiSelectBase({
         shownSelections.push(selections[i]);
       } else {
         additionalSelectionCount = `...${selections.length - i} more`;
+        additionalSelectionText = selections.slice(i, selections.length).join(', ');
         break;
       }
     }
@@ -137,11 +147,9 @@ function MultiSelectBase({
           <Chip className={classes.chip} variant="outlined" key={value} label={value} />
         ))}
         {additionalSelectionCount != '' && (
-          <Chip
-            className={classes.chip}
-            key={additionalSelectionCount}
-            label={additionalSelectionCount}
-          />
+          <LightTooltip title={additionalSelectionText} placement="right-start">
+            <u className={classes.hyperlink}>{additionalSelectionCount}</u>
+          </LightTooltip>
         )}
       </Box>
     );

--- a/app/cdap/components/AbstractWidget/FormInputs/MultiSelect/index.tsx
+++ b/app/cdap/components/AbstractWidget/FormInputs/MultiSelect/index.tsx
@@ -15,7 +15,6 @@
  */
 
 import React, { useEffect, useRef, useState } from 'react';
-
 import { IWidgetProps } from 'components/AbstractWidget';
 import { Tooltip, Checkbox, ListItemText, MenuItem, Box, Chip, Select } from '@material-ui/core';
 import { WIDGET_PROPTYPES } from 'components/AbstractWidget/constants';
@@ -144,12 +143,12 @@ function MultiSelectBase({
     }
     return (
       <Box>
-        {shownSelections.map((value) => (
-          <Chip className={classes.chip} variant="outlined" key={value} label={value} />
+        {shownSelections.map((item) => (
+          <Chip className={classes.chip} variant="outlined" key={item} label={item} />
         ))}
-        {additionalSelectionCount != '' && (
+        {additionalSelectionCount !== '' && (
           <LightTooltip title={additionalSelectionText} placement="right-start">
-            <u className={classes.hyperlink}>{additionalSelectionCount}</u>
+            <a className={classes.hyperlink}>{additionalSelectionCount}</a>
           </LightTooltip>
         )}
       </Box>

--- a/app/cdap/components/AbstractWidget/FormInputs/MultiSelect/index.tsx
+++ b/app/cdap/components/AbstractWidget/FormInputs/MultiSelect/index.tsx
@@ -15,6 +15,7 @@
  */
 
 import React, { useEffect, useRef, useState } from 'react';
+import styled from 'styled-components';
 import { IWidgetProps } from 'components/AbstractWidget';
 import { Tooltip, Checkbox, ListItemText, MenuItem, Box, Chip, Select } from '@material-ui/core';
 import { WIDGET_PROPTYPES } from 'components/AbstractWidget/constants';
@@ -38,14 +39,7 @@ const styles = (theme) => {
     root: {
       margin: theme.Spacing(2),
     },
-    chip: {
-      margin: 2,
-      backgroundColor: 'white',
-    },
-    hyperlink: {
-      margin: 2,
-      color: '#0000EE',
-    },
+    // unable to use styled component for Tooltip
     tooltip: {
       backgroundColor: theme.palette.common.white,
       color: 'rgba(0, 0, 0, 0.87)',
@@ -54,6 +48,15 @@ const styles = (theme) => {
     },
   };
 };
+
+const StyledChip = styled(Chip)`
+  margin: 3px;
+  background-color: white;
+`;
+
+const Hyperlink = styled.a`
+  margin: 3px;
+`;
 
 interface IMultiSelectProps
   extends IWidgetProps<IMultiSelectWidgetProps>,
@@ -119,7 +122,7 @@ function MultiSelectBase({
       return (
         <Box>
           {selections.map((item) => (
-            <Chip className={classes.chip} variant="outlined" key={item} label={item} />
+            <StyledChip variant="outlined" key={item} label={item} />
           ))}
         </Box>
       );
@@ -141,7 +144,7 @@ function MultiSelectBase({
     return (
       <Box>
         {shownSelections.map((item) => (
-          <Chip className={classes.chip} variant="outlined" key={item} label={item} />
+          <StyledChip variant="outlined" key={item} label={item} />
         ))}
         {additionalSelectionCount !== '' && (
           <Tooltip
@@ -149,7 +152,7 @@ function MultiSelectBase({
             title={additionalSelectionText}
             placement="right-start"
           >
-            <a className={classes.hyperlink}>{additionalSelectionCount}</a>
+            <Hyperlink>{additionalSelectionCount}</Hyperlink>
           </Tooltip>
         )}
       </Box>


### PR DESCRIPTION
# CDAP-17954: add dynamic hiding overflow values for multiSelect

## Description
Changed the logic of how MultiSelect renders values. Before it shows <firstElement> + <totalcount - 1>. Now it will try to fill out the available space then show the remaining count number (see attached screenshots)

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-17954](https://cdap.atlassian.net/browse/CDAP-17954)

## Test Plan
Manual test

## Screenshots
<img width="819" alt="image" src="https://user-images.githubusercontent.com/98125204/156858541-fa2063d3-71c9-4209-826c-9cae1cc53ce9.png">
<img width="460" alt="image" src="https://user-images.githubusercontent.com/98125204/156858594-95499f1b-b1ec-4c9d-b4f8-3f6882ef7e97.png">


