### PR TITLE
CDAP-18918: fix to ensure that we allow limited Filter operation for …

### DIFF
--- a/app/cdap/components/AbstractWidget/AbstractMultiRowWidget/AbstractRow.tsx
+++ b/app/cdap/components/AbstractWidget/AbstractMultiRowWidget/AbstractRow.tsx
@@ -19,7 +19,6 @@ import IconButton from '@material-ui/core/IconButton';
 import AddIcon from '@material-ui/icons/Add';
 import DeleteIcon from '@material-ui/icons/Delete';
 import { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
-import If from 'components/shared/If';
 import { KEY_CODE } from 'services/global-constants';
 import { IErrorObj } from 'components/shared/ConfigurationGroup/utilities';
 import classnames from 'classnames';
@@ -51,6 +50,7 @@ export interface IAbstractRowProps<S extends typeof AbstractRowStyles> extends W
   index: number;
   autofocus: boolean;
   disabled: boolean;
+  addRowDisabled?: boolean;
   onChange: (id: string, value: string) => void;
   addRow: () => void;
   removeRow: () => void;
@@ -113,24 +113,28 @@ export default class AbstractRow<
         >
           {this.renderInput()}
 
-          <If condition={!this.props.disabled}>
+          {!this.props.disabled && (
             <React.Fragment>
-              <IconButton onClick={this.props.addRow} data-cy="add-row">
+              <IconButton
+                disabled={this.props.addRowDisabled}
+                onClick={this.props.addRow}
+                data-cy="add-row"
+              >
                 <AddIcon fontSize="small" />
               </IconButton>
-              <If condition={!this.props.deleteDisabled}>
+              {!this.props.deleteDisabled && (
                 <IconButton color="secondary" onClick={this.props.removeRow} data-cy="remove-row">
                   <DeleteIcon fontSize="small" />
                 </IconButton>
-              </If>
+              )}
             </React.Fragment>
-          </If>
+          )}
         </div>
-        <If condition={errorMsg}>
+        {errorMsg && (
           <div className={this.props.classes.errorText} data-cy={`error-text-${index}`}>
             {errorMsg}
           </div>
-        </If>
+        )}
       </React.Fragment>
     );
   }

--- a/app/cdap/components/AbstractWidget/KeyValueDropdownWidget/KeyValueDropdownRow.tsx
+++ b/app/cdap/components/AbstractWidget/KeyValueDropdownWidget/KeyValueDropdownRow.tsx
@@ -25,7 +25,6 @@ import Input from '@material-ui/core/Input';
 import MenuItem from '@material-ui/core/MenuItem';
 import Select from '@material-ui/core/Select';
 import withStyles from '@material-ui/core/styles/withStyles';
-import If from 'components/shared/If';
 
 const styles = (theme) => {
   return {
@@ -157,14 +156,17 @@ class KeyValueDropdownRow extends AbstractRow<IKeyValueDropdownRowProps, IKeyVal
 
     return (
       <div className={this.props.classes.inputContainer}>
-        <If condition={this.props.ordering !== OrderingEnum.VALUESFIRST}>
-          {InputField}
-          {SelectField}
-        </If>
-        <If condition={this.props.ordering === OrderingEnum.VALUESFIRST}>
-          {SelectField}
-          {InputField}
-        </If>
+        {this.props.ordering !== OrderingEnum.VALUESFIRST ? (
+          <>
+            {InputField}
+            {SelectField}
+          </>
+        ) : (
+          <>
+            {SelectField}
+            {InputField}
+          </>
+        )}
       </div>
     );
   };

--- a/app/cdap/components/AbstractWidget/KeyValueDropdownWidget/index.tsx
+++ b/app/cdap/components/AbstractWidget/KeyValueDropdownWidget/index.tsx
@@ -31,6 +31,7 @@ import { objectQuery } from 'services/helpers';
 interface IKeyValueDropdownWidgetProps extends IMultiRowWidgetProps {
   'key-placeholder'?: string;
   'kv-delimiter'?: string;
+  'kv-pair-limit'?: number;
   dropdownOptions: IDropdownOption[];
   delimiter?: string;
   showDelimiter?: boolean;
@@ -43,6 +44,8 @@ class KeyValueDropdownWidgetView extends AbstractMultiRowWidget<IKeyValueDropdow
     const keyPlaceholder = objectQuery(this.props, 'widgetProps', 'key-placeholder');
     const kvDelimiter = objectQuery(this.props, 'widgetProps', 'kv-delimiter');
     const dropdownOptions = objectQuery(this.props, 'widgetProps', 'dropdownOptions');
+    const rowLimit = objectQuery(this.props, 'widgetProps', 'kv-pair-limit');
+    const addRowDisabled = !!rowLimit && Object.keys(this.values).length >= rowLimit;
 
     return (
       <KeyValueDropdownRow
@@ -55,6 +58,7 @@ class KeyValueDropdownWidgetView extends AbstractMultiRowWidget<IKeyValueDropdow
         removeRow={this.removeRow.bind(this, index)}
         autofocus={this.state.autofocus === id}
         changeFocus={this.changeFocus}
+        addRowDisabled={addRowDisabled}
         disabled={this.props.disabled}
         keyPlaceholder={keyPlaceholder}
         kvDelimiter={kvDelimiter}

--- a/app/cdap/components/shared/ConfigurationGroup/WidgetWrapper/index.tsx
+++ b/app/cdap/components/shared/ConfigurationGroup/WidgetWrapper/index.tsx
@@ -22,7 +22,6 @@ import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/wit
 import AbstractWidget from 'components/AbstractWidget';
 import DescriptionTooltip from 'components/shared/ConfigurationGroup/PropertyRow/DescriptionTooltip';
 import { IErrorObj } from 'components/shared/ConfigurationGroup/utilities';
-import If from 'components/shared/If';
 import PropTypes from 'prop-types';
 import ThemeWrapper from 'components/ThemeWrapper';
 import classnames from 'classnames';
@@ -144,14 +143,12 @@ const WidgetWrapperView: React.FC<IWidgetWrapperProps> = ({
       onBlur={onBlur}
       data-cy="widget-wrapper-container"
     >
-      <If condition={!hideWrapper && !hideLabel}>
+      {!hideWrapper && !hideLabel && (
         <div className={`widget-wrapper-label ${classes.label}`}>
           {widgetProperty.label}
-          <If condition={pluginProperty.required}>
-            <span className={classes.required}>*</span>
-          </If>
+          {pluginProperty.required && <span className={classes.required}>*</span>}
         </div>
-      </If>
+      )}
       <div className={classes.widgetContainer}>
         <AbstractWidget
           type={widgetType}
@@ -165,11 +162,11 @@ const WidgetWrapperView: React.FC<IWidgetWrapperProps> = ({
           dataCy={pluginProperty.name}
         />
       </div>
-      <If condition={!hideDescription && !hideWrapper}>
+      {!hideDescription && !hideWrapper && (
         <div className={classes.tooltipContainer}>
           <DescriptionTooltip description={pluginProperty.description} />
         </div>
-      </If>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
# Fix to ensure that we allow limited Filter operations for Deduplicate widget. 

## Description
Currently the UI has an option to add multiple filter fields and functions (multiple dropdown options) for the deduplicate plugin, but is functionally not possible. A validation exception is thrown when we add more than one filter field. This PR adds the ability to restrict the number of drop-downs. The sister PR: https://github.com/cdapio/hydrator-plugins/pull/1553

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-18918](https://cdap.atlassian.net/browse/CDAP-18918)

## Test Plan
Manual

## Screenshots

![image](https://user-images.githubusercontent.com/20428112/158900864-4a4433ff-56e3-488f-884f-7b9aae5930cc.png)

