### PR TITLE
CDAP-18912 Don't save preferences when pipeline configuration is updated

### DIFF
--- a/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ConfigModelessActionButtons/index.js
+++ b/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ConfigModelessActionButtons/index.js
@@ -20,11 +20,9 @@ import {
   updatePipeline,
   runPipeline,
   schedulePipeline,
-  updatePreferences,
 } from 'components/PipelineConfigurations/Store/ActionCreator';
 import { setRunError } from 'components/PipelineDetails/store/ActionCreator';
 import ConfigModelessSaveBtn from 'components/PipelineConfigurations/ConfigurationsContent/ConfigModelessActionButtons/ConfigModelessSaveBtn';
-import { Observable } from 'rxjs/Observable';
 
 require('./ConfigModelessActionButtons.scss');
 
@@ -65,7 +63,7 @@ export default class ConfigModelessActionButtons extends Component {
     this.setState({
       [loadingState]: true,
     });
-    Observable.forkJoin(updatePipeline(), updatePreferences()).subscribe(
+    updatePipeline().subscribe(
       () => {
         actionFn();
         this.setState({


### PR DESCRIPTION
# CDAP-18912 Don't save preferences when pipeline configuration is updated

## Description
The preferences (runtime args) moved out of this dialog, and saving them here causes inherited values to be explicitly set.

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-18912](https://cdap.atlassian.net/browse/CDAP-18912)

## Test Plan
Manually verify

## Screenshots
N/A


