### PR TITLE
[CDAP-19175] replicator fix set initial transformation

### DIFF
--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/index.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/index.tsx
@@ -158,12 +158,14 @@ const SelectColumnsView = (props: ISelectColumnsProps) => {
   }, [state.columns]);
 
   useEffect(() => {
-    if (props.transformations[props.tableInfo.table]) {
-      dispatch({
-        type: 'setInitialTransformations',
-        payload: props.transformations[props.tableInfo.table].columnTransformations,
-      });
-    }
+    Object.values(props.transformations).forEach((tableTransformation) => {
+      if (tableTransformation.tableName === props.tableInfo.table) {
+        dispatch({
+          type: 'setInitialTransformations',
+          payload: tableTransformation.columnTransformations,
+        });
+      }
+    });
   }, []);
 
   const handleSearch = (search) => {

--- a/app/cdap/components/Replicator/utilities/index.ts
+++ b/app/cdap/components/Replicator/utilities/index.ts
@@ -244,7 +244,15 @@ export async function convertConfigToState(rawConfig, parentArtifact) {
     activeStep: 1,
     offsetBasePath: objectQuery(rawConfig, 'config', 'offsetBasePath') || '',
     numInstances: objectQuery(rawConfig, 'config', 'parallelism', 'numInstances') || 1,
+    transformations: objectQuery(rawConfig, 'config', 'tableTransformations') || {},
   };
+
+  // replace key in transformations with tableName
+  Object.keys(newState.transformations).forEach((key) => {
+    const newKey = newState.transformations[key].tableName;
+    newState.transformations[newKey] = newState.transformations[key];
+    delete newState.transformations[key];
+  });
 
   const stages = objectQuery(rawConfig, 'config', 'stages') || [];
 


### PR DESCRIPTION
# [CDAP-19175] replicator fix set initial transformation

## Description
Include transformation info on reading the draft or importing from json
previously the if condition that checks initial transformation returns undefined, so the set initial transformation never triggers.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19175](https://cdap.atlassian.net/browse/CDAP-19175)





[CDAP-19175]: https://cdap.atlassian.net/browse/CDAP-19175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ