### PR TITLE
CDAP-19077 Fix size of source parsing dialog whether or not error is shown

### DIFF
--- a/app/cdap/components/Connections/Browser/ParsingConfigModal/index.tsx
+++ b/app/cdap/components/Connections/Browser/ParsingConfigModal/index.tsx
@@ -112,7 +112,7 @@ export default function ParsingConfigModal({
   };
 
   return (
-    <Dialog open={true} maxWidth="md">
+    <Dialog open={true} maxWidth="sm" fullWidth={true}>
       <DialogTitle>Parsing Options</DialogTitle>
       <DialogContent>
         <ContentContainer>


### PR DESCRIPTION
# CDAP-19077 Fix size of source parsing dialog whether or not error is shown

## Description
By setting the `maxWidth` with `fullSize={true}`, the dialog will maintain the same width regardless of the contents.

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19077](https://cdap.atlassian.net/browse/CDAP-19077)

## Test Plan
Manually verify

## Screenshots
No error:
![image](https://user-images.githubusercontent.com/2728821/165381376-c665ca68-b6e2-4558-ba42-5d5996f6ec8a.png)

Error:
![image](https://user-images.githubusercontent.com/2728821/165381424-f3d56099-31eb-4655-80d4-1236509f170d.png)



