### PR TITLE
CDAP-19057 Support connections without artifact version set

### DIFF
--- a/app/cdap/api/artifact.js
+++ b/app/cdap/api/artifact.js
@@ -18,6 +18,7 @@ import { apiCreator } from 'services/resource-helper';
 
 let dataSrc = DataSourceConfigurer.getInstance();
 const basepath = '/namespaces/:namespace/artifacts';
+const listArtifactVersionsPath = basepath + '/:artifactId';
 const baseArtifactPath = basepath + '/:artifactId/versions/:version';
 const basePluginArtifactJSON = baseArtifactPath + '/properties';
 
@@ -39,6 +40,7 @@ export const MyArtifactApi = {
   delete: apiCreator(dataSrc, 'DELETE', 'REQUEST', baseArtifactPath),
   loadPluginConfiguration: apiCreator(dataSrc, 'PUT', 'REQUEST', basePluginArtifactJSON),
   list: apiCreator(dataSrc, 'GET', 'REQUEST', basepath),
+  listArtifactVersions: apiCreator(dataSrc, 'GET', 'REQUEST', listArtifactVersionsPath),
   reloadSystemArtifacts: apiCreator(dataSrc, 'POST', 'REQUEST', '/namespaces/system/artifacts'),
   fetchPluginDetails: apiCreator(
     dataSrc,

--- a/package.json
+++ b/package.json
@@ -246,6 +246,7 @@
     "redux-undo": "1.0.0",
     "request": "2.88.0",
     "rxjs": "5.5.2",
+    "semver": "^7.3.7",
     "serve-favicon": "2.5.0",
     "shepherd.js": "2.0.0-beta.17",
     "sockjs": "0.3.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19273,6 +19273,13 @@ semver@^7.3.5:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.3.7:
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
+  dependencies:
+    lru-cache "^6.0.0"
+
 send@0.17.1:
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/send/-/send-0.17.1.tgz#c1d8b059f7900f7466dd4938bdc44e11ddb376c8"


### PR DESCRIPTION
# CDAP-19057 Support connections without artifact version set

## Description
Default connections, and others defined via capability-configs, might not have the artifact version set. For those, fetch the artifact information to find the latest version.

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19057](https://cdap.atlassian.net/browse/CDAP-19057)

## Test Plan
Manually verify

## Screenshots
N/A


