### PR TITLE
[CDAP-18338] fix plugin widgets not showing default values on toggle

### DIFF
--- a/app/cdap/components/shared/ConfigurationGroup/utilities/__tests__/utilities.test.ts
+++ b/app/cdap/components/shared/ConfigurationGroup/utilities/__tests__/utilities.test.ts
@@ -48,7 +48,7 @@ describe('Unit tests for Utilities', () => {
           ],
         },
       ];
-      expect(removeFilteredProperties(values, filteredConfigurationGroups)).toStrictEqual({
+      expect(removeFilteredProperties(values, filteredConfigurationGroups)).toEqual({
         location: 'US-default',
         project: 'test',
       });

--- a/app/cdap/components/shared/ConfigurationGroup/utilities/index.ts
+++ b/app/cdap/components/shared/ConfigurationGroup/utilities/index.ts
@@ -389,7 +389,8 @@ export function removeFilteredProperties(values, filteredConfigurationGroups) {
     filteredConfigurationGroups.forEach((group) => {
       group.properties.forEach((property) => {
         if (property.show === false) {
-          delete newValues[property.name];
+          // instead of deleting the field, set it to undefined
+          newValues[property.name] = undefined;
         }
       });
     });


### PR DESCRIPTION
# [CDAP-18338] fix plugin widgets not showing default values on toggle

## Description
Because some widgets conditions are depending on some default values, those values are lost in previous implementation when toggling/switching stuff, change the flow to continuously update values until not able to. 

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-18338](https://cdap.atlassian.net/browse/CDAP-18338)

## Test Plan
Manual testing




[CDAP-18338]: https://cdap.atlassian.net/browse/CDAP-18338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ