### PR TITLE
[CDAP-19160] replicator using the new api to get assessTable response

### DIFF
--- a/app/cdap/api/replicator.js
+++ b/app/cdap/api/replicator.js
@@ -51,6 +51,7 @@ export const MyReplicatorApi = {
   assessPipeline: apiCreator(dataSrc, 'POST', 'REQUEST', `${draftPath}/assessPipeline`),
   validatePipeline: apiCreator(dataSrc, 'POST', 'REQUEST', validatePipelinePath),
   assessTable: apiCreator(dataSrc, 'POST', 'REQUEST', `${draftPath}/assessTable`),
+  getTargetTableInfo: apiCreator(dataSrc, 'POST', 'REQUEST', `${servicePath}/assessTable`),
   fetchArtifactProperties: apiCreator(dataSrc, 'GET', 'REQUEST', artifactBasePath),
 
   // Detail

--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/types.ts
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/types.ts
@@ -46,6 +46,7 @@ export interface ISelectColumnsProps {
   ) => void;
   assessmentLoading: boolean;
   tinkEnabled: boolean;
+  getReplicatorConfig: () => any;
 }
 
 interface IColumn {

--- a/app/cdap/components/Replicator/types.ts
+++ b/app/cdap/components/Replicator/types.ts
@@ -39,6 +39,11 @@ export interface ITableInfo {
   schema?: string;
 }
 
+export interface IDeltaConfig {
+  dBTable: ITableInfo;
+  deltaConfig?: any;
+}
+
 export interface ITable extends ITableInfo {
   numColumns?: number;
 }


### PR DESCRIPTION
# [CDAP-19160] replicator using the new api to get assessTable response

## Description
With a new endpoint on [Delta](https://github.com/data-integrations/delta/pull/179), I'm able to bypass `assessTable` checking table selected by manually adding unselected table into the payload. Still feels hacky
[API Doc](https://docs.google.com/document/d/1ABJVdya_-D4nytM4AIXvoKdtXhH7n7Ma1ymjFPqTOP8/edit?resourcekey=0-8rGhaxybWhjQ-5kg6K_3WQ#heading=h.69ygdocmqjea)

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19160](https://cdap.atlassian.net/browse/CDAP-19160)





[CDAP-19160]: https://cdap.atlassian.net/browse/CDAP-19160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ