### PR TITLE
fix: CDAP-19152: error on page load, and incorrect namespace name

### DIFF
--- a/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/reducer.ts
+++ b/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/reducer.ts
@@ -19,7 +19,6 @@ import { TetheringApi } from 'api/tethering';
 import { MyNamespaceApi } from 'api/namespace';
 import { IApiError, IValidationErrors, INamespace } from '../types';
 import {
-  K8S_NS_NAME,
   K8S_NS_CPU_LIMITS,
   K8S_NS_MEMORY_LIMITS,
   DEFAULT_NS,
@@ -176,13 +175,17 @@ export const fetchNamespaceList = async (dispatch) => {
       namespaces.unshift({
         namespace: DEFAULT_NS,
         cpuLimit: ns.config[K8S_NS_CPU_LIMITS],
-        memoryLimit: `${ns.config[K8S_NS_MEMORY_LIMITS]}${K8S_NS_MEMORY_LIMIT_UNIT}`,
+        memoryLimit: ns.config[K8S_NS_MEMORY_LIMITS]
+          ? `${ns.config[K8S_NS_MEMORY_LIMITS]}${K8S_NS_MEMORY_LIMIT_UNIT}`
+          : undefined,
       });
     } else {
       namespaces.push({
-        namespace: ns.config[K8S_NS_NAME],
+        namespace: ns.name,
         cpuLimit: ns.config[K8S_NS_CPU_LIMITS],
-        memoryLimit: `${ns.config[K8S_NS_MEMORY_LIMITS]}${K8S_NS_MEMORY_LIMIT_UNIT}`,
+        memoryLimit: ns.config[K8S_NS_MEMORY_LIMITS]
+          ? `${ns.config[K8S_NS_MEMORY_LIMITS]}${K8S_NS_MEMORY_LIMIT_UNIT}`
+          : undefined,
       });
     }
   });

--- a/app/cdap/components/Administration/TetheringTabContent/utils.ts
+++ b/app/cdap/components/Administration/TetheringTabContent/utils.ts
@@ -59,5 +59,5 @@ export const areInputsValid = ({ selectedNamespaces, inputFields }) => {
 export const getScrollableColTemplate = (template: string) => `${template} ${SCROLLER_WIDTH}`;
 
 export const trimMemoryLimit = (limit) => {
-  return limit.toString().slice(0, -K8S_NS_MEMORY_LIMIT_UNIT.length);
+  return limit ? limit.toString().slice(0, -K8S_NS_MEMORY_LIMIT_UNIT.length) : '';
 };


### PR DESCRIPTION
# Error on Tethering Connections Page Load

## Description
Currently, the UI trims memory limit units (i.e., `Gi`), when the memory limit is undefined, it errors out when calling`toString()` on the limit. The UI was also incorrectly showing `k8s.namespace.name` instead of `namespace.name`

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19152](https://cdap.atlassian.net/browse/CDAP-19152)

## Test Plan
Manual

## Screenshots


