### PR TITLE
[CDAP-18952] fix mssql inconsistent table name

### DIFF
--- a/app/cdap/components/Replicator/utilities/index.ts
+++ b/app/cdap/components/Replicator/utilities/index.ts
@@ -446,7 +446,12 @@ export function identifyReplicatorEntityFromMetadata(metadata: {
  */
 export function parseErrorMessageForTransformations(message: string) {
   const [_, tablePiece, columnPiece, messagePiece] = message.split(' : ');
-  const table = tablePiece.split(' ')[0];
+  // for mssql source, table name will be in format of schema.table
+  // hence need to split on '.' and take the last element as table name
+  const table = tablePiece
+    .split(' ')[0]
+    .split('.')
+    .slice(-1)[0];
   const column = columnPiece.split(' ')[0];
   const errorMessage = messagePiece;
 


### PR DESCRIPTION
# [CDAP-18952] fix mssql inconsistent table name

## Description
After changing the format of mssql table name to `schema.table`, the response table name will also become this format, but the UI only need the tablename to do subsequent work. Hence need the extra split step

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-18952](https://cdap.atlassian.net/browse/CDAP-18952)





[CDAP-18952]: https://cdap.atlassian.net/browse/CDAP-18952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ