### PR TITLE
Replication transformations for 6.7 - adds table assessment support, better errors etc

### DIFF
--- a/app/cdap/api/artifact.js
+++ b/app/cdap/api/artifact.js
@@ -30,7 +30,7 @@ export const MyArtifactApi = {
     'REQUEST',
     `${baseArtifactPath}/extensions/microservice`
   ),
-  gettMicroservicePluginDetails: apiCreator(
+  getMicroservicePluginDetails: apiCreator(
     dataSrc,
     'GET',
     'REQUEST',
@@ -45,5 +45,17 @@ export const MyArtifactApi = {
     'GET',
     'REQUEST',
     `${baseArtifactPath}/extensions/:extensionType/plugins/:pluginName`
+  ),
+  fetchPluginTypes: apiCreator(
+    dataSrc,
+    'GET',
+    'REQUEST',
+    `${baseArtifactPath}/extensions/:extensionType?scope=:scope`
+  ),
+  fetchArtifactVersion: apiCreator(
+    dataSrc,
+    'GET',
+    'REQUEST',
+    '/namespaces/:namespace/artifacts/:artifactName?scope=:scope'
   ),
 };

--- a/app/cdap/api/replicator.js
+++ b/app/cdap/api/replicator.js
@@ -27,6 +27,7 @@ const servicePath = `${deltaAppPath}/services/assessor/methods/v1/contexts/:name
 const draftPath = `${servicePath}/drafts/:draftId`;
 const workerPath = `${appPath}/workers/DeltaWorker`;
 const artifactBasePath = `/namespaces/:namespace/artifacts/:artifactName/versions/:artifactVersion/properties`;
+const validatePipelinePath = `${servicePath}/assessPipeline`;
 
 export const MyReplicatorApi = {
   getDeltaApp: apiCreator(dataSrc, 'GET', 'REQUEST', deltaAppPath),
@@ -48,6 +49,7 @@ export const MyReplicatorApi = {
   getTableInfo: apiCreator(dataSrc, 'POST', 'REQUEST', `${draftPath}/describeTable`),
   getReplicator: apiCreator(dataSrc, 'GET', 'REQUEST', appPath),
   assessPipeline: apiCreator(dataSrc, 'POST', 'REQUEST', `${draftPath}/assessPipeline`),
+  validatePipeline: apiCreator(dataSrc, 'POST', 'REQUEST', validatePipelinePath),
   assessTable: apiCreator(dataSrc, 'POST', 'REQUEST', `${draftPath}/assessTable`),
   fetchArtifactProperties: apiCreator(dataSrc, 'GET', 'REQUEST', artifactBasePath),
 

--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/TransformDelete.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/TransformDelete.tsx
@@ -26,11 +26,8 @@ export default function TransformMenuButton({
   row,
   deleteColumnsFromTransforms,
   transforms,
-  tableInfo,
-  columns,
 }: ITransformDeleteProps) {
-  const cols = (transforms && transforms.columnTransformations) ?? [];
-  const transformsInColumn = cols.filter(({ columnName }) => {
+  const transformsInColumn = transforms.filter(({ columnName }) => {
     return columnName === row.name;
   });
 
@@ -43,7 +40,7 @@ export default function TransformMenuButton({
   };
 
   const handleDeleteClick = (index) => {
-    deleteColumnsFromTransforms(tableInfo, index, columns());
+    deleteColumnsFromTransforms(index);
     handleClose();
   };
 
@@ -101,12 +98,12 @@ export default function TransformMenuButton({
           </Grid>
         </Grid>
 
-        {cols.map((col, i) => {
-          const name = col.columnName;
-          const dir = col.directive;
+        {transforms.map((tr, i) => {
+          const name = tr.columnName;
+          const dir = tr.directive;
           const thisCol = name === row.name;
           return (
-            <Grid container direction="row">
+            <Grid container direction="row" key={`${name}-${dir}-row`}>
               <MenuItem
                 style={{
                   minWidth: '400px',

--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/reducer.ts
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/reducer.ts
@@ -67,6 +67,22 @@ export const reducer = (state: ISelectColumnsState, action) => {
         ...state,
         filterErrs: action.payload,
       };
+    case 'setColumnTransformation':
+      return {
+        ...state,
+        transformations: [...state.transformations, action.payload],
+      };
+    case 'removeColumnTransformation':
+      const newTransforms = state.transformations.splice(0, action.payload);
+      return {
+        ...state,
+        transformations: newTransforms,
+      };
+    case 'setInitialTransformations':
+      return {
+        ...state,
+        transformations: action.payload,
+      };
     default:
       return state;
   }
@@ -83,4 +99,5 @@ export const initialState = {
   error: null,
   search: '',
   columnsWithErrors: '',
+  transformations: [],
 };

--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/styles.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/styles.tsx
@@ -19,6 +19,7 @@ import styled from 'styled-components';
 import { Button, Checkbox, Grid, Radio, RadioGroup } from '@material-ui/core';
 import ChevronRight from '@material-ui/icons/ChevronRight';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
+import PrimaryOutlinedButton from 'components/shared/Buttons/PrimaryOutlinedButton';
 
 export const Backdrop = styled.div`
   position: absolute;
@@ -78,10 +79,6 @@ export const RadioContainer = styled.div`
   padding-left: 10px;
   margin-top: 15px;
   margin-bottom: 5px;
-`;
-
-export const ButtonWithMarginRight = styled(Button)`
-  margin-right: 25px;
 `;
 
 export const StyledRadioGroup = styled(RadioGroup)`
@@ -285,4 +282,8 @@ export const Circle = styled.div`
 
 export const NumSpan = styled.span`
   text-align: right;
+`;
+
+export const CancelButton = styled(PrimaryOutlinedButton)`
+  margin-right: 40px;
 `;

--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/types.ts
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/types.ts
@@ -32,19 +32,20 @@ export interface ISelectColumnsProps {
   toggle: () => void;
   saveDraft: () => Observable<any>;
   draftId: string;
-  addColumnsToTransforms: (
-    opts: IColumnTransformation,
-    table: ITableInfo,
-    columns: ISelectedList
-  ) => void;
-  deleteColumnsFromTransforms: (
-    table: ITableInfo,
-    colTransIndex: number,
-    columns: ISelectedList
-  ) => void;
-  transformations: ITransformation;
+  transformations: { [tableName: string]: ITransformation };
   tableAssessments: undefined | { [colName: string]: ITableAssessmentColumn };
-  handleAssessTable: (table: ITableInfo, columns: IColumnsList) => void;
+  handleAssessTable: (
+    table: ITableInfo,
+    transformations: IColumnTransformation[],
+    columns: IColumnsList
+  ) => void;
+  saveTransformationsAndColumns: (
+    table: ITableInfo,
+    transformations?: ITransformation,
+    columns?: ISelectedList
+  ) => void;
+  assessmentLoading: boolean;
+  tinkEnabled: boolean;
 }
 
 interface IColumn {
@@ -68,27 +69,38 @@ export interface ISelectColumnsState {
   error: any;
   filterErrs: string[];
   search: string;
+  transformations: IColumnTransformation[];
 }
 
 export interface ITransformAddProps {
   row: IColumn;
-  tableInfo: ITableInfo;
-  columns: () => ISelectedList;
-  addColumnsToTransforms: (
-    opts: IColumnTransformation,
-    table: ITableInfo,
-    columns: ISelectedList
-  ) => void;
+  addColumnsToTransforms: (opts: IColumnTransformation) => void;
+  tinkEnabled: boolean;
 }
 
 export interface ITransformDeleteProps {
   row: IColumn;
-  tableInfo: ITableInfo;
-  transforms: ITransformation;
-  columns: () => ISelectedList;
-  deleteColumnsFromTransforms: (
-    table: ITableInfo,
-    colTransIndex: number,
-    columns: ISelectedList
-  ) => void;
+  transforms: IColumnTransformation[];
+  deleteColumnsFromTransforms: (colTransIndex: number) => void;
+}
+
+export interface ITransAssessmentResDesc {
+  name: string;
+  description: string;
+  suggestion: string;
+  impact: string;
+  severity: 'ERROR' | string;
+}
+
+export interface ITransAssessmentRes {
+  connectivity: any[];
+  features: ITransAssessmentResDesc[];
+  tables: Array<{
+    numColumnsNotSupported: number;
+    numColumnsPartiallySupported: number;
+    database: string;
+    table: string;
+    numColumns: number;
+  }>;
+  transformationIssues: ITransAssessmentResDesc[];
 }

--- a/app/cdap/components/Replicator/Create/Content/SelectTables/index.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectTables/index.tsx
@@ -507,7 +507,11 @@ class SelectTablesView extends React.PureComponent<ISelectTablesProps, ISelectTa
         initialSelected={this.getInitialSelected()}
         toggle={this.openTable.bind(this, null)}
         onSave={this.onColumnsSelection}
+        assessmentLoading={this.props.assessmentLoading}
+        transformations={this.props.transformations}
+        saveTransformationsAndColumns={this.props.saveTransformationsAndColumns}
         assessTable={this.props.handleAssessTable}
+        isTinkEnabled={this.props.tinkEnabled}
       />
     );
   };

--- a/app/cdap/components/Replicator/utilities/__tests__/utilities.test.ts
+++ b/app/cdap/components/Replicator/utilities/__tests__/utilities.test.ts
@@ -18,6 +18,7 @@ import {
   generateTableKey,
   constructTablesSelection,
   convertConfigToState,
+  parseErrorMessageForTransformations,
 } from 'components/Replicator/utilities';
 import { DML } from 'components/Replicator/types';
 import { List, Map, Set } from 'immutable';
@@ -126,6 +127,16 @@ describe('Replication Utilities', () => {
       expect(result[0].columns[0].name).toBe('col-table1-1');
       expect(result[0].columns[1].name).toBe('col-table1-2');
     });
+  });
+
+  describe('Parse transformations error message', () => {
+    const exampleError =
+      'Failed to apply transformations on the schema for the table : ORDERS and column : PRICE with error : Field name QTY already exists.';
+
+    const [table, column, errorMessage] = parseErrorMessageForTransformations(exampleError);
+    expect(table).toBe('ORDERS');
+    expect(column).toBe('PRICE');
+    expect(errorMessage).toBe('Field name QTY already exists.');
   });
 
   describe('Convert JSON Config to State', () => {

--- a/app/cdap/components/Replicator/utilities/index.ts
+++ b/app/cdap/components/Replicator/utilities/index.ts
@@ -435,3 +435,20 @@ export function identifyReplicatorEntityFromMetadata(metadata: {
 }): boolean {
   return metadata.type === 'Worker' && metadata.program === 'DeltaWorker';
 }
+
+/**
+ * Returns Table, column and error message from table assessment for transformations
+ * Message always comes in this format:
+ * Failed to apply transformations on the schema for the table : ORDERS and column : PRICE with error : Field name QTY already exists.
+ * so we just need to split the string on colons etc.
+ * @param string description of the error
+ * @returns [table, column, error message]
+ */
+export function parseErrorMessageForTransformations(message: string) {
+  const [_, tablePiece, columnPiece, messagePiece] = message.split(' : ');
+  const table = tablePiece.split(' ')[0];
+  const column = columnPiece.split(' ')[0];
+  const errorMessage = messagePiece;
+
+  return [table, column, errorMessage];
+}

--- a/app/cdap/components/hydrator/components/SidePanel/SidePanel.tsx
+++ b/app/cdap/components/hydrator/components/SidePanel/SidePanel.tsx
@@ -91,7 +91,7 @@ const ListOrIconsButton = styled(Button)`
 
 interface ISidePanelProps {
   itemGenericName: string;
-  groups: Array<any>;
+  groups: any[];
   groupGenericName: string;
   onPanelItemClick: (event: any, plugin: any) => void;
 }

--- a/app/cdap/services/WizardStores/MicroserviceUpload/ActionCreator.js
+++ b/app/cdap/services/WizardStores/MicroserviceUpload/ActionCreator.js
@@ -133,7 +133,7 @@ const getMicroservicePluginProperties = (pluginId) => {
     scope
   };
 
-  return MyArtifactApi.gettMicroservicePluginDetails(pluginParams);
+  return MyArtifactApi.getMicroservicePluginDetails(pluginParams);
 };
 
 const getTrimmedMicroserviceQueueObj = (queueObj) => {

--- a/app/cdap/services/resource-helper/index.js
+++ b/app/cdap/services/resource-helper/index.js
@@ -23,6 +23,7 @@ import { objectQuery } from 'services/helpers';
 const cookie = new Cookies();
 
 function createApi(dataSrc, method, type, path, options = {}) {
+  // add api version to options to change it to v1
   return (params = {}, body, headers) => {
     let url = buildUrl(path, params);
 


### PR DESCRIPTION
# Replication transformations for 6.7

## Description
Adds support for calling assessPipeline on a non-draft table
Adds better error messages for columns
Can't save table until you run the assessment
Checks artifacts for tink and conditionally enables
Adds mask submenu and last 2, last 4 and custom mask options

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Screenshots
<img width="268" alt="Screen Shot 2022-03-16 at 9 55 36 AM" src="https://user-images.githubusercontent.com/2054644/158649857-b85aec63-c567-4616-be03-98c3893a010a.png">

![Screen Shot 2022-03-10 at 9 17 00 PM](https://user-images.githubusercontent.com/2054644/157807165-3edf4d7a-3505-4081-93a9-5280769fadd3.png)
![Screen Shot 2022-03-10 at 9 18 44 PM](https://user-images.githubusercontent.com/2054644/157807169-4fca70e0-fd31-42c2-a05e-f0a18742b108.png)

