### PR TITLE
[CDAP-18866] fix, add a scrollable overflow container outside pipelineStopPopver

### DIFF
--- a/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsButtons/PipelineStopButton/PipelineStopPopover.js
+++ b/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsButtons/PipelineStopButton/PipelineStopPopover.js
@@ -153,67 +153,69 @@ export default class PipelineStopPopover extends Component {
               ) : null}
             </button>
           </div>
-          <table className="stop-btn-popover-table table">
-            <thead>
-              <tr>
-                <th />
-                <th>{T.translate('features.PipelineDetails.startTime')}</th>
-                <th>{T.translate('features.PipelineDetails.duration')}</th>
-                <th />
-              </tr>
-            </thead>
-            <tbody>
-              {this.props.runs.map((run, i) => {
-                let runStartTime;
-                if (run.starting) {
-                  runStartTime = moment.unix(run.starting).calendar();
-                } else {
-                  runStartTime = '--';
-                }
+          <div className="stop-btn-popover-table-container">
+            <table className="stop-btn-popover-table table">
+              <thead>
+                <tr>
+                  <th />
+                  <th>{T.translate('features.PipelineDetails.startTime')}</th>
+                  <th>{T.translate('features.PipelineDetails.duration')}</th>
+                  <th />
+                </tr>
+              </thead>
+              <tbody>
+                {this.props.runs.map((run, i) => {
+                  let runStartTime;
+                  if (run.starting) {
+                    runStartTime = moment.unix(run.starting).calendar();
+                  } else {
+                    runStartTime = '--';
+                  }
 
-                return (
-                  <tr
-                    key={i}
-                    className={classnames({
-                      'current-run-row': run.runid === this.props.currentRunId,
-                    })}
-                  >
-                    <td>
-                      <a href={this.getRunIdUrl(run.runid)}>
-                        {run.runid === this.props.currentRunId ? (
-                          <IconSVG name="icon-check" />
-                        ) : null}
-                      </a>
-                    </td>
-                    <td>
-                      <a href={this.getRunIdUrl(run.runid)}>{runStartTime}</a>
-                    </td>
-                    <td>
-                      <a href={this.getRunIdUrl(run.runid)}>
-                        <Duration
-                          targetTime={run.starting}
-                          isMillisecond={false}
-                          showFullDuration={true}
-                        />
-                      </a>
-                    </td>
-                    <td>
-                      {this.state.runsBeingStopped.indexOf(run.runid) !== -1 ? (
-                        <IconSVG name="icon-spinner" className="fa-spin" />
-                      ) : (
-                        <span
-                          className="stop-run"
-                          onClick={this.stopSingleRun.bind(this, run.runid)}
-                        >
-                          {T.translate(`${PREFIX}.stopRun`)}
-                        </span>
-                      )}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
+                  return (
+                    <tr
+                      key={i}
+                      className={classnames({
+                        'current-run-row': run.runid === this.props.currentRunId,
+                      })}
+                    >
+                      <td>
+                        <a href={this.getRunIdUrl(run.runid)}>
+                          {run.runid === this.props.currentRunId ? (
+                            <IconSVG name="icon-check" />
+                          ) : null}
+                        </a>
+                      </td>
+                      <td>
+                        <a href={this.getRunIdUrl(run.runid)}>{runStartTime}</a>
+                      </td>
+                      <td>
+                        <a href={this.getRunIdUrl(run.runid)}>
+                          <Duration
+                            targetTime={run.starting}
+                            isMillisecond={false}
+                            showFullDuration={true}
+                          />
+                        </a>
+                      </td>
+                      <td>
+                        {this.state.runsBeingStopped.indexOf(run.runid) !== -1 ? (
+                          <IconSVG name="icon-spinner" className="fa-spin" />
+                        ) : (
+                          <span
+                            className="stop-run"
+                            onClick={this.stopSingleRun.bind(this, run.runid)}
+                          >
+                            {T.translate(`${PREFIX}.stopRun`)}
+                          </span>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
         </fieldset>
       </Popover>
     );

--- a/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsButtons/PipelineStopButton/PipelineStopPopover.scss
+++ b/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsButtons/PipelineStopButton/PipelineStopPopover.scss
@@ -64,6 +64,12 @@
       }
     }
 
+    .stop-btn-popover-table-container {
+      overflow-y: scroll;
+      overflow-x: hidden;
+      max-height: 800px;
+    }
+
     .table.stop-btn-popover-table {
       background-color: white;
 


### PR DESCRIPTION
# CDAP-18866: fix, add a scrollable overflow container outside pipelineStopPopover

## Description
Previously the running pipelines table's height is not set, which means if there are too many active runs of current pipeline, the stop button popover will grow and push the header outside of the current page.  Now we add a max height and scrollable overflow so that all the current runs will be visible

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-18866](https://cdap.atlassian.net/browse/CDAP-18866)

## Test Plan

## Screenshots

![Screen Shot 2022-04-11 at 18 06 19](https://user-images.githubusercontent.com/20428112/162842211-4b6ba9d2-c073-40f8-aa02-104740b2e3f1.png)

