### PR TITLE
CDAP-18929 Handle router down without crashing Node process

### DIFF
--- a/server/express.js
+++ b/server/express.js
@@ -538,18 +538,21 @@ function makeApp(authAddress, cdapConfig, uiSettings) {
         function(err, response) {
           if (err) {
             log.info('Server responded with error: ' + err + ' for API : "/v3/namespaces"');
-            res.status(response.statusCode || 500).send(err);
+            res.status(response && response.statusCode || 502).send(err);
           } else {
             res.status(response.statusCode).send('OK');
           }
         }
       ).on('error', function(err) {
-        try {
-          res.status(500).send(err);
-        } catch (e) {
-          log.error('Failed sending exception to client', e);
+        // If an error hasn't already been sent, send it here
+        if (!res.headersSent) {
+          try {
+              res.status(502).send(err);
+          } catch (e) {
+            log.error('Failed sending exception to client', e);
+          }
+          log.error(err);
         }
-        log.error(err);
       });
     },
   ]);


### PR DESCRIPTION
# CDAP-18929 Handle router down without crashing Node process

## Description
The Node server was checking the response status code on errors from the router. However, when the router is down, there's no response object.

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-18929](https://cdap.atlassian.net/browse/CDAP-18929)

## Test Plan
Manually test on CDF instance

## Screenshots
N/A


