### PR TITLE
CDAP-19217 Connection creation: Fetch plugin properties for non-system scope correctly

### DIFF
--- a/app/cdap/components/Connections/Create/reducer.ts
+++ b/app/cdap/components/Connections/Create/reducer.ts
@@ -238,9 +238,9 @@ export async function fetchConnectionDetails(connection) {
     namespace: getCurrentNamespace(),
     datapipelineArtifactVersion: cdapVersion,
     connectionTypeName: connection.name,
-    artifactname,
-    artifactversion,
-    artifactscope,
+    artifactName: artifactname,
+    artifactVersion: artifactversion,
+    artifactScope: artifactscope,
   });
 
   const pluginKey = `${connection.name}-connector`;


### PR DESCRIPTION
# CDAP-19217 Connection creation: Fetch plugin properties for non-system scope correctly

## Description
The `artifactScope` query parameter key is case-sensitive

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19217](https://cdap.atlassian.net/browse/CDAP-19217)

## Test Plan
Manually verify

## Screenshots
N/A


