### PR TITLE
[CDAP-18958] Make replicator transformation steps remember the column rename

### DIFF
--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/TransformAdd.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/TransformAdd.tsx
@@ -27,7 +27,7 @@ export default function TransformAddButton({
   row,
   addColumnsToTransforms,
   tinkEnabled,
-  transforms,
+  currentColumnName,
 }: ITransformAddProps) {
   // todo replace this with a useReducer
   const [anchorEl, setAnchorEl] = useState(null);
@@ -39,17 +39,6 @@ export default function TransformAddButton({
 
   const open = !!anchorEl;
   const subMenuOpen = !!subMenuAnchorEl;
-
-  const getCurrentColumnName = (columnName: string) => {
-    const sameColumnRenames = transforms.filter(
-      (transform) => transform.columnName == columnName && transform.directive.includes('rename')
-    );
-    if (sameColumnRenames.length > 0) {
-      const currName = sameColumnRenames[sameColumnRenames.length - 1].directive.split(' ')[2];
-      return currName;
-    }
-    return columnName;
-  };
 
   const handleClick = (event) => {
     setAnchorEl(event.currentTarget);
@@ -69,7 +58,6 @@ export default function TransformAddButton({
   };
 
   const handleSetMaskLast = (numChars: number) => {
-    const currentColumnName = getCurrentColumnName(row.name);
     const newDirective = addMaskToTransforms({
       columnName: currentColumnName,
       directive: `right * ${numChars}`,
@@ -91,7 +79,6 @@ export default function TransformAddButton({
 
   const handleAddToTransforms = () => {
     let fullDirective: string;
-    const currentColumnName = getCurrentColumnName(row.name);
     const transformInfo = {
       columnName: currentColumnName,
       directive: directiveText,

--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/TransformAdd.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/TransformAdd.tsx
@@ -40,6 +40,17 @@ export default function TransformAddButton({
   const open = !!anchorEl;
   const subMenuOpen = !!subMenuAnchorEl;
 
+  const getCurrentColumnName = (columnName: string) => {
+    const sameColumnRenames = transforms.filter(
+      (transform) => transform.columnName == columnName && transform.directive.includes('rename')
+    );
+    if (sameColumnRenames.length > 0) {
+      const currName = sameColumnRenames[sameColumnRenames.length - 1].directive.split(' ')[2];
+      return currName;
+    }
+    return columnName;
+  };
+
   const handleClick = (event) => {
     setAnchorEl(event.currentTarget);
   };
@@ -58,8 +69,9 @@ export default function TransformAddButton({
   };
 
   const handleSetMaskLast = (numChars: number) => {
+    const currentColumnName = getCurrentColumnName(row.name);
     const newDirective = addMaskToTransforms({
-      columnName: row.name,
+      columnName: currentColumnName,
       directive: `right * ${numChars}`,
     });
     addColumnsToTransforms({
@@ -79,21 +91,15 @@ export default function TransformAddButton({
 
   const handleAddToTransforms = () => {
     let fullDirective: string;
+    const currentColumnName = getCurrentColumnName(row.name);
     const transformInfo = {
-      columnName: row.name,
+      columnName: currentColumnName,
       directive: directiveText,
     };
 
     if (directive === 'tink') {
       fullDirective = addTinkToTransforms(transformInfo);
     } else if (directive === 'Rename') {
-      const sameColumnRenames = transforms.filter(
-        (transform) => transform.columnName == row.name && transform.directive.includes('rename')
-      );
-      if (sameColumnRenames.length > 0) {
-        const currName = sameColumnRenames[sameColumnRenames.length - 1].directive.split(' ')[2];
-        transformInfo.columnName = currName;
-      }
       fullDirective = addRenameToTransforms(transformInfo);
     } else {
       fullDirective = addMaskToTransforms(transformInfo);

--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/TransformAdd.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/TransformAdd.tsx
@@ -27,6 +27,7 @@ export default function TransformAddButton({
   row,
   addColumnsToTransforms,
   tinkEnabled,
+  transforms,
 }: ITransformAddProps) {
   // todo replace this with a useReducer
   const [anchorEl, setAnchorEl] = useState(null);
@@ -86,6 +87,13 @@ export default function TransformAddButton({
     if (directive === 'tink') {
       fullDirective = addTinkToTransforms(transformInfo);
     } else if (directive === 'Rename') {
+      const sameColumnRenames = transforms.filter(
+        (transform) => transform.columnName == row.name && transform.directive.includes('rename')
+      );
+      if (sameColumnRenames.length > 0) {
+        const currName = sameColumnRenames[sameColumnRenames.length - 1].directive.split(' ')[2];
+        transformInfo.columnName = currName;
+      }
       fullDirective = addRenameToTransforms(transformInfo);
     } else {
       fullDirective = addMaskToTransforms(transformInfo);

--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/table.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/table.tsx
@@ -106,6 +106,17 @@ export const renderTable = ({
   // empty table assessments object means there were no errors
   const allAssessmentsPassed = hasTableAssessments && Object.keys(tableAssessments).length === 0;
   const errNames = [];
+  const getCurrentColumnName = (columnName: string) => {
+    const sameColumnRenames = transforms.filter(
+      (transform) => transform.columnName == columnName && transform.directive.includes('rename')
+    );
+    if (sameColumnRenames.length > 0) {
+      const currName = sameColumnRenames[sameColumnRenames.length - 1].directive.split(' ')[2];
+      return currName;
+    }
+    return columnName;
+  };
+
   let errs;
 
   if (hasTableAssessments) {
@@ -315,7 +326,7 @@ export const renderTable = ({
                   <TransformAddButton
                     row={row}
                     tinkEnabled={tinkEnabled}
-                    transforms={transforms}
+                    currentColumnName={getCurrentColumnName(row.name)}
                     addColumnsToTransforms={addColumnsToTransforms}
                     columns={selectedList}
                   />

--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/table.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/table.tsx
@@ -315,6 +315,7 @@ export const renderTable = ({
                   <TransformAddButton
                     row={row}
                     tinkEnabled={tinkEnabled}
+                    transforms={transforms}
                     addColumnsToTransforms={addColumnsToTransforms}
                     columns={selectedList}
                   />

--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/types.ts
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/types.ts
@@ -76,7 +76,7 @@ export interface ITransformAddProps {
   row: IColumn;
   addColumnsToTransforms: (opts: IColumnTransformation) => void;
   tinkEnabled: boolean;
-  transforms: IColumnTransformation[];
+  currentColumnName: string;
 }
 
 export interface ITransformDeleteProps {

--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/types.ts
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/types.ts
@@ -76,6 +76,7 @@ export interface ITransformAddProps {
   row: IColumn;
   addColumnsToTransforms: (opts: IColumnTransformation) => void;
   tinkEnabled: boolean;
+  transforms: IColumnTransformation[];
 }
 
 export interface ITransformDeleteProps {


### PR DESCRIPTION
# [CDAP-18958] Make replicator transformation steps remember the column rename

## Description
Before if a user does a chain of rename operations to the same column, the directive will only show the original 'from', not the intermediate values. Now it will check the transformation history and find out the current column name if a rename ever happened previously.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-18958](https://cdap.atlassian.net/browse/CDAP-18958)

## Test Plan
manual testing

## Screenshots
<img width="440" alt="image" src="https://user-images.githubusercontent.com/98125204/162485010-c13437db-1a29-43b5-9f99-364ec8f398cd.png">




[CDAP-18958]: https://cdap.atlassian.net/browse/CDAP-18958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ