### PR TITLE
[CDAP-18971 | CDAP-19054] Disable mask option when data type is not VARCHAR

### DIFF
--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/TransformAdd.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/TransformAdd.tsx
@@ -39,6 +39,8 @@ export default function TransformAddButton({
   const open = !!anchorEl;
   const subMenuOpen = !!subMenuAnchorEl;
 
+  const isString = row.targetType.toLowerCase() === 'string';
+
   const handleClick = (event) => {
     setAnchorEl(event.currentTarget);
   };
@@ -135,7 +137,7 @@ export default function TransformAddButton({
         <MenuItem onClick={handleMenuClick}>
           Rename <ArrowRight />
         </MenuItem>
-        <MenuItem onClick={handleMaskOpen}>
+        <MenuItem disabled={!isString} onClick={handleMaskOpen}>
           Mask <ArrowRight />
         </MenuItem>
         <Menu
@@ -154,9 +156,13 @@ export default function TransformAddButton({
             dense: true,
           }}
         >
-          <MenuItem onClick={() => handleSetMaskLast(2)}>Show last 2</MenuItem>
-          <MenuItem onClick={() => handleSetMaskLast(4)}>Show last 4</MenuItem>
-          <MenuItem onClick={handleMenuClick}>
+          <MenuItem disabled={!isString} onClick={() => handleSetMaskLast(2)}>
+            Show last 2
+          </MenuItem>
+          <MenuItem disabled={!isString} onClick={() => handleSetMaskLast(4)}>
+            Show last 4
+          </MenuItem>
+          <MenuItem disabled={!isString} onClick={handleMenuClick}>
             Custom <ArrowRight />
           </MenuItem>
           {tinkEnabled && (

--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/table.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/table.tsx
@@ -289,7 +289,7 @@ export const renderTable = ({
                   <span></span>
                 </Grid>
                 <GridCell item xs={4}>
-                  <NoPaddingSpanLeft>{row.type.toLowerCase()}</NoPaddingSpanLeft>
+                  <NoPaddingSpanLeft>{row.targetType.toLowerCase()}</NoPaddingSpanLeft>
                 </GridCell>
               </GridCellContainer>
               <GridDividerCell item xs={2} container direction="row">
@@ -316,7 +316,6 @@ export const renderTable = ({
                     row={row}
                     tinkEnabled={tinkEnabled}
                     addColumnsToTransforms={addColumnsToTransforms}
-                    columns={selectedList}
                   />
                 </GridCell>
                 <GridCell item xs={6}>

--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/types.ts
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/types.ts
@@ -52,6 +52,10 @@ interface IColumn {
   name: string;
   type: string;
   nullable: boolean;
+  sourceName: string;
+  sourceType: string;
+  targetName: string;
+  targetType: string;
 }
 
 export enum ReplicateSelect {


### PR DESCRIPTION
# [CDAP-18971 | CDAP-19054] Disable musk option when data type is not VARCHAR

## Description
disable non string column's mask option
fix target data type not showing correctly

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-18971](https://cdap.atlassian.net/browse/CDAP-18971) [CDAP-19054](https://cdap.atlassian.net/browse/CDAP-19054)

## Screenshots
![image](https://user-images.githubusercontent.com/98125204/161354718-3c25c79d-2bb6-4b90-8f3e-7d17b0521a47.png)
![image](https://user-images.githubusercontent.com/98125204/163609085-4a2712a1-d2c5-45e2-a1d9-b0e87738ed02.png)






[CDAP-18971]: https://cdap.atlassian.net/browse/CDAP-18971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ