### PR TITLE
Add loading button HOC and use for Test Connection

### DIFF
--- a/app/cdap/components/Connections/Create/ConnectionConfiguration/ConnectionConfigForm.tsx
+++ b/app/cdap/components/Connections/Create/ConnectionConfiguration/ConnectionConfigForm.tsx
@@ -16,11 +16,14 @@
 
 import * as React from 'react';
 import ConfigurationGroup from 'components/shared/ConfigurationGroup';
-import { Button } from '@material-ui/core';
 import makeStyle from '@material-ui/core/styles/makeStyles';
 import PropertyRow from 'components/shared/ConfigurationGroup/PropertyRow';
-import LoadingSVG from 'components/shared/LoadingSVG';
 import Alert from '@material-ui/lab/Alert';
+import PrimaryContainedButton from 'components/shared/Buttons/PrimaryContainedButton';
+import PrimaryOutlinedButton from 'components/shared/Buttons/PrimaryOutlinedButton';
+import ButtonLoadingHoc from 'components/shared/Buttons/ButtonLoadingHoc';
+
+const PrimaryOutlinedLoadingButton = ButtonLoadingHoc(PrimaryOutlinedButton);
 
 const useStyle = makeStyle((theme) => {
   return {
@@ -109,8 +112,6 @@ export function ConnectionConfigForm({
         errors={testResults.configurationErrors}
       />
       <div className={classes.connectionTestMessage}>
-        {testResults.inProgress && <LoadingSVG height="1rem" />}
-
         {testResults.succeeded && (
           <Alert severity="success" className={classes.alert} data-cy="connection-test-success">
             Successfully connected.
@@ -130,16 +131,15 @@ export function ConnectionConfigForm({
           ))}
       </div>
       <div className={classes.formStyles}>
-        <Button
-          variant="outlined"
-          color="primary"
+        <PrimaryOutlinedLoadingButton
+          loading={testResults.inProgress}
           onClick={() => onConnectionTest({ properties: values })}
           disabled={testResults.inProgress}
           data-cy="connection-test-button"
         >
           Test Connection
-        </Button>
-        <Button
+        </PrimaryOutlinedLoadingButton>
+        <PrimaryContainedButton
           variant="contained"
           color="primary"
           onClick={() =>
@@ -152,7 +152,7 @@ export function ConnectionConfigForm({
           data-cy="connection-submit-button"
         >
           {isEdit ? 'Save' : 'Create'}
-        </Button>
+        </PrimaryContainedButton>
       </div>
     </div>
   );

--- a/app/cdap/components/shared/Buttons/ButtonLoadingHoc/index.tsx
+++ b/app/cdap/components/shared/Buttons/ButtonLoadingHoc/index.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React from 'react';
+import ButtonLoadingIcon from '../ButtonLoadingIcon';
+
+export default function ButtonLoadingHoc(BaseButton) {
+  return (props) => {
+    return (
+      <BaseButton
+        {...props}
+        disabled={props.disabled || props.loading}
+        startIcon={props.loading && <ButtonLoadingIcon />}
+      />
+    );
+  };
+}

--- a/app/cdap/components/shared/Buttons/Buttons.stories.tsx
+++ b/app/cdap/components/shared/Buttons/Buttons.stories.tsx
@@ -19,6 +19,7 @@ import PrimaryContainedButton from './PrimaryContainedButton';
 import PrimaryTextButton from './PrimaryTextButton';
 import PrimaryOutlinedButton from './PrimaryOutlinedButton';
 import ButtonLoadingIcon from './ButtonLoadingIcon';
+import ButtonLoadingHoc from './ButtonLoadingHoc';
 
 export default {
   title: 'MuiButtons',
@@ -67,15 +68,12 @@ PrimaryOutlined.argTypes = {
   onClick: { action: 'click' },
 };
 
+const PrimaryContainedLoadingButton = ButtonLoadingHoc(PrimaryContainedButton);
+
 export const LoadingButton = ({ label, loading, disabled, onClick, ...args }) => (
-  <PrimaryContainedButton
-    onClick={onClick}
-    startIcon={loading && <ButtonLoadingIcon />}
-    disabled={disabled || loading}
-    {...args}
-  >
+  <PrimaryContainedLoadingButton onClick={onClick} loading={loading} disabled={disabled} {...args}>
     {label}
-  </PrimaryContainedButton>
+  </PrimaryContainedLoadingButton>
 );
 LoadingButton.args = {
   disabled: false,


### PR DESCRIPTION
# Add loading button HOC and use for Test Connection

## Description
This adds a higher-order component to wrap a Mui button and provide a better "loading" experience. This includes a Storybook use case and usage in for the Test Connection button in Connection creation.

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [X] General Improvement
- [ ] Cherry Pick

## Links
Jira: N/A

## Test Plan

## Screenshots
![image](https://user-images.githubusercontent.com/2728821/157329170-f69ef2c4-c143-48b1-8c99-402d5bf343ab.png)


