### PR TITLE
fix/CDAP-19166: change wrong prop name to capture entered email

### DIFF
--- a/app/cdap/components/CaskWizards/AddNamespace/ResourcesStep/index.tsx
+++ b/app/cdap/components/CaskWizards/AddNamespace/ResourcesStep/index.tsx
@@ -104,7 +104,7 @@ const mapDispatchToServiceAccountEmailProps = (dispatch) => {
     onChange: (e) => {
       dispatch({
         type: AddNamespaceActions.setServiceAccountEmail,
-        payload: { k8sNamespace: e.target.value },
+        payload: { serviceAccountEmail: e.target.value },
       });
     },
   };


### PR DESCRIPTION
# Fix CDAP-19166 bug in namespace creation

## Description
This PR fixes the incorrect state update for kubernetes resources when user enters a service account email address.

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19166](https://cdap.atlassian.net/browse/CDAP-19166)

## Test Plan
Manual

## Screenshots


