### PR TITLE
[CDAP-19137|18338] Address new bugs for 18338

### DIFF
--- a/app/cdap/components/shared/ConfigurationGroup/utilities/index.ts
+++ b/app/cdap/components/shared/ConfigurationGroup/utilities/index.ts
@@ -397,3 +397,18 @@ export function removeFilteredProperties(values, filteredConfigurationGroups) {
 
   return newValues;
 }
+
+// Some fields may have been cleared and lost their default value
+// this function adds default value to property which shows and
+// currently has a null value and non-null default value
+export function addDefaultValueToShownProperties(configGroup, newValues) {
+  const cpyValues = { ...newValues };
+  configGroup.forEach((config) => {
+    config.properties.forEach((property) => {
+      if (property.show && newValues[property.name] === undefined && property.defaultValue) {
+        cpyValues[property.name] = property.defaultValue;
+      }
+    });
+  });
+  return cpyValues;
+}


### PR DESCRIPTION
# [CDAP-19137|18338] Address new bugs for 18338

## Description
[pull 448](https://github.com/cdapio/cdap-ui/pull/448) caused an infinite useEffect loop. Because the value it checks is an object. Due to the design of useEffect, as long as a new object is set, even if the contents are the same, useEffect will still trigger, hence infinite loop. The fix is to use "isEqual" from lodash to decide whether to set new object.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19137](https://cdap.atlassian.net/browse/CDAP-19137)
[CDAP-18338](https://cdap.atlassian.net/browse/CDAP-18338)

## Test Plan
Probably should write a new e2e test
pipeline.spec.ts and pipeline.postrunactions.spec.ts now pass (previously failed in e2e)

