### PR TITLE
[CDAP-19160] Replicator step 4 will now saveDraft with updated tables

### DIFF
--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/types.ts
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/types.ts
@@ -22,6 +22,9 @@ import {
   ITransformation,
   ISelectedList,
   ITableAssessmentColumn,
+  ITablesStore,
+  IColumnsStore,
+  IDMLStore,
 } from 'components/Replicator/types';
 import { Observable } from 'rxjs/Observable';
 
@@ -46,6 +49,15 @@ export interface ISelectColumnsProps {
   ) => void;
   assessmentLoading: boolean;
   tinkEnabled: boolean;
+  setTables: (
+    tables: ITablesStore,
+    columns: IColumnsStore,
+    dmlBlacklist: IDMLStore,
+    checkTransformations?: boolean
+  ) => void;
+  tables: ITablesStore;
+  columns: IColumnsStore;
+  dmlBlacklist: IDMLStore;
 }
 
 interface IColumn {


### PR DESCRIPTION
# [CDAP-19160] Replicator step 4 will now saveDraft with updated tables

## Description
`assessTable` only works for selected tables. Now it will `saveDraft` before `assessTable`

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19160](https://cdap.atlassian.net/browse/CDAP-19160)

## Test Plan
manual testing




[CDAP-19160]: https://cdap.atlassian.net/browse/CDAP-19160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ