### PR TITLE
CDAP-18932 Use consistent name and filter on Studio plugin side panel

### DIFF
--- a/app/directives/group-side-panel/group-side-panel-ctrl.js
+++ b/app/directives/group-side-panel/group-side-panel-ctrl.js
@@ -97,6 +97,27 @@ angular.module(PKG.name + '.commons')
       return myHelpers.objectQuery(this.pluginsMap, key, 'widgets', 'icon', 'arguments', 'url');
     };
 
+    this.getFilteredPluginsFromGroup = (group) => {
+      const trimmedSearchText = this.searchText ? this.searchText.trim().toLowerCase() : null;
+
+      const containsTerm = (field, term) => {
+        if (!field) {
+          return false;
+        }
+        return field.toLowerCase().indexOf(term) > -1;
+      }
+
+      if (!trimmedSearchText || !trimmedSearchText.length) {
+        return group.plugins;
+      }
+
+      return group.plugins.filter(plugin => {
+        return containsTerm(plugin.name, trimmedSearchText) ||
+          containsTerm(plugin.label, trimmedSearchText) ||
+          containsTerm(this.generateLabel(plugin), trimmedSearchText);
+      });
+    }
+
     let sub = AvailablePluginsStore.subscribe(() => {
       this.pluginsMap = AvailablePluginsStore.getState().plugins.pluginsMap;
     });

--- a/app/directives/group-side-panel/group-side-panel.html
+++ b/app/directives/group-side-panel/group-side-panel.html
@@ -53,7 +53,7 @@
 
           <!-- ICON VIEW -->
           <div ng-if="MySidePanel.view === 'icon'"
-               ng-repeat="plugin in group.filtered = (group.plugins | myMultiKeySearch: ['name', 'label']: MySidePanel.searchText | orderBy: 'pluginTemplate || name') track by $index"
+               ng-repeat="plugin in group.filtered = (MySidePanel.getFilteredPluginsFromGroup(group) | orderBy: 'pluginTemplate || name') track by $index"
                class="plugin-item {{plugin.nodeClass}}"
                ng-class="{'hovered': plugin.hovering}"
                my-popover
@@ -88,7 +88,7 @@
 
           <!-- LIST VIEW -->
           <div ng-if="MySidePanel.view === 'list'"
-               ng-repeat="plugin in group.filtered = (group.plugins | myMultiKeySearch: ['name', 'label']: MySidePanel.searchText | orderBy: 'pluginTemplate || name') track by $index"
+               ng-repeat="plugin in group.filtered = (MySidePanel.getFilteredPluginsFromGroup(group) | orderBy: 'pluginTemplate || name') track by $index"
                class="plugin-item {{plugin.nodeClass}}"
                ng-click="MySidePanel.onItemClicked($event, plugin)"
                data-cy="plugin-{{plugin.name}}-{{plugin.type}}">
@@ -99,7 +99,7 @@
                   data-template="plugin.template"
                   content-data="plugin"
                   data-popover-context="MySidePanel"
-            >{{ (plugin.name || plugin.pluginTemplate) | myRemoveCamelcase}}</span>
+            >{{ MySidePanel.generateLabel(plugin) }}</span>
             <span class="plugin-badge">T</span>
           </div>
         </div>


### PR DESCRIPTION
# CDAP-18932 Use consistent name and filter on Studio plugin side panel

## Description
The UI has been showing custom names on the Icon view and basic names on the List view. This change changes the List view to use custom names. It also fixes the filter function, which had ignored the custom name.

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-18932](https://cdap.atlassian.net/browse/CDAP-18932)

## Test Plan
Manual testing

## Screenshots
Names:
Before:
![image](https://user-images.githubusercontent.com/2728821/158900224-5c6fd62e-db7b-4eb6-9d2d-89f0946a127f.png)

After:
![image](https://user-images.githubusercontent.com/2728821/158900257-369bc3a0-cedd-4d6e-a033-6d6af528d9f6.png)

Filter:
Before
![image](https://user-images.githubusercontent.com/2728821/158900161-6e2a322c-45b9-4d6e-bcc1-9c598bb83aba.png)

After
![image](https://user-images.githubusercontent.com/2728821/158900185-f6437f8f-bc05-40d2-8163-9fb96924c34f.png)


