### PR TITLE
fix/CDAP-19124

### DIFF
--- a/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/reducer.ts
+++ b/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/reducer.ts
@@ -166,7 +166,13 @@ export const fetchNamespaceList = async (dispatch) => {
   const namespaces = [];
 
   namespaceList.forEach((ns) => {
-    if (ns.name !== DEFAULT_NS) {
+    if (ns.name === DEFAULT_NS) {
+      namespaces.unshift({
+        namespace: DEFAULT_NS,
+        cpuLimit: ns.config[K8S_NS_CPU_LIMITS],
+        memoryLimit: ns.config[K8S_NS_MEMORY_LIMITS],
+      });
+    } else {
       namespaces.push({
         namespace: ns.config[K8S_NS_NAME],
         cpuLimit: ns.config[K8S_NS_CPU_LIMITS],

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -214,10 +214,10 @@ features:
             label: Name
           CpuLimit:
             name: cpuLimit
-            label: CPU
+            label: CPU (# of cores)
           MemoryLimit:
             name: memoryLimit
-            label: Memory
+            label: Memory (GB)
         CDFInformation:
           title: CDF Information
           ProjectName: 

--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "angularjs-dropdown-multiselect": "1.5.2",
     "angular-marked": "1.0.1",
     "js-beautify": "1.6.2",
-    "angular-file-saver": "1.0.3",
+    "angular-file-saver": "70aab54d6349c2945bae585a814011f1db8dcc2e",
     "d3-tip": "0.6.7",
     "esprima": "2.0.0",
     "ngInfiniteScroll": "1.2.1",


### PR DESCRIPTION
# Add units for CPU and memory limits in the namespaces table

## Description
This PR adds units for cpu and memory limit in the namespaces table when creating a new request. It also shows the `default` namespace which was being filtered previously

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19124](https://cdap.atlassian.net/browse/CDAP-19124)

## Test Plan
Manual

## Screenshots
![Screen Shot 2022-04-21 at 11 56 34 AM](https://user-images.githubusercontent.com/94018249/164533412-2a00723f-de38-42de-8e6a-bcacb9debb52.png)


