### PR TITLE
fix: CDAP-19131 and more

### DIFF
--- a/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/NamespacesTable.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/NamespacesTable.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Grid, GridHeader, GridBody, GridRow, GridCell, StyledCheckbox } from '../shared.styles';
-import { getScrollableColTemplate } from '../utils';
+import { getScrollableColTemplate, trimMemoryLimit } from '../utils';
 import { INamespace } from '../types';
 import { OMNI_NS_COLUMN_TEMPLATE, OMNI_NS_TABLE_HEADERS } from './constants';
 
@@ -83,7 +83,7 @@ const NameSpacesTable = ({
         </GridCell>
         <GridCell>{namespace}</GridCell>
         <GridCell>{cpuLimit}</GridCell>
-        <GridCell>{memoryLimit}</GridCell>
+        <GridCell>{trimMemoryLimit(memoryLimit)}</GridCell>
       </GridRow>
     );
   };

--- a/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/constants.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/constants.tsx
@@ -22,6 +22,7 @@ export const DEFAULT_NS = 'default';
 export const K8S_NS_NAME = 'k8s.namespace';
 export const K8S_NS_CPU_LIMITS = 'k8s.namespace.cpu.limits';
 export const K8S_NS_MEMORY_LIMITS = 'k8s.namespace.memory.limits';
+export const K8S_NS_MEMORY_LIMIT_UNIT = 'Gi';
 
 const I18NPREFIX = 'features.Administration.Tethering.CreateRequest';
 export const I18N_OMNI_PREFIX = `${I18NPREFIX}.OmniNamespaces`;

--- a/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/reducer.ts
+++ b/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/reducer.ts
@@ -18,7 +18,13 @@ import { IAction } from 'services/redux-helpers';
 import { TetheringApi } from 'api/tethering';
 import { MyNamespaceApi } from 'api/namespace';
 import { IApiError, IValidationErrors, INamespace } from '../types';
-import { K8S_NS_NAME, K8S_NS_CPU_LIMITS, K8S_NS_MEMORY_LIMITS, DEFAULT_NS } from './constants';
+import {
+  K8S_NS_NAME,
+  K8S_NS_CPU_LIMITS,
+  K8S_NS_MEMORY_LIMITS,
+  DEFAULT_NS,
+  K8S_NS_MEMORY_LIMIT_UNIT,
+} from './constants';
 
 export interface INewTetheringReqState {
   namespaces: INamespace[];
@@ -170,13 +176,13 @@ export const fetchNamespaceList = async (dispatch) => {
       namespaces.unshift({
         namespace: DEFAULT_NS,
         cpuLimit: ns.config[K8S_NS_CPU_LIMITS],
-        memoryLimit: ns.config[K8S_NS_MEMORY_LIMITS],
+        memoryLimit: `${ns.config[K8S_NS_MEMORY_LIMITS]}${K8S_NS_MEMORY_LIMIT_UNIT}`,
       });
     } else {
       namespaces.push({
         namespace: ns.config[K8S_NS_NAME],
         cpuLimit: ns.config[K8S_NS_CPU_LIMITS],
-        memoryLimit: ns.config[K8S_NS_MEMORY_LIMITS],
+        memoryLimit: `${ns.config[K8S_NS_MEMORY_LIMITS]}${K8S_NS_MEMORY_LIMIT_UNIT}`,
       });
     }
   });

--- a/app/cdap/components/Administration/TetheringTabContent/TetheringTable/constants.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/TetheringTable/constants.tsx
@@ -19,7 +19,7 @@ import T from 'i18n-react';
 import { StyledIcon } from '../shared.styles';
 
 export const PREFIX = 'features.Administration.Tethering';
-export const DESC_COLUMN_TEMPLATE = '50px 200px 5fr 200px 1.5fr 240px 225px';
+export const DESC_COLUMN_TEMPLATE = '50px 200px 5fr 200px 1.5fr 280px 225px';
 
 export const ICONS = {
   active: {

--- a/app/cdap/components/Administration/TetheringTabContent/TetheringTable/index.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/TetheringTable/index.tsx
@@ -18,9 +18,10 @@ import React, { useState, useEffect } from 'react';
 import { Grid, GridHeader, GridBody, GridRow, GridCell } from '../shared.styles';
 import { CONNECTIONS_TABLE_HEADERS } from './constants';
 import { IConnection, ITableData } from '../types';
+import { trimMemoryLimit } from '../utils';
 import { getIconForStatus, renderAllocationsHeader, getTransformedTableData } from './utils';
 
-const COLUMN_TEMPLATE = '50px 200px 2fr 1.5fr 1.5fr 200px 1.5fr 120px 120px 225px';
+const COLUMN_TEMPLATE = '50px 200px 2fr 1.5fr 1.5fr 200px 1.5fr 140px 140px 225px';
 
 interface ITetheringTableProps {
   tableData: IConnection[];
@@ -127,7 +128,7 @@ const TetheringTable = ({
             {namespace}
           </GridCell>
           <GridCell border={!isLast}>{cpuLimit}</GridCell>
-          <GridCell border={!isLast}>{memoryLimit}</GridCell>
+          <GridCell border={!isLast}>{trimMemoryLimit(memoryLimit)}</GridCell>
           {isFirst && <GridCell lastCol={true}>{renderLastColumn(instanceName)}</GridCell>}
         </GridRow>
       );

--- a/app/cdap/components/Administration/TetheringTabContent/utils.ts
+++ b/app/cdap/components/Administration/TetheringTabContent/utils.ts
@@ -16,6 +16,7 @@
 
 import T from 'i18n-react';
 import { IValidationErrors } from './types';
+import { K8S_NS_MEMORY_LIMIT_UNIT } from './NewTetheringRequest/constants';
 
 const I18NPREFIX = 'features.Administration.Tethering.CreateRequest';
 const SCROLLER_WIDTH = '16px';
@@ -56,3 +57,7 @@ export const areInputsValid = ({ selectedNamespaces, inputFields }) => {
 };
 
 export const getScrollableColTemplate = (template: string) => `${template} ${SCROLLER_WIDTH}`;
+
+export const trimMemoryLimit = (limit) => {
+  return limit.toString().slice(0, -K8S_NS_MEMORY_LIMIT_UNIT.length);
+};

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -247,8 +247,8 @@ features:
          instanceName: Instance name
          region: Region
          tetheredNamespace: Tethered namespace
-         cpu: CPU
-         memory: Memory
+         cpu: CPU (# of cores)
+         memory: Memory (GB)
       Actions:
         edit: Edit
         delete: Delete


### PR DESCRIPTION
# CDAP-19131

## Description
This PR adds "Gi" to the memory limit in tethering namespaces table (upon sending the creation request) to avoid an error currently happening in the backend. It also adds cpu & memory limit units in pending and connection tables headers (see screenshot).

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19131](https://cdap.atlassian.net/browse/CDAP-19131)

## Test Plan
Manual

## Screenshots
![Screen Shot 2022-04-22 at 11 55 23 AM](https://user-images.githubusercontent.com/94018249/164777031-13ddd2be-8a88-4f40-9828-55ea453aa06b.png)


