### PR TITLE
CDAP-18897 Add "Deprecated" warning to Wrangler's parse as csv "Use first line as header" option

### DIFF
--- a/app/cdap/components/DataPrep/Directives/Parse/Modals/CSVModal.js
+++ b/app/cdap/components/DataPrep/Directives/Parse/Modals/CSVModal.js
@@ -21,6 +21,7 @@ import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 import classnames from 'classnames';
 import T from 'i18n-react';
 import MouseTrap from 'mousetrap';
+import WarningIcon from '@material-ui/icons/Warning';
 
 const PREFIX = 'features.DataPrep.Directives.Parse';
 
@@ -152,6 +153,10 @@ export default class CSVModal extends Component {
                   'fa-check-square': this.state.firstRowHeader,
                 })}
               />
+              <span className="deprecated-warning">
+                <WarningIcon size="small" />
+                {T.translate(`${PREFIX}.Parsers.CSV.deprecatedWarning`)}
+              </span>
               <span>{T.translate(`${PREFIX}.Parsers.CSV.firstRowHeader`)}</span>
             </span>
           </div>

--- a/app/cdap/components/DataPrep/Directives/Parse/ParseDirective.scss
+++ b/app/cdap/components/DataPrep/Directives/Parse/ParseDirective.scss
@@ -53,6 +53,10 @@ $option-hover-active-bg-color: #dddddd;
       span:first-child {
         margin-right: 5px;
       }
+      .deprecated-warning {
+        font-weight: bold;
+        margin-right: 5px;
+      }
     }
 
     .list-options > div,

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -1091,6 +1091,7 @@ features:
             label: Avro
           CSV:
             customPlaceholder: "Delimiter (e.g ;, #, %, ^)"
+            deprecatedWarning: "[Deprecated]"
             firstRowHeader: Set first row as header
             label: CSV
             modalTitle: Please select the delimiter


### PR DESCRIPTION
# CDAP-18897 Add "Deprecated" warning to Wrangler's parse as csv "Use first line as header" option

## Description
I did not convert the CSS because of planned work on the Wrangler UI

## PR Type
- [ ] Bug Fix
- [X] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-18897](https://cdap.atlassian.net/browse/CDAP-18897)

## Test Plan
Visual change only

## Screenshots
![image](https://user-images.githubusercontent.com/2728821/157347321-0c1837d7-8853-4fdf-8a89-b938d148adcb.png)



