### PR TITLE
[CDAP-18876] change required field of connection name to true

### DIFF
--- a/app/cdap/components/Connections/Create/ConnectionConfiguration/ConnectionConfigForm.tsx
+++ b/app/cdap/components/Connections/Create/ConnectionConfiguration/ConnectionConfigForm.tsx
@@ -75,7 +75,7 @@ export function ConnectionConfigForm({
             pluginProperty={{
               name: 'name',
               macroSupported: false,
-              required: false,
+              required: true,
             }}
             value={name}
             onChange={(v) => setName(v.name)}


### PR DESCRIPTION
# [CDAP-18876] change required field of connection name to true

## Description
Adding "*" to Connection Name field since clicking "create" will not go through if Connection Name is empty.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-18876](https://cdap.atlassian.net/browse/CDAP-18876)

## Test Plan
Manual Testing

## Screenshots
<img width="289" alt="image" src="https://user-images.githubusercontent.com/98125204/158707914-19ec336a-e4c7-4f5c-bbca-878a5e8de024.png">




[CDAP-18876]: https://cdap.atlassian.net/browse/CDAP-18876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ