### PR TITLE
[CDAP-18982] fix, change indicator of stopping status to blue

### DIFF
--- a/app/cdap/services/StatusMapper.js
+++ b/app/cdap/services/StatusMapper.js
@@ -51,13 +51,13 @@ function getStatusIndicatorClass(displayStatus) {
   if (
     displayStatus === statusMap[PROGRAM_STATUSES.RUNNING] ||
     displayStatus === statusMap[PROGRAM_STATUSES.STARTING] ||
-    displayStatus === statusMap[PROGRAM_STATUSES.PENDING]
+    displayStatus === statusMap[PROGRAM_STATUSES.PENDING] ||
+    displayStatus === statusMap[PROGRAM_STATUSES.STOPPING]
   ) {
     return 'status-blue';
   } else if (
     displayStatus === statusMap[PROGRAM_STATUSES.SUCCEEDED] ||
-    displayStatus === statusMap[PROGRAM_STATUSES.SCHEDULING] ||
-    displayStatus === statusMap[PROGRAM_STATUSES.STOPPING]
+    displayStatus === statusMap[PROGRAM_STATUSES.SCHEDULING]
   ) {
     return 'status-light-green';
   } else if (


### PR DESCRIPTION
# CDAP-18982: fix, change indicator of stopping status to blue

## Description
To keep the consistency with previous indicator pattern, proposing that we treat ‘STOPPING' as a transition status just like ‘PENDING’ and 'STARTING’

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-18982](https://cdap.atlassian.net/browse/CDAP-18982)

## Test Plan

## Screenshots
Before:
<img width="139" alt="image" src="https://user-images.githubusercontent.com/20428112/162803580-ffda45e2-a877-41e2-a107-66c25530081b.png">
After:
<img width="111" alt="image" src="https://user-images.githubusercontent.com/20428112/162803630-8e45a37d-fe4c-469c-bb18-79389c056491.png">

