### PR TITLE
CDAP-19147 Use plugin widget filters to show/hide properties in source parsing

### DIFF
--- a/app/cdap/components/Connections/Browser/ParsingConfigModal/index.tsx
+++ b/app/cdap/components/Connections/Browser/ParsingConfigModal/index.tsx
@@ -103,13 +103,24 @@ export default function ParsingConfigModal({
     properties: state.selectedProperties,
   };
 
-  const handleConfig = () => {
+  const handleConfirm = () => {
     dispatch({
       type: SET_STATUS_ACTION,
       value: STATE_CONFIG_CONFIRMED,
     });
-    onConfirm(state.selectedProperties);
+    const confirmedProperties = {};
+    // Filter out hidden properties before submitting
+    Object.keys(state.selectedProperties).forEach((propertyKey) => {
+      if (!state.hiddenProperties[propertyKey]) {
+        confirmedProperties[propertyKey] = state.selectedProperties[propertyKey];
+      }
+    });
+    onConfirm(confirmedProperties);
   };
+
+  const widgets = state.widgets.filter((widget) => {
+    return !state.hiddenProperties[widget.name];
+  });
 
   return (
     <Dialog open={true} maxWidth="sm" fullWidth={true}>
@@ -119,7 +130,7 @@ export default function ParsingConfigModal({
           {(state.status === STATE_AVAILABLE || state.status === STATE_CONFIG_CONFIRMED) && (
             <>
               {errorMessage && <StyledAlert severity="error">{errorMessage}</StyledAlert>}
-              {state.widgets.map((widget) => (
+              {widgets.map((widget) => (
                 <PropertyRow
                   key={widget.name}
                   widgetProperty={widget}
@@ -153,7 +164,7 @@ export default function ParsingConfigModal({
       <DialogActions>
         <PrimaryTextButton onClick={onCancel}>Cancel</PrimaryTextButton>
         <PrimaryTextButton
-          onClick={handleConfig}
+          onClick={handleConfirm}
           disabled={state.status !== STATE_AVAILABLE}
           data-cy="parsing-config-confirm"
         >


### PR DESCRIPTION
# CDAP-19147 Use plugin widget filters to show/hide properties in source parsing

## Description
Some properties are hidden or shown based on the selected file type (e.g. `delimiter` is only shown for delimited files). Use the plugin widget filters to show/hide properties based on user selections. Also, only submit visible properties to the sample request.

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19147](https://cdap.atlassian.net/browse/CDAP-19147)

## Test Plan
Manually verify

## Screenshots
![image](https://user-images.githubusercontent.com/2728821/165996562-7ee8da97-d2a9-4f2b-ac1f-81ad9cc60387.png)

![image](https://user-images.githubusercontent.com/2728821/165996579-da163457-317f-4aef-b638-55ff4a4f6e74.png)


