### PR TITLE
[CDAP-18942] bump up frontend-maven-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
           <plugin>
             <groupId>com.github.eirslett</groupId>
             <artifactId>frontend-maven-plugin</artifactId>
-            <version>1.6</version>
+            <version>1.11.0</version>
             <executions>
               <execution>
                 <id>dist</id>
@@ -327,7 +327,7 @@
           <plugin>
             <groupId>com.github.eirslett</groupId>
             <artifactId>frontend-maven-plugin</artifactId>
-            <version>1.6</version>
+            <version>1.11.0</version>
             <executions>
               <execution>
                 <id>dist</id>


### PR DESCRIPTION
# [CDAP-18942] bump up frontend-maven-plugin version

## Description
Bump up frontend-maven-plugin version to make M1 Mac compatible

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-18942](https://cdap.atlassian.net/browse/CDAP-18942)

## Test Plan
Built was successful after the change 





[CDAP-18942]: https://cdap.atlassian.net/browse/CDAP-18942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ