### PR TITLE
CDAP-19077 Fix size of source parsing dialog whether or not error is shown for 6.7

### DIFF
--- a/app/cdap/components/Connections/Browser/ParsingConfigModal/index.tsx
+++ b/app/cdap/components/Connections/Browser/ParsingConfigModal/index.tsx
@@ -112,7 +112,7 @@ export default function ParsingConfigModal({
   };
 
   return (
-    <Dialog open={true} maxWidth="md">
+    <Dialog open={true} maxWidth="sm" fullWidth={true}>
       <DialogTitle>Parsing Options</DialogTitle>
       <DialogContent>
         <ContentContainer>


### PR DESCRIPTION
# CDAP-19077 Fix size of source parsing dialog whether or not error is shown

## Description
Cherry-pick of #464 

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [X] Cherry Pick

## Links
Jira: [CDAP-19077](https://cdap.atlassian.net/browse/CDAP-19077)

## Test Plan
Manually verify

## Screenshots
See #464 


