### PR TITLE
CDAP-18959 Fix "Deprecated" text on Wrangler CSV parsing dialog

### DIFF
--- a/app/cdap/components/DataPrep/Directives/Parse/Modals/CSVModal.js
+++ b/app/cdap/components/DataPrep/Directives/Parse/Modals/CSVModal.js
@@ -155,7 +155,7 @@ export default class CSVModal extends Component {
               />
               <span className="deprecated-warning">
                 <WarningIcon size="small" />
-                {T.translate(`${PREFIX}.Parsers.CSV.deprecatedWarning`)}
+                [{T.translate(`${PREFIX}.Parsers.CSV.deprecatedWarning`)}]
               </span>
               <span>{T.translate(`${PREFIX}.Parsers.CSV.firstRowHeader`)}</span>
             </span>

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -1091,7 +1091,7 @@ features:
             label: Avro
           CSV:
             customPlaceholder: "Delimiter (e.g ;, #, %, ^)"
-            deprecatedWarning: "[Deprecated]"
+            deprecatedWarning: "Deprecated"
             firstRowHeader: Set first row as header
             label: CSV
             modalTitle: Please select the delimiter


### PR DESCRIPTION
# CDAP-18959 Fix "Deprecated" text on Wrangler CSV parsing dialog

## Description
Our I18n library uses Markdown and interprets square brackets like `[Text]` as a paragraph marker. This PR moves the square brackets out of the I18n text into the JSX.

It's possible to disable Markdown interpretation but we'd have to put all our I18n parsing into `V1` mode (currently in `V0`) which could change the semantics of some strings. See https://www.npmjs.com/package/i18n-react#markdown-syntax

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-18959](https://cdap.atlassian.net/browse/CDAP-18959)

## Test Plan
Visually verify

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/2728821/162538022-7ca988b5-1ae4-4f86-a725-6507f90de018.png)

After:
![image](https://user-images.githubusercontent.com/2728821/162538050-d99693c7-87ef-4376-8849-a968e586732e.png)



