### PR TITLE
CDAP-19186 Disable Metadata-in-React for 6.7

### DIFF
--- a/app/cdap/services/ThemeHelper.ts
+++ b/app/cdap/services/ThemeHelper.ts
@@ -436,7 +436,7 @@ function parse1Point0Spec(themeJSON: IOnePoint0SpecJSON): IThemeObj {
       showReloadSystemArtifacts: true,
       showSqlPipeline: true,
       showCDC: false,
-      isMetadataInReact: true,
+      isMetadataInReact: false,
     };
     if (isNilOrEmpty(featuresJson)) {
       return features;


### PR DESCRIPTION
# CDAP-19186 Disable Metadata-in-React for 6.7

## Description
A regression was found in how the lineage graph renders

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19186](https://cdap.atlassian.net/browse/CDAP-19186)

## Test Plan
Manually verify that the old Metadata UX is in use

## Screenshots
N/A


