### PR TITLE
add memory limit unit upon namespace creation

### DIFF
--- a/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/reducer.ts
+++ b/app/cdap/components/Administration/TetheringTabContent/NewTetheringRequest/reducer.ts
@@ -18,12 +18,7 @@ import { IAction } from 'services/redux-helpers';
 import { TetheringApi } from 'api/tethering';
 import { MyNamespaceApi } from 'api/namespace';
 import { IApiError, IValidationErrors, INamespace } from '../types';
-import {
-  K8S_NS_CPU_LIMITS,
-  K8S_NS_MEMORY_LIMITS,
-  DEFAULT_NS,
-  K8S_NS_MEMORY_LIMIT_UNIT,
-} from './constants';
+import { K8S_NS_CPU_LIMITS, K8S_NS_MEMORY_LIMITS, DEFAULT_NS } from './constants';
 
 export interface INewTetheringReqState {
   namespaces: INamespace[];
@@ -175,17 +170,13 @@ export const fetchNamespaceList = async (dispatch) => {
       namespaces.unshift({
         namespace: DEFAULT_NS,
         cpuLimit: ns.config[K8S_NS_CPU_LIMITS],
-        memoryLimit: ns.config[K8S_NS_MEMORY_LIMITS]
-          ? `${ns.config[K8S_NS_MEMORY_LIMITS]}${K8S_NS_MEMORY_LIMIT_UNIT}`
-          : undefined,
+        memoryLimit: ns.config[K8S_NS_MEMORY_LIMITS],
       });
     } else {
       namespaces.push({
         namespace: ns.name,
         cpuLimit: ns.config[K8S_NS_CPU_LIMITS],
-        memoryLimit: ns.config[K8S_NS_MEMORY_LIMITS]
-          ? `${ns.config[K8S_NS_MEMORY_LIMITS]}${K8S_NS_MEMORY_LIMIT_UNIT}`
-          : undefined,
+        memoryLimit: ns.config[K8S_NS_MEMORY_LIMITS],
       });
     }
   });

--- a/app/cdap/services/WizardStores/AddNamespace/ActionCreator.js
+++ b/app/cdap/services/WizardStores/AddNamespace/ActionCreator.js
@@ -16,6 +16,8 @@
 import AddNamespaceStore from 'services/WizardStores/AddNamespace/AddNamespaceStore';
 import { MyNamespaceApi } from 'api/namespace';
 
+const K8S_NS_MEMORY_LIMIT_UNIT = 'Gi';
+
 const createNamespace = () => {
   return createOrEditNamespace(MyNamespaceApi.create);
 };
@@ -71,7 +73,7 @@ const createOrEditNamespace = (api) => {
   }
 
   if (state.resources.k8sNamespaceMemoryLimit) {
-    putParams['config']['k8s.namespace.memory.limits'] = state.resources.k8sNamespaceMemoryLimit;
+    putParams['config']['k8s.namespace.memory.limits'] = `${state.resources.k8sNamespaceMemoryLimit}${K8S_NS_MEMORY_LIMIT_UNIT}`;
   }
 
   if (state.resources.serviceAccountEmail) {


### PR DESCRIPTION
# Add memory limit unit upon namespace creation

## Description
This PR adds namespace memory limit unit "Gi" upon its creation (this will prevent a problem on the backend)

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19131](https://cdap.atlassian.net/browse/CDAP-19131)

## Test Plan
Manual

## Screenshots
N/A

