### PR TITLE
[CDAP-18450] Add support for configuring composite trigger properties

### DIFF
--- a/app/cdap/components/PipelineTriggers/EnabledTriggersTab/EnabledInlineTriggerRow.tsx
+++ b/app/cdap/components/PipelineTriggers/EnabledTriggersTab/EnabledInlineTriggerRow.tsx
@@ -28,12 +28,14 @@ import {
   HelperText,
   PipelineDescription,
   PipelineName,
+  PipelineTriggerButton,
   StyledNameSpace,
   TextCenter,
 } from 'components/PipelineTriggers/shared.styles';
 import styled from 'styled-components';
 
 const TRIGGER_PREFIX = 'features.PipelineTriggers';
+const PAYLOAD_PREFIX = 'features.PipelineTriggers.ScheduleRuntimeArgs.PayloadConfigModal';
 
 const InlineTriggersExpandedRow = styled.div`
   border: 2px solid #dedede;
@@ -46,7 +48,9 @@ const PipelineLink = styled.a`
 `;
 
 const InlineTriggerActionButtonsContainer = styled.div`
-  padding-bottom: 40px;
+  display: flex;
+  justify-content: flex-end;
+  padding: 0 10px 10px 0;
 `;
 
 const InlineTriggerHeaderRow = styled.div`
@@ -69,6 +73,7 @@ const EnabledInlineTriggerRow = ({
   const [isLoading, setLoading] = useState(true);
   const [expandedTriggerInfo, setExpandedTriggerInfo] = useState(null);
   const [namespace, setNameSpace] = useState(null);
+  const [payloadModalOpen, setPayloadModalOpen] = useState(false);
 
   useEffect(() => {
     getGroupInlinePipelineInfo(trigger).subscribe((res) => {
@@ -78,6 +83,10 @@ const EnabledInlineTriggerRow = ({
     const ns = NamespaceStore.getState().selectedNamespace;
     setNameSpace(ns);
   }, []);
+
+  const handlePayloadToggleClick = () => {
+    setPayloadModalOpen(!payloadModalOpen);
+  };
 
   const renderLoading = () => {
     return (
@@ -131,11 +140,20 @@ const EnabledInlineTriggerRow = ({
         </div>
         {disableError && <ErrorText>{disableError}</ErrorText>}
         <InlineTriggerActionButtonsContainer>
+          <PipelineTriggerButton
+            onClick={handlePayloadToggleClick}
+            data-cy={`${triggeringPipelineInfo.id}-view-payload-btn`}
+          >
+            {T.translate(`${PAYLOAD_PREFIX}.configPayloadBtnDisabled`)}
+          </PipelineTriggerButton>
           <PayloadConfigModal
+            isOpen={payloadModalOpen}
             triggeringPipelineInfo={triggeringPipelineInfo}
             triggeredPipelineInfo={triggeredPipelineInfo}
+            onToggle={handlePayloadToggleClick}
             scheduleInfo={groupSchedule}
             disabled={true}
+            pipelineCompositeTriggersEnabled={true}
           />
         </InlineTriggerActionButtonsContainer>
       </div>

--- a/app/cdap/components/PipelineTriggers/EnabledTriggersTab/index.tsx
+++ b/app/cdap/components/PipelineTriggers/EnabledTriggersTab/index.tsx
@@ -68,8 +68,8 @@ const EnabledTriggersView = ({
   pipelineName,
   setTab,
 }: IEnabledTriggersViewProps) => {
-  const andTriggersEnabled = useFeatureFlagDefaultFalse(
-    'pipeline.triggers.conditional.and.enabled'
+  const pipelineCompositeTriggersEnabled = useFeatureFlagDefaultFalse(
+    'pipeline.composite.triggers.enabled'
   );
   const enabledSingleTriggers = enabledTriggers.filter(
     (schedule) => schedule.trigger.type === PipelineTriggersTypes.programStatus
@@ -83,14 +83,14 @@ const EnabledTriggersView = ({
   return (
     <ExistingTriggersTab>
       <PipelineTriggerHeader>
-        {andTriggersEnabled
-          ? T.translate(`${PREFIX}.andTriggersTitle`, { pipelineName })
+        {pipelineCompositeTriggersEnabled
+          ? T.translate(`${PREFIX}.compositeTriggersTitle`, { pipelineName })
           : T.translate(`${PREFIX}.title`, { pipelineName })}
       </PipelineTriggerHeader>
 
       <PipelineCount>
-        {andTriggersEnabled
-          ? T.translate(`${PREFIX}.andTriggersPipelineCount`, {
+        {pipelineCompositeTriggersEnabled
+          ? T.translate(`${PREFIX}.compositeTriggersPipelineCount`, {
               context: enabledTriggers.length,
             })
           : T.translate(`${PREFIX}.pipelineCount`, {
@@ -121,7 +121,7 @@ const EnabledTriggersView = ({
         </div>
       )}
 
-      {andTriggersEnabled && (
+      {pipelineCompositeTriggersEnabled && (
         <AddNewTriggerButton
           color="primary"
           variant="contained"

--- a/app/cdap/components/PipelineTriggers/PayloadConfigModal/PayloadConfigModal.scss
+++ b/app/cdap/components/PipelineTriggers/PayloadConfigModal/PayloadConfigModal.scss
@@ -16,12 +16,6 @@
 
 .payload-config-modal {
   float: right;
-  margin-right: 15px;
-
-  .view-payload-btn {
-    background: white;
-    text-transform: none;
-  }
 }
 
 body.theme-cdap {

--- a/app/cdap/components/PipelineTriggers/PayloadConfigModal/index.js
+++ b/app/cdap/components/PipelineTriggers/PayloadConfigModal/index.js
@@ -22,7 +22,6 @@ import ScheduleRuntimeArgs from 'components/PipelineTriggers/ScheduleRuntimeArgs
 import IconSVG from 'components/shared/IconSVG';
 import T from 'i18n-react';
 import CardActionFeedback, { CARD_ACTION_TYPES } from 'components/shared/CardActionFeedback';
-import Button from '@material-ui/core/Button';
 
 require('./PayloadConfigModal.scss');
 
@@ -33,41 +32,24 @@ export default class PayloadConfigModal extends Component {
     isOpen: PropTypes.bool,
     triggeringPipelineInfo: PropTypes.object,
     triggeredPipelineInfo: PropTypes.string,
-    onClose: PropTypes.func,
-    onEnableSchedule: PropTypes.func,
+    onConfigureSchedule: PropTypes.func,
     disabled: PropTypes.bool,
     scheduleInfo: PropTypes.object,
     configureError: PropTypes.string,
     onToggle: PropTypes.func,
-    andTriggersEnabled: PropTypes.bool,
-  };
-
-  state = {
-    isOpen: false,
-  };
-
-  toggle = () => {
-    const newState = !this.state.isOpen;
-    this.setState({
-      isOpen: newState,
-    });
-    if (typeof this.props.onToggle === 'function') {
-      this.props.onToggle(newState);
-    }
-    if (!this.state.isOpen && this.props.onClose) {
-      this.props.onClose();
-    }
+    pipelineCompositeTriggersEnabled: PropTypes.bool,
+    modalConfigTab: PropTypes.object,
   };
 
   renderModal = () => {
-    if (!this.state.isOpen) {
+    if (!this.props.isOpen) {
       return null;
     }
 
     return (
       <Modal
-        isOpen={this.state.isOpen}
-        toggle={this.toggle}
+        isOpen={this.props.isOpen}
+        toggle={this.props.onToggle}
         modalClassName="payload-config-modal"
         size="lg"
         zIndex="1061"
@@ -76,7 +58,7 @@ export default class PayloadConfigModal extends Component {
         <ModalHeader className="clearfix">
           <span className="pull-left">{T.translate(`${PREFIX}.title`)}</span>
           <div className="btn-group pull-right">
-            <a className="btn" onClick={this.toggle}>
+            <a className="btn" onClick={this.props.onToggle}>
               <IconSVG name="icon-close" className="fa" />
             </a>
           </div>
@@ -85,10 +67,11 @@ export default class PayloadConfigModal extends Component {
           <ScheduleRuntimeArgs
             triggeringPipelineInfo={this.props.triggeringPipelineInfo}
             triggeredPipelineInfo={this.props.triggeredPipelineInfo}
-            onEnableSchedule={this.props.onEnableSchedule}
+            onEnableSchedule={this.props.onConfigureSchedule}
             disabled={this.props.disabled}
             scheduleInfo={this.props.scheduleInfo}
-            andTriggersEnabled={this.props.andTriggersEnabled}
+            pipelineCompositeTriggersEnabled={this.props.pipelineCompositeTriggersEnabled}
+            modalConfigTab={this.props.modalConfigTab}
           />
         </ModalBody>
         {this.props.configureError && (
@@ -103,22 +86,6 @@ export default class PayloadConfigModal extends Component {
   };
 
   render() {
-    const label = this.props.disabled
-      ? T.translate(`${PREFIX}.configPayloadBtnDisabled`)
-      : T.translate(`${PREFIX}.configPayloadBtn`);
-    const btnCy = this.props.disabled ? 'view-payload-btn' : 'trigger-config-btn';
-
-    return (
-      <div className="payload-config-modal">
-        <Button
-          className="view-payload-btn"
-          onClick={this.toggle}
-          data-cy={`${this.props.triggeringPipelineInfo.id}-${btnCy}`}
-        >
-          {label}
-        </Button>
-        {this.renderModal()}
-      </div>
-    );
+    return <div className="payload-config-modal">{this.renderModal()}</div>;
   }
 }

--- a/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/ScheduleRuntimeArgsActions.js
+++ b/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/ScheduleRuntimeArgsActions.js
@@ -131,8 +131,25 @@ function bulkSetArgMapping(argsArray) {
     },
   });
 }
+
+/**
+ * Method to get the information of member trigger of an AND or OR pipeline trigger group.
+ * @param args - triggering pipeline argument/plugin mapping.
+ * @param triggeringPipelineInfo - the triggering pipeline ID info.
+ * @returns all the args that belong to the triggering pipeline.
+ */
+function filterPropertyMapping(args, triggeringPipelineInfo) {
+  return args.filter(
+    (arg) =>
+      arg.pipelineId &&
+      arg.pipelineId.namespace === triggeringPipelineInfo.namespace &&
+      arg.pipelineId.pipelineName === triggeringPipelineInfo.id
+  );
+}
+
 export {
   fetchPipelineMacroDetails,
+  filterPropertyMapping,
   setArgMapping,
   resetStore,
   bulkSetArgMapping,

--- a/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/Tabs/ComputeConfigTab/index.js
+++ b/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/Tabs/ComputeConfigTab/index.js
@@ -23,10 +23,10 @@ import { setSelectedProfile } from 'components/PipelineTriggers/ScheduleRuntimeA
 
 const PREFIX = 'features.PipelineTriggers.ScheduleRuntimeArgs.Tabs.ComputeConfig';
 
-function ComputeConfigTab({ triggeringPipelineId, selectedProfile, disabled }) {
+function ComputeConfigTab({ selectedProfile, disabled }) {
   return (
     <div className="compute-config-tab">
-      {disabled ? null : <h4>{T.translate(`${PREFIX}.title`, { triggeringPipelineId })} </h4>}
+      {disabled ? null : <h4>{T.translate(`${PREFIX}.title`)} </h4>}
       <ProfilesListViewInPipeline
         selectedProfile={selectedProfile}
         onProfileSelect={setSelectedProfile}
@@ -43,7 +43,6 @@ ComputeConfigTab.propTypes = {
 
 const mapStateToProps = (state) => {
   return {
-    triggeringPipelineId: state.args.triggeringPipelineInfo.id,
     selectedProfile: state.args.selectedProfile,
     disabled: state.args.disabled,
   };

--- a/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/Tabs/TabConfig.js
+++ b/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/Tabs/TabConfig.js
@@ -52,4 +52,47 @@ const TabConfig = {
   layout: 'vertical',
   defaultTab: 1.1,
 };
-export default TabConfig;
+
+const PayLoadConfigTabConfig = {
+  tabs: [
+    {
+      id: 1,
+      type: 'tab-group',
+      name: T.translate(`${PREFIX}.PayloadConfig.title`),
+      opened: true,
+      subtabs: [
+        {
+          id: 1.1,
+          name: T.translate(`${PREFIX}.RuntimeArgs.title`),
+          content: <RuntimeArgsTab />,
+          default: true,
+        },
+        {
+          id: 1.2,
+          name: T.translate(`${PREFIX}.StageProps.title`),
+          content: <StagePropertiesTab />,
+        },
+      ],
+    },
+  ],
+  layout: 'vertical',
+  defaultTab: 1.1,
+};
+
+const ComputeProfileTabConfig = {
+  tabs: [
+    {
+      id: 1,
+      name: T.translate(`${PREFIX}.ComputeConfig.tabTitle`),
+      content: <ComputeConfigTab />,
+    },
+  ],
+  layout: 'vertical',
+  defaultTab: 1,
+};
+
+export default {
+  TabConfig,
+  PayLoadConfigTabConfig,
+  ComputeProfileTabConfig,
+};

--- a/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/index.js
+++ b/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/index.js
@@ -19,6 +19,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import {
   fetchPipelineMacroDetails,
+  filterPropertyMapping,
   resetStore,
   bulkSetArgMapping,
   setSelectedProfile,
@@ -27,7 +28,7 @@ import ScheduleRuntimeArgsStore, {
   SCHEDULERUNTIMEARGSACTIONS,
 } from 'components/PipelineTriggers/ScheduleRuntimeArgs/ScheduleRuntimeArgsStore';
 import ConfigurableTab from 'components/shared/ConfigurableTab';
-import TabConfig from 'components/PipelineTriggers/ScheduleRuntimeArgs/Tabs/TabConfig';
+import Tabs from 'components/PipelineTriggers/ScheduleRuntimeArgs/Tabs/TabConfig';
 import T from 'i18n-react';
 import classnames from 'classnames';
 import { objectQuery } from 'services/helpers';
@@ -48,7 +49,8 @@ export default class ScheduleRuntimeArgs extends Component {
     triggeredPipelineInfo: PropTypes.object.isRequired,
     disabled: PropTypes.bool,
     scheduleInfo: PropTypes.object,
-    andTriggersEnabled: PropTypes.bool,
+    pipelineCompositeTriggersEnabled: PropTypes.bool,
+    modalConfigTab: PropTypes.object,
   };
 
   state = {
@@ -98,7 +100,9 @@ export default class ScheduleRuntimeArgs extends Component {
 
       let argsArray = [];
 
-      let runtimeArgs = triggerProperties.arguments;
+      let runtimeArgs = this.props.pipelineCompositeTriggersEnabled
+        ? filterPropertyMapping(triggerProperties.arguments, this.props.triggeringPipelineInfo)
+        : triggerProperties.arguments;
       if (runtimeArgs.length > 0) {
         runtimeArgs.forEach((args) => {
           argsArray.push({
@@ -109,7 +113,12 @@ export default class ScheduleRuntimeArgs extends Component {
         });
       }
 
-      let pluginProperties = triggerProperties.pluginProperties;
+      let pluginProperties = this.props.pipelineCompositeTriggersEnabled
+        ? filterPropertyMapping(
+            triggerProperties.pluginProperties,
+            this.props.triggeringPipelineInfo
+          )
+        : triggerProperties.pluginProperties;
       if (pluginProperties.length > 0) {
         pluginProperties.forEach((properties) => {
           let key = `${this.props.triggeringPipelineInfo.id}:${properties.stageName}:${properties.source}`;
@@ -172,7 +181,7 @@ export default class ScheduleRuntimeArgs extends Component {
           disabled={this.isEnableTriggerDisabled()}
           data-cy="configure-and-enable-trigger-btn"
         >
-          {this.props.andTriggersEnabled
+          {this.props.pipelineCompositeTriggersEnabled
             ? T.translate(`${PREFIX}.configure_select_btn`)
             : T.translate(`${PREFIX}.configure_enable_btn`)}
         </button>
@@ -183,7 +192,9 @@ export default class ScheduleRuntimeArgs extends Component {
       <div className={classnames('schedule-runtime-args', { disabled: this.props.disabled })}>
         <Provider store={ScheduleRuntimeArgsStore}>
           <fieldset disabled={this.props.disabled}>
-            <ConfigurableTab tabConfig={TabConfig} />
+            <ConfigurableTab
+              tabConfig={this.props.modalConfigTab ? this.props.modalConfigTab : Tabs.TabConfig}
+            />
           </fieldset>
         </Provider>
 

--- a/app/cdap/components/PipelineTriggers/index.js
+++ b/app/cdap/components/PipelineTriggers/index.js
@@ -81,7 +81,7 @@ export default class PipelineTriggers extends Component {
       payload: {
         pipelineName: this.props.pipelineName,
         workflowName: GLOBALS.programId[this.props.pipelineType],
-        pipelineAndTriggersEnabled: this.props.usePipelineAndTriggers,
+        pipelineCompositeTriggersEnabled: this.props.usePipelineCompositeTriggers,
       },
     });
 
@@ -130,7 +130,7 @@ export default class PipelineTriggers extends Component {
       >
         <Provider store={PipelineTriggersStore}>
           <div className="pipeline-triggers-content">
-            {this.props.usePipelineAndTriggers ? null : (
+            {this.props.usePipelineCompositeTriggers ? null : (
               <div className="tab-headers">
                 <div
                   className={classnames('tab', { active: this.state.activeTab === 0 })}
@@ -161,7 +161,7 @@ export default class PipelineTriggers extends Component {
 }
 
 PipelineTriggers.propTypes = {
-  usePipelineAndTriggers: PropTypes.bool.isRequired,
+  usePipelineCompositeTriggers: PropTypes.bool.isRequired,
   pipelineName: PropTypes.string.isRequired,
   namespace: PropTypes.string.isRequired,
   pipelineType: PropTypes.string.isRequired,

--- a/app/cdap/components/PipelineTriggers/reducer.ts
+++ b/app/cdap/components/PipelineTriggers/reducer.ts
@@ -26,15 +26,25 @@ export function triggerConditionReducer(oldstate, action) {
       return { ...oldstate, killed: !oldstate.killed };
     case 'FAILED':
       return { ...oldstate, failed: !oldstate.failed };
+    case 'TOGGLE_PAYLOAD':
+      return {
+        ...oldstate,
+        payloadModalOpen: !oldstate.payloadModalOpen,
+        mappingError: !oldstate.payloadModalOpen ? '' : oldstate.mappingError,
+      };
+    case 'INVALID_MAPPING':
+      return { ...oldstate, mappingError: action.error };
     default:
       return oldstate;
   }
 }
 
-export const initialConditionState = {
+export const initialInlineTriggerState = {
   completed: true,
   killed: false,
   failed: false,
+  payloadModalOpen: false,
+  mappingError: '',
 };
 
 export function triggerNameReducer(oldstate, action) {
@@ -71,6 +81,14 @@ export function triggerNameReducer(oldstate, action) {
         triggerNameError: '',
         triggerName: action.triggerName,
       };
+    case 'TOGGLE_PAYLOAD':
+      return { ...oldstate, computeModalOpen: !oldstate.computeModalOpen };
+    case 'COMPUTE_PROFILE':
+      return {
+        ...oldstate,
+        computeProfile: { ...oldstate.computeProfile, ...action.computeProfile },
+        computeModalOpen: !oldstate.computeModalOpen,
+      };
     default:
       return oldstate;
   }
@@ -81,5 +99,7 @@ export const initialNameState = {
   namespace: '',
   triggerName: '',
   isNameInvalid: true,
+  computeModalOpen: false,
+  computeProfile: {},
   triggerNameError: T.translate(`${TRIGGER_PREFIX}.triggerNameRequired`),
 };

--- a/app/cdap/components/PipelineTriggers/shared.styles.tsx
+++ b/app/cdap/components/PipelineTriggers/shared.styles.tsx
@@ -52,6 +52,8 @@ export const HelperText = styled.div`
 `;
 
 export const ActionButtonsContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
   padding: 15px;
 `;
 
@@ -72,6 +74,7 @@ export const PipelineListHeader = styled.div`
   font-weight: bold;
   border-bottom: 1px solid #dedede;
   padding: 5px 0;
+  margin-top: 5px;
 `;
 
 export const PipelineTriggerHeader = styled.div`

--- a/app/cdap/components/PipelineTriggers/store/PipelineTriggersActionCreator.ts
+++ b/app/cdap/components/PipelineTriggers/store/PipelineTriggersActionCreator.ts
@@ -344,25 +344,25 @@ export function addToTriggerGroup(
   if (!!mapping && !!triggersGroupRunArgs) {
     mapping.forEach((map) => {
       const keySplit = map.key.split(':');
-      const currpPipelineId = {
+      const currentPipelineId = {
         namespace: selectedNamespace,
         pipelineName: triggeringPipelineInfo.id,
       };
       if (keySplit.length > 1) {
         triggersGroupRunArgs.pluginProperties.push({
-          pipelineId: currpPipelineId,
+          pipelineId: currentPipelineId,
           stageName: keySplit[1],
           source: keySplit[2],
           target: map.value,
         });
-        triggersGroupRunArgs.targets.set(map.value || keySplit[2], currpPipelineId);
+        triggersGroupRunArgs.targets.set(map.value || keySplit[2], currentPipelineId);
       } else {
         triggersGroupRunArgs.arguments.push({
-          pipelineId: currpPipelineId,
+          pipelineId: currentPipelineId,
           source: map.key,
           target: map.value,
         });
-        triggersGroupRunArgs.targets.set(map.value || map.key, currpPipelineId);
+        triggersGroupRunArgs.targets.set(map.value || map.key, currentPipelineId);
       }
     });
   }
@@ -409,9 +409,10 @@ export function generateRuntimeMapping(mapping: ITriggerPropertyMapping[]) {
 
 /**
  * Method to validate the incoming trigger argument mapping.
- * @param mapping - the argument mappings of the pipeline trigger.
+ *
+ * @param mappings - the argument mappings of the pipeline trigger.
  * @param triggersGroupRunArgsToAdd - the run arguments of the pipeline group trigger.
- * @returns the validation result, null for valid result, string error for invalid result.
+ * @returns {string} the validation result, null for valid result, string error for invalid result.
  */
 export function validateTriggerMappping(
   mappings: ITriggerPropertyMapping[],

--- a/app/cdap/components/PipelineTriggers/store/PipelineTriggersActions.ts
+++ b/app/cdap/components/PipelineTriggers/store/PipelineTriggersActions.ts
@@ -21,7 +21,7 @@ const PipelineTriggersActions = {
   changeNamespace: 'TRIGGERS_CHANGE_NAMESPACE',
   setPipeline: 'TRIGGERS_SET_PIPELINE',
   setExpandedPipeline: 'TRIGGERS_SET_EXPANDED_PIPELINE',
-  setExpandedTrigger: 'TRIGGERS_SET_EXPANDED_TRIGGER',
+  setExpandedSchedule: 'TRIGGERS_SET_EXPANDED_SCHEDULE',
   setExpandedInlineTrigger: 'TRIGGERS_SET_EXPANDED_INLINE_TRIGGER',
   setTriggersAndPipelineList: 'TRIGGERS_SET_TRIGGERS_PIPELINE',
   setEnabledTriggerPipelineInfo: 'TRIGGERS_SET_PIPELINE_INFO',

--- a/app/cdap/components/PipelineTriggers/store/PipelineTriggersStore.ts
+++ b/app/cdap/components/PipelineTriggers/store/PipelineTriggersStore.ts
@@ -20,24 +20,25 @@ import {
   IPipelineInfo,
   IProgramStatusTrigger,
   ISchedule,
-  ITriggersGroupRunArgs,
+  ICompositeTriggerRunArgsWithTargets,
+  ITriggeringPipelineId,
 } from 'components/PipelineTriggers/store/ScheduleTypes';
 import PipelineTriggersTypes from 'components/PipelineTriggers/store/PipelineTriggersTypes';
 
 interface IPayLoad {
   pipelineName?: string;
   workflowName?: string;
-  pipelineAndTriggersEnabled?: boolean;
+  pipelineCompositeTriggersEnabled?: boolean;
   pipelineList?: IPipelineInfo[];
   selectedNamespace?: string;
   selectedTriggersType?: string;
   triggersGroupToAdd?: IProgramStatusTrigger[];
-  triggersGroupRunArgsToAdd?: ITriggersGroupRunArgs;
+  triggersGroupRunArgsToAdd?: ICompositeTriggerRunArgsWithTargets;
   enabledTriggers?: ISchedule[];
   expandedPipeline?: string;
   error?: any;
   isOpen?: boolean;
-  expandedTrigger?: string;
+  expandedSchedule?: string;
   pipelineInfo?: IPipelineInfo;
 }
 
@@ -59,16 +60,15 @@ const defaultInitialState = {
   triggersGroupRunArgsToAdd: {
     arguments: [],
     pluginProperties: [],
-    propertiesConfig: [],
+    targets: new Map<string, ITriggeringPipelineId>(),
   },
   enabledTriggers: [],
   pipelineName: '',
   pipelineType: '',
   expandedPipeline: null,
-  expandedTrigger: null,
+  expandedSchedule: null,
   configureError: null,
-  payloadModalIsOpen: false,
-  pipelineAndTriggersEnabled: false,
+  pipelineCompositeTriggersEnabled: false,
 };
 
 const defaultInitialEnabledTriggersState = {
@@ -86,7 +86,7 @@ const triggers = (state = defaultInitialState, action = defaultAction) => {
         ...state,
         pipelineName: action.payload.pipelineName,
         workflowName: action.payload.workflowName,
-        pipelineAndTriggersEnabled: action.payload.pipelineAndTriggersEnabled,
+        pipelineCompositeTriggersEnabled: action.payload.pipelineCompositeTriggersEnabled,
       };
       break;
     case PipelineTriggersActions.changeNamespace:
@@ -109,13 +109,6 @@ const triggers = (state = defaultInitialState, action = defaultAction) => {
       stateCopy = {
         ...state,
         triggersGroupToAdd: action.payload.triggersGroupToAdd,
-        expandedPipeline: null,
-        configureError: null,
-      };
-      break;
-    case PipelineTriggersActions.setTriggersGroupRunArgsMapping:
-      stateCopy = {
-        ...state,
         triggersGroupRunArgsToAdd: action.payload.triggersGroupRunArgsToAdd,
         expandedPipeline: null,
         configureError: null,
@@ -128,7 +121,7 @@ const triggers = (state = defaultInitialState, action = defaultAction) => {
         triggersGroupRunArgsToAdd: {
           arguments: [],
           pluginProperties: [],
-          propertiesConfig: [],
+          targets: new Map<string, ITriggeringPipelineId>(),
         },
         expandedPipeline: null,
         configureError: null,
@@ -151,10 +144,10 @@ const triggers = (state = defaultInitialState, action = defaultAction) => {
         configureError: null,
       };
       break;
-    case PipelineTriggersActions.setExpandedTrigger:
+    case PipelineTriggersActions.setExpandedSchedule:
       stateCopy = {
         ...state,
-        expandedTrigger: action.payload.expandedTrigger,
+        expandedSchedule: action.payload.expandedSchedule,
         configureError: null,
       };
       break;
@@ -162,13 +155,6 @@ const triggers = (state = defaultInitialState, action = defaultAction) => {
       stateCopy = {
         ...state,
         configureError: action.payload.error,
-      };
-      break;
-    case PipelineTriggersActions.setPayloadModalState:
-      stateCopy = {
-        ...state,
-        payloadModalIsOpen: action.payload.isOpen,
-        configureError: null,
       };
       break;
     case PipelineTriggersActions.reset:
@@ -184,7 +170,7 @@ const enabledTriggers = (state = defaultInitialEnabledTriggersState, action = de
   let stateCopy;
 
   switch (action.type) {
-    case PipelineTriggersActions.setExpandedTrigger:
+    case PipelineTriggersActions.setExpandedSchedule:
       stateCopy = {
         ...state,
         loading: true,

--- a/app/cdap/components/PipelineTriggers/store/ScheduleTypes.ts
+++ b/app/cdap/components/PipelineTriggers/store/ScheduleTypes.ts
@@ -57,6 +57,7 @@ export interface ISchedule {
   timeoutMillis: number;
   lastUpdateTime?: number;
   status?: string;
+  isTransformed?: boolean;
 }
 
 export interface IPipelineInfo {
@@ -96,8 +97,32 @@ export interface ITriggeringPipelineInfo {
   version?: string;
 }
 
-export interface ITriggersGroupRunArgs {
-  arguments: any[];
-  pluginProperties: any[];
-  propertiesConfig: any[];
+export interface ICompositeTriggerRunArgs {
+  arguments: IRuntimeArgumentMapping[];
+  pluginProperties: IPluginPropertyMapping[];
+}
+
+export interface ICompositeTriggerRunArgsWithTargets extends ICompositeTriggerRunArgs {
+  targets: Map<string, ITriggeringPipelineId>;
+}
+
+export interface IRuntimeArgumentMapping {
+  source: string;
+  target: string;
+  pipelineId: ITriggeringPipelineId;
+}
+
+export interface ITriggeringPipelineId {
+  namespace: string;
+  pipelineName: string;
+}
+
+export interface IPluginPropertyMapping extends IRuntimeArgumentMapping {
+  stageName: string;
+}
+
+export interface ITriggerPropertyMapping {
+  key: string;
+  value: string;
+  type: string;
 }

--- a/app/cdap/components/PipelineTriggersSidebars/index.tsx
+++ b/app/cdap/components/PipelineTriggersSidebars/index.tsx
@@ -48,8 +48,8 @@ function PipelineTriggersWithFeatures({
     <div className="pipeline-triggers-sidebar-container">
       <PipelineTriggers
         {...{
-          usePipelineAndTriggers: useFeatureFlagDefaultFalse(
-            'pipeline.triggers.conditional.and.enabled'
+          usePipelineCompositeTriggers: useFeatureFlagDefaultFalse(
+            'pipeline.composite.triggers.enabled'
           ),
           pipelineName,
           namespace,

--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/table.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/table.tsx
@@ -316,7 +316,6 @@ export const renderTable = ({
                     row={row}
                     tinkEnabled={tinkEnabled}
                     addColumnsToTransforms={addColumnsToTransforms}
-                    columns={selectedList}
                   />
                 </GridCell>
                 <GridCell item xs={6}>

--- a/app/cdap/services/react/providers/featureFlagProvider.tsx
+++ b/app/cdap/services/react/providers/featureFlagProvider.tsx
@@ -21,7 +21,7 @@ type IStringBoolean = 'true' | 'false';
 
 export interface IFeatureFlags {
   'replication.transformations.enabled'?: IStringBoolean;
-  'pipeline.triggers.conditional.and.enabled'?: IStringBoolean;
+  'pipeline.composite.triggers.enabled'?: IStringBoolean;
 }
 
 export const FeatureFlagsContext = createContext(null);

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -2662,11 +2662,11 @@ features:
     description: Description
     EnabledTriggers:
       addNewTrigger: Add new trigger
-      andTriggersPipelineCount:
+      compositeTriggersPipelineCount:
         0: "No triggers set"
         1: "{context} trigger is set"
         _: "{context} triggers are set"
-      andTriggersTitle: "View Enabled triggers for pipeline \"{pipelineName}\""
+      compositeTriggersTitle: "View Enabled triggers for pipeline \"{pipelineName}\""
       buttonLabel: Disable Trigger
       deleteTrigger: Delete Trigger
       deleteTriggerButton: Delete Trigger
@@ -2690,7 +2690,7 @@ features:
     pipelineTriggerType: "Trigger Type: {type}"
     ScheduleRuntimeArgs:
       configure_enable_btn: Configure and Enable Trigger
-      configure_select_btn: Configure and Select Trigger
+      configure_select_btn: Select
       DefaultMessages:
         choose_runtime_arg: Pick runtime argument
         choose_plugin: Pick plugin
@@ -2701,7 +2701,7 @@ features:
         title: Payload configuration
       Tabs:
         ComputeConfig:
-          title: Select a compute profile to use when the pipeline is triggered by "{triggeringPipelineId}"
+          title: Select a compute profile to use when the pipeline is triggered.
           tabTitle: Compute config
         PayloadConfig:
           title: Payload config
@@ -2726,7 +2726,8 @@ features:
           title: Plugin config
     SetTriggers:
       addNewTrigger: Enable the trigger
-      andTriggersTitle: "Add a new trigger for \"{pipelineName}\""
+      configComputeProfie: Compute Profile
+      compositeTriggersTitle: "Add a new trigger for \"{pipelineName}\""
       buttonLabel: Enable Trigger
       pipelineCount: "{count} pipelines available"
       selectedPipelines: "Selected Pipelines:"


### PR DESCRIPTION
# Add support for configuring composite trigger properties

## Description
Add support for configuring composite trigger properties. When configuring the composite triggers, the runtime and plugin arguments can be individually configured within the triggering pipeline. The compute file can be configured in the top layer of the page. The sister backend PR is: https://github.com/cdapio/cdap/pull/14176

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-18450](https://cdap.atlassian.net/browse/CDAP-18450)

## Test Plan
Manual + E2E

## Screenshots
![image](https://user-images.githubusercontent.com/20428112/162534317-05c9b147-7a42-4426-adca-1f8d9c1c653a.png)
![image](https://user-images.githubusercontent.com/20428112/162534343-3905cb49-0026-4436-a471-f8b5570f15f8.png)
![image](https://user-images.githubusercontent.com/20428112/162534547-7e431d95-0b30-4f34-b29c-f74f655fd899.png)



