### PR TITLE
Fix auth bug in cdap

### DIFF
--- a/app/login/login.js
+++ b/app/login/login.js
@@ -67,8 +67,8 @@ class Login extends Component {
         }
       })
       .then((res) => {
-        const isSecure = window.CDAP_CONFIG.sslEnabled;
-        cookie.set('CDAP_Auth_Token', res.access_token, {
+        const { isSecure, access_token } = res;
+        cookie.set('CDAP_Auth_Token', access_token, {
           path: '/',
           secure: isSecure,
           sameSite: 'strict',

--- a/server/express.js
+++ b/server/express.js
@@ -466,7 +466,9 @@ function makeApp(authAddress, cdapConfig, uiSettings) {
         var statusCode = (nres ? nres.statusCode : 500) || 500;
         res.status(statusCode).send(nbody);
       } else {
-        res.send(nbody);
+        const jsonBody = JSON.parse(nbody);
+        jsonBody.isSecure = isSecure;
+        res.send(JSON.stringify(jsonBody));
       }
     });
   }


### PR DESCRIPTION
# CDAP UI on kubernetes does not allow login

## Description
This bug happens since the window object does not have the `CDAP_CONFIG` prop at the time of authentication. Login component cannot retrieve isSecure prop from `CDAP_CONFIG`, hence resulting in an error. As part of the fix, I'm sending the isSecure prop as part of the auth response to avoid the null pointer reference error.

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-18960](https://cdap.atlassian.net/browse/CDAP-18960)

## Test Plan
This was manually tested on Vinisha's kubernetes cluster and I was able to login (see screenshot below).

## Screenshots
<img width="1365" alt="Screen Shot 2022-04-15 at 10 59 59 AM" src="https://user-images.githubusercontent.com/94018249/163604923-f360c7b0-2063-4d89-86af-5da4716d4216.png">


