### PR TITLE
[CDAP-18338] fix configForm ui not remembering user input on toggle

### DIFF
--- a/app/cdap/components/shared/ConfigurationGroup/utilities/index.ts
+++ b/app/cdap/components/shared/ConfigurationGroup/utilities/index.ts
@@ -397,3 +397,36 @@ export function removeFilteredProperties(values, filteredConfigurationGroups) {
 
   return newValues;
 }
+
+/**
+ * replace the values in values1 with values2
+ *
+ * @param values1 the target that we want to update
+ * @param values2 the source that the target gets value from
+ */
+export function replaceDifferenceInObjects(values1, values2) {
+  const values = { ...values1 };
+  Object.keys(values2).forEach((key) => {
+    values[key] = values2[key];
+  });
+  return values;
+}
+
+/**
+ * replace the values in filteredValues with currentValues when
+ * the property.show is true
+ *
+ * @param filteredValues the result values of removing hidden properties
+ * @param currentValues the state that includes all current user input
+ * @param configGroup a filter group based on user input that decide whether a property
+ *                    show of not
+ */
+export function addCurrentValueToShownProperty(filteredValues, currentValues, configGroup) {
+  configGroup.forEach((config) => {
+    config.properties.forEach((property) => {
+      if (property.show) {
+        filteredValues[property.name] = currentValues[property.name];
+      }
+    });
+  });
+}


### PR DESCRIPTION
# [CDAP-18338] fix configForm ui not remembering user input on toggle

## Description
Changed the approach to use another state to remember the current user input and insert the values back to the new filtered values after toggling. 

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-18338](https://cdap.atlassian.net/browse/CDAP-18338)





[CDAP-18338]: https://cdap.atlassian.net/browse/CDAP-18338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ