### PR TITLE
[CDAP-18581] improve error checking for import connection json

### DIFF
--- a/app/cdap/components/Connections/Create/index.tsx
+++ b/app/cdap/components/Connections/Create/index.tsx
@@ -27,11 +27,11 @@ import {
   navigateToConfigStep,
   navigateToConnectionCategoryStep,
   navigateToConnectionList,
-  IConnectorDetails,
   fetchConnectionDetails,
   createConnection,
   getConnection,
   testConnection,
+  IConnectorDetailsWithErrorMessage,
 } from 'components/Connections/Create/reducer';
 import LoadingSVGCentered from 'components/shared/LoadingSVGCentered';
 import { Redirect } from 'react-router';
@@ -69,10 +69,13 @@ export function CreateConnection({
   const [loading, setLoading] = React.useState(true);
   const [state, dispatch] = React.useReducer(reducer, initialState);
   const activeCategory = React.useRef(null);
-  const [connectionDetails, setConnectionDetails] = React.useState<IConnectorDetails>({
+  const [connectionDetails, setConnectionDetails] = React.useState<
+    IConnectorDetailsWithErrorMessage
+  >({
     connectorWidgetJSON: null,
     connectorProperties: null,
     connectorDoc: null,
+    error: null,
   });
   const [initValues, setInitValues] = React.useState({});
   const [error, setError] = React.useState(null);
@@ -127,11 +130,13 @@ export function CreateConnection({
     setLoading(true);
     const connDetails = await fetchConnectionDetails(selectedConnector);
     setConnectionDetails(connDetails);
-    navigateToConfigStep(dispatch, selectedConnector);
+    if (!connDetails.error) {
+      navigateToConfigStep(dispatch, selectedConnector);
+    }
     setLoading(false);
     setTestResponseMessages(undefined);
     setTestSucceeded(false);
-    setError(null);
+    setError(connDetails.error);
     setConfigurationErrors(null);
   };
 

--- a/app/cdap/components/Connections/Create/index.tsx
+++ b/app/cdap/components/Connections/Create/index.tsx
@@ -15,6 +15,7 @@
  */
 
 import * as React from 'react';
+import { useState, useEffect, useRef, useContext, useReducer } from 'react';
 import T from 'i18n-react';
 import { CategorizedConnectors } from 'components/Connections/Create/CategorizedConnectors';
 import makeStyle from '@material-ui/core/styles/makeStyles';
@@ -31,7 +32,7 @@ import {
   createConnection,
   getConnection,
   testConnection,
-  IConnectorDetailsWithErrorMessage,
+  IConnectorDetails,
 } from 'components/Connections/Create/reducer';
 import LoadingSVGCentered from 'components/shared/LoadingSVGCentered';
 import { Redirect } from 'react-router';
@@ -64,26 +65,24 @@ export function CreateConnection({
   isEdit = false,
   enableRouting = true,
 }) {
-  const { mode, disabledTypes } = React.useContext(ConnectionsContext);
+  const { mode, disabledTypes } = useContext(ConnectionsContext);
   const classes = useStyle();
-  const [loading, setLoading] = React.useState(true);
-  const [state, dispatch] = React.useReducer(reducer, initialState);
-  const activeCategory = React.useRef(null);
-  const [connectionDetails, setConnectionDetails] = React.useState<
-    IConnectorDetailsWithErrorMessage
-  >({
+  const [loading, setLoading] = useState(true);
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const activeCategory = useRef(null);
+  const [connectionDetails, setConnectionDetails] = useState<IConnectorDetails>({
     connectorWidgetJSON: null,
     connectorProperties: null,
     connectorDoc: null,
-    error: null,
+    connectorError: null,
   });
-  const [initValues, setInitValues] = React.useState({});
-  const [error, setError] = React.useState(null);
-  const [configurationErrors, setConfigurationErrors] = React.useState(null);
-  const [testSucceeded, setTestSucceeded] = React.useState(false);
-  const [testInProgress, setTestInProgress] = React.useState(false);
-  const [testResponseMessages, setTestResponseMessages] = React.useState(undefined);
-  const [redirectUrl, setRedirectUrl] = React.useState(null);
+  const [initValues, setInitValues] = useState({});
+  const [error, setError] = useState(null);
+  const [configurationErrors, setConfigurationErrors] = useState(null);
+  const [testSucceeded, setTestSucceeded] = useState(false);
+  const [testInProgress, setTestInProgress] = useState(false);
+  const [testResponseMessages, setTestResponseMessages] = useState(undefined);
+  const [redirectUrl, setRedirectUrl] = useState(null);
 
   const init = async () => {
     try {
@@ -93,7 +92,7 @@ export function CreateConnection({
       setLoading(false);
     }
   };
-  React.useEffect(() => {
+  useEffect(() => {
     init();
 
     if (initialConfig && Object.keys(initialConfig).length > 0) {
@@ -130,13 +129,13 @@ export function CreateConnection({
     setLoading(true);
     const connDetails = await fetchConnectionDetails(selectedConnector);
     setConnectionDetails(connDetails);
-    if (!connDetails.error) {
+    if (!connDetails.connectorError) {
       navigateToConfigStep(dispatch, selectedConnector);
     }
     setLoading(false);
     setTestResponseMessages(undefined);
     setTestSucceeded(false);
-    setError(connDetails.error);
+    setError(connDetails.connectorError);
     setConfigurationErrors(null);
   };
 
@@ -279,6 +278,7 @@ export function CreateConnection({
           connectorProperties={connectionDetails.connectorProperties}
           connectorWidgetJSON={connectionDetails.connectorWidgetJSON}
           connectorDoc={connectionDetails.connectorDoc}
+          connectorError={connectionDetails.connectorError}
           onConnectionCreate={onConnectionCreate}
           onConnectionTest={onConnectionTest}
           initValues={initValues}

--- a/app/cdap/components/Connections/Create/reducer.ts
+++ b/app/cdap/components/Connections/Create/reducer.ts
@@ -44,10 +44,7 @@ export interface IConnectorDetails {
   connectorProperties: Record<string, any>;
   connectorWidgetJSON: unknown;
   connectorDoc: unknown;
-}
-
-export interface IConnectorDetailsWithErrorMessage extends IConnectorDetails {
-  error: string;
+  connectorError: string;
 }
 
 enum ICreateConnectionActions {
@@ -225,11 +222,11 @@ function addVersionInfo(categoryToConnectionsMap, versionsMap) {
 }
 
 export async function fetchConnectionDetails(connection) {
-  const connDetails: IConnectorDetailsWithErrorMessage = {
+  const connDetails: IConnectorDetails = {
     connectorProperties: null,
     connectorWidgetJSON: null,
     connectorDoc: null,
-    error: null,
+    connectorError: null,
   };
   const {
     name: artifactname = 'google-cloud',
@@ -277,9 +274,7 @@ export async function fetchConnectionDetails(connection) {
     connDetails.connectorWidgetJSON = JSON.parse(connectionWidgetJSON[widgetJSONKey]);
     connDetails.connectorDoc = connectionDoc[docKey];
   } catch (e) {
-    // tslint:disable-next-line: no-console
-    connDetails.error = `Error fetching widget json or parsing: '${e.response}'`;
-    // console.log('Error fetching widget json or parsing: ', e);
+    connDetails.connectorError = `Error fetching widget json or parsing: '${e.response}'`;
   }
   return connDetails;
 }

--- a/app/cdap/components/Connections/Create/reducer.ts
+++ b/app/cdap/components/Connections/Create/reducer.ts
@@ -46,6 +46,10 @@ export interface IConnectorDetails {
   connectorDoc: unknown;
 }
 
+export interface IConnectorDetailsWithErrorMessage extends IConnectorDetails {
+  error: string;
+}
+
 enum ICreateConnectionActions {
   INIT,
   SET_CATEGORIES,
@@ -221,10 +225,11 @@ function addVersionInfo(categoryToConnectionsMap, versionsMap) {
 }
 
 export async function fetchConnectionDetails(connection) {
-  const connDetails: IConnectorDetails = {
+  const connDetails: IConnectorDetailsWithErrorMessage = {
     connectorProperties: null,
     connectorWidgetJSON: null,
     connectorDoc: null,
+    error: null,
   };
   const {
     name: artifactname = 'google-cloud',
@@ -273,7 +278,8 @@ export async function fetchConnectionDetails(connection) {
     connDetails.connectorDoc = connectionDoc[docKey];
   } catch (e) {
     // tslint:disable-next-line: no-console
-    console.log('Error fetching widget json or parsing: ', e);
+    connDetails.error = `Error fetching widget json or parsing: '${e.response}'`;
+    // console.log('Error fetching widget json or parsing: ', e);
   }
   return connDetails;
 }

--- a/app/cdap/components/Connections/CreateConnectionModal/index.tsx
+++ b/app/cdap/components/Connections/CreateConnectionModal/index.tsx
@@ -15,10 +15,10 @@
  */
 
 import React from 'react';
+import { useState, useEffect } from 'react';
 import makeStyles from '@material-ui/core/styles/makeStyles';
 import { CreateConnection } from 'components/Connections/Create';
 import { createPortal } from 'react-dom';
-import If from 'components/shared/If';
 
 const useStyle = makeStyles((theme) => {
   return {
@@ -45,9 +45,9 @@ export default function CreateConnectionModal({
   const classes = useStyle();
 
   const body = document.body;
-  const [el] = React.useState(document.createElement('div'));
+  const [el] = useState(document.createElement('div'));
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (isOpen) {
       body.appendChild(el);
     }
@@ -62,7 +62,7 @@ export default function CreateConnectionModal({
 
   return createPortal(
     <div className={classes.root}>
-      <If condition={isOpen}>
+      {isOpen && (
         <CreateConnection
           onToggle={onToggle}
           initialConfig={initialConfig}
@@ -70,7 +70,7 @@ export default function CreateConnectionModal({
           isEdit={isEdit}
           enableRouting={false}
         />
-      </If>
+      )}
     </div>,
     el
   );

--- a/app/cdap/components/Connections/ImportConnectionBtn/index.tsx
+++ b/app/cdap/components/Connections/ImportConnectionBtn/index.tsx
@@ -38,6 +38,12 @@ export default function ImportConnectionBtn({ onCreate, className = null }) {
 
   const classes = useStyle();
 
+  function handleFileClear() {
+    if (fileInputRef && fileInputRef.current) {
+      fileInputRef.current.value = null;
+    }
+  }
+
   function handleFile(event) {
     if (!objectQuery(event, 'target', 'files', 0)) {
       return;
@@ -85,6 +91,7 @@ export default function ImportConnectionBtn({ onCreate, className = null }) {
         <input
           type="file"
           accept=".json"
+          onClick={handleFileClear}
           onChange={handleFile}
           ref={fileInputRef}
           className={classes.hidden}

--- a/app/cdap/components/Connections/ImportConnectionBtn/index.tsx
+++ b/app/cdap/components/Connections/ImportConnectionBtn/index.tsx
@@ -38,6 +38,7 @@ export default function ImportConnectionBtn({ onCreate, className = null }) {
 
   const classes = useStyle();
 
+  // This makes sure the onChange hook will fire for same file
   function handleFileClear() {
     if (fileInputRef && fileInputRef.current) {
       fileInputRef.current.value = null;
@@ -105,14 +106,14 @@ export default function ImportConnectionBtn({ onCreate, className = null }) {
         onCreate={handleCreate}
       />
 
-      <If condition={!!parseError}>
+      {!!parseError && (
         <Alert
           message={parseError}
           type="error"
           showAlert={true}
           onClose={() => setParseError(null)}
         />
-      </If>
+      )}
     </>
   );
 }


### PR DESCRIPTION
# [CDAP-18581] improve error checking for import connection json

## Description
- Add error checking for importing connection from a json file. QUESTION: as of now if there's an error, it will still open the createConnectionModal, do we want this or we want to close the modal altogether?
- Allow importing the same file consecutively, before the onChange hook will not fire if same file is uploaded

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-18581](https://cdap.atlassian.net/browse/CDAP-18581)

## Screenshots
<img width="932" alt="image" src="https://user-images.githubusercontent.com/98125204/163068839-0b8f92f3-ad85-4520-9ab9-8718ade88dd5.png">




[CDAP-18581]: https://cdap.atlassian.net/browse/CDAP-18581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ