### PR TITLE
CDAP-19158 Upload schema when parsing from source

### DIFF
--- a/app/cdap/components/Connections/Browser/ParsingConfigModal/ImportFileButton.tsx
+++ b/app/cdap/components/Connections/Browser/ParsingConfigModal/ImportFileButton.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { useRef } from 'react';
+import styled from 'styled-components';
+import PrimaryTextButton from 'components/shared/Buttons/PrimaryTextButton';
+import { objectQuery } from 'services/helpers';
+
+const HiddenInput = styled.input`
+  display: none !important;
+`; // beating specificity. The file input needs to be hidden at all times
+
+export default function ImportFileButton({ onFileSelect, ...props }) {
+  const fileInputRef = useRef<HTMLInputElement>();
+
+  // This makes sure the onChange hook will fire for same file
+  const handleFileClear = () => {
+    if (fileInputRef && fileInputRef.current) {
+      fileInputRef.current.value = null;
+    }
+  };
+
+  const handleFile = (event) => {
+    if (!objectQuery(event, 'target', 'files', 0)) {
+      return;
+    }
+    const uploadedFile = event.target.files[0];
+
+    if (onFileSelect) {
+      onFileSelect(uploadedFile);
+    }
+  };
+
+  return (
+    <PrimaryTextButton component="label" {...props}>
+      Import Schema
+      <HiddenInput
+        type="file"
+        accept=".json"
+        onClick={handleFileClear}
+        onChange={handleFile}
+        ref={fileInputRef}
+      />
+    </PrimaryTextButton>
+  );
+}

--- a/app/cdap/components/shared/Buttons/PrimaryContainedButton/index.tsx
+++ b/app/cdap/components/shared/Buttons/PrimaryContainedButton/index.tsx
@@ -17,9 +17,9 @@
 import React from 'react';
 import Button from '@material-ui/core/Button';
 
-export default function PrimaryContainedButton({ children, onClick, disabled = false, ...props }) {
+export default function PrimaryContainedButton({ children, disabled = false, ...props }) {
   return (
-    <Button variant="contained" color="primary" disabled={disabled} onClick={onClick} {...props}>
+    <Button variant="contained" color="primary" disabled={disabled} {...props}>
       {children}
     </Button>
   );

--- a/app/cdap/components/shared/Buttons/PrimaryOutlinedButton/index.tsx
+++ b/app/cdap/components/shared/Buttons/PrimaryOutlinedButton/index.tsx
@@ -17,9 +17,9 @@
 import React from 'react';
 import Button from '@material-ui/core/Button';
 
-export default function PrimaryOutlinedButton({ children, onClick, disabled = false, ...props }) {
+export default function PrimaryOutlinedButton({ children, disabled = false, ...props }) {
   return (
-    <Button color="primary" variant="outlined" disabled={disabled} onClick={onClick} {...props}>
+    <Button color="primary" variant="outlined" disabled={disabled} {...props}>
       {children}
     </Button>
   );

--- a/app/cdap/components/shared/Buttons/PrimaryTextButton/index.tsx
+++ b/app/cdap/components/shared/Buttons/PrimaryTextButton/index.tsx
@@ -17,9 +17,9 @@
 import React from 'react';
 import Button from '@material-ui/core/Button';
 
-export default function PrimaryTextButton({ children, onClick, disabled = false, ...props }) {
+export default function PrimaryTextButton({ children, disabled = false, ...props }) {
   return (
-    <Button color="primary" disabled={disabled} onClick={onClick} {...props}>
+    <Button color="primary" disabled={disabled} {...props}>
       {children}
     </Button>
   );

--- a/app/cdap/components/shared/ConfigurationGroup/PropertyRow/DescriptionTooltip.tsx
+++ b/app/cdap/components/shared/ConfigurationGroup/PropertyRow/DescriptionTooltip.tsx
@@ -25,15 +25,31 @@ const StyledHelpIcon = styled(Help)`
 
 interface IDescriptionTooltipProps {
   description?: string;
+  placement?:
+    | 'bottom'
+    | 'left'
+    | 'right'
+    | 'top'
+    | 'bottom-end'
+    | 'bottom-start'
+    | 'left-end'
+    | 'left-start'
+    | 'right-end'
+    | 'right-start'
+    | 'top-end'
+    | 'top-start';
 }
 
-const DescriptionTooltip: React.FC<IDescriptionTooltipProps> = ({ description }) => {
+const DescriptionTooltip: React.FC<IDescriptionTooltipProps> = ({
+  description,
+  placement = 'left',
+}) => {
   if (!description) {
     return null;
   }
 
   return (
-    <PropertyRowTooltip title={description} placement="left">
+    <PropertyRowTooltip title={description} placement={placement}>
       <StyledHelpIcon />
     </PropertyRowTooltip>
   );

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -1521,6 +1521,9 @@ features:
       edit: Edit
       editConnection: 'Edit {connector} connection - "{connectionName}"'
       createConnection: "Create a {connector} connection"
+      SourceParsing:
+        ImportSchema:
+          description: In most cases, schema is inferred automatically. Use the Import Schema button to override the inferred schema. It is also useful for specifying schema manually, for formats such as JSON where schema inference is not possible.
     database: Database ({count})
     gcs: Google Cloud Storage ({count})
     hdfs: File System


### PR DESCRIPTION
# CDAP-19158 Upload schema when parsing from source

## Description
Adds the option to upload a schema when parsing at the source. This is necessary for some types (e.g. avro) and optional for others. Will be cherry-picked to 6.7.

## PR Type
- [ ] Bug Fix
- [X] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19158](https://cdap.atlassian.net/browse/CDAP-19158)

## Test Plan
Manually verify

## Screenshots
![image](https://user-images.githubusercontent.com/2728821/166344243-c9dfd465-f24e-49e2-ab41-18d781df9df7.png)

Information tooltip:
![image](https://user-images.githubusercontent.com/2728821/166344259-02ec0481-2946-4ee7-9de9-9d6f50691170.png)

After importing schema:
![image](https://user-images.githubusercontent.com/2728821/166344283-81c5048d-eda8-437a-bd68-35b2ee9e5be5.png)



