### PR TITLE
CDAP-19025 Add fields to node when adding to canvas so hidden required fields can be checked

### DIFF
--- a/app/hydrator/controllers/create/leftpanel-ctrl.js
+++ b/app/hydrator/controllers/create/leftpanel-ctrl.js
@@ -325,13 +325,15 @@ class HydratorPlusPlusLeftPanelCtrl {
     this.DAGPlusPlusNodesActionsFactory.resetSelectedNode();
     let name = item.name || item.pluginTemplate;
     const configProperties = {};
+    let configurationGroups;
+    let widgets;
 
     if (!item.pluginTemplate) {
       let itemArtifact = item.artifact;
       let key = `${item.name}-${item.type}-${itemArtifact.name}-${itemArtifact.version}-${itemArtifact.scope}`;
-      const widgets = this.myHelpers.objectQuery(this.availablePluginMap, key, 'widgets');
+      widgets = this.myHelpers.objectQuery(this.availablePluginMap, key, 'widgets');
       const displayName = this.myHelpers.objectQuery(widgets, 'display-name');
-      const configurationGroups = this.myHelpers.objectQuery(widgets, 'configuration-groups');
+      configurationGroups = this.myHelpers.objectQuery(widgets, 'configuration-groups');
       if (configurationGroups && configurationGroups.length > 0) {
         configurationGroups.forEach(cg => {
           cg.properties.forEach(prop => {
@@ -361,7 +363,9 @@ class HydratorPlusPlusLeftPanelCtrl {
         inputSchema: item.inputSchema,
         pluginTemplate: item.pluginTemplate,
         description: item.description,
-        lock: item.lock
+        lock: item.lock,
+        configGroups: configurationGroups,
+        filters: widgets && widgets.filters
       };
     } else {
       config = {
@@ -374,7 +378,9 @@ class HydratorPlusPlusLeftPanelCtrl {
         icon: item.icon,
         description: item.description,
         type: item.type,
-        warning: true
+        warning: true,
+        configGroups: configurationGroups,
+        filters: widgets && widgets.filters
       };
     }
     this.DAGPlusPlusNodesActionsFactory.addNode(config);


### PR DESCRIPTION
# CDAP-19025 Add fields to node when adding to canvas so hidden required fields can be checked

## Description
When we added a node to the canvas, hidden required fields were shown as missing. Some fields on the node that are needed to check for this state were not being applied. This PR adds those fields.

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19025](https://cdap.atlassian.net/browse/CDAP-19025)

## Test Plan
Manually test adding a plugin
Manually test adding a template

## Screenshots
N/A

