### PR TITLE
CDAP-19198 CDAP-19200 Make pre-configured connections view-only

### DIFF
--- a/app/cdap/components/Connections/Browser/SidePanel/index.tsx
+++ b/app/cdap/components/Connections/Browser/SidePanel/index.tsx
@@ -162,7 +162,6 @@ export function ConnectionsBrowserSidePanel({
         onToggle={() => setCreateConnOpen(!createConnOpen)}
         initialConfig={null}
         onCreate={initState}
-        isEdit={false}
       />
 
       <If condition={!hideAddConnection}>

--- a/app/cdap/components/Connections/Create/ConnectionConfiguration/ConnectionConfigForm.tsx
+++ b/app/cdap/components/Connections/Create/ConnectionConfiguration/ConnectionConfigForm.tsx
@@ -23,6 +23,7 @@ import Alert from '@material-ui/lab/Alert';
 import PrimaryContainedButton from 'components/shared/Buttons/PrimaryContainedButton';
 import PrimaryOutlinedButton from 'components/shared/Buttons/PrimaryOutlinedButton';
 import ButtonLoadingHoc from 'components/shared/Buttons/ButtonLoadingHoc';
+import { ConnectionConfigurationMode } from 'components/Connections/types';
 
 const I18NPREFIX = 'features.Administration.Tethering.CreateRequest';
 const PrimaryOutlinedLoadingButton = ButtonLoadingHoc(PrimaryOutlinedButton);
@@ -57,7 +58,7 @@ export function ConnectionConfigForm({
   initProperties = {},
   initName = '',
   initDescription = '',
-  isEdit,
+  mode,
   testResults,
 }) {
   const [values, setValues] = React.useState<Record<string, string>>(initProperties);
@@ -95,7 +96,7 @@ export function ConnectionConfigForm({
   return (
     <div>
       <div>
-        {!isEdit && (
+        {mode === ConnectionConfigurationMode.CREATE && (
           <PropertyRow
             widgetProperty={{
               'widget-type': 'textbox',
@@ -121,7 +122,10 @@ export function ConnectionConfigForm({
           widgetProperty={{
             'widget-type': 'textbox',
             'widget-attributes': {
-              placeholder: 'Specify a description to identify the connection',
+              placeholder:
+                mode !== ConnectionConfigurationMode.VIEW
+                  ? 'Specify a description to identify the connection'
+                  : '',
             },
             label: 'Description',
             name: 'description',
@@ -133,7 +137,7 @@ export function ConnectionConfigForm({
           }}
           value={description}
           onChange={(v) => setDescription(v.description)}
-          disabled={false}
+          disabled={mode === ConnectionConfigurationMode.VIEW}
           extraConfig={{ properties: {} }}
         />
       </div>
@@ -142,6 +146,7 @@ export function ConnectionConfigForm({
         pluginProperties={connectorProperties}
         values={values}
         onChange={setValues}
+        disabled={mode === ConnectionConfigurationMode.VIEW}
         errors={configurationErrors}
       />
       <div className={classes.connectionTestMessage}>
@@ -163,24 +168,26 @@ export function ConnectionConfigForm({
             </Alert>
           ))}
       </div>
-      <div className={classes.formStyles}>
-        <PrimaryOutlinedLoadingButton
-          loading={testResults.inProgress}
-          onClick={() => onConnectionTest({ properties: values })}
-          disabled={testResults.inProgress}
-          data-cy="connection-test-button"
-        >
-          Test Connection
-        </PrimaryOutlinedLoadingButton>
-        <PrimaryContainedButton
-          variant="contained"
-          color="primary"
-          onClick={onCreate}
-          data-cy="connection-submit-button"
-        >
-          {isEdit ? 'Save' : 'Create'}
-        </PrimaryContainedButton>
-      </div>
+      {mode !== ConnectionConfigurationMode.VIEW && (
+        <div className={classes.formStyles}>
+          <PrimaryOutlinedLoadingButton
+            loading={testResults.inProgress}
+            onClick={() => onConnectionTest({ properties: values })}
+            disabled={testResults.inProgress}
+            data-cy="connection-test-button"
+          >
+            Test Connection
+          </PrimaryOutlinedLoadingButton>
+          <PrimaryContainedButton
+            variant="contained"
+            color="primary"
+            onClick={onCreate}
+            data-cy="connection-submit-button"
+          >
+            {mode === ConnectionConfigurationMode.EDIT ? 'Save' : 'Create'}
+          </PrimaryContainedButton>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/cdap/components/Connections/Create/ConnectionConfiguration/index.tsx
+++ b/app/cdap/components/Connections/Create/ConnectionConfiguration/index.tsx
@@ -21,6 +21,7 @@ import ConfigurableTab, { ITabConfigObj, TabLayoutEnum } from 'components/shared
 import makeStyle from '@material-ui/core/styles/makeStyles';
 import Markdown from 'components/shared/Markdown';
 import { ConnectionConfigForm } from 'components/Connections/Create/ConnectionConfiguration/ConnectionConfigForm';
+import { ConnectionConfigurationMode } from 'components/Connections/types';
 
 const useStyle = makeStyle(() => {
   return {
@@ -49,7 +50,7 @@ interface IConnectionConfigurationProps extends IConnectorDetails {
     messages?: any;
     configurationErrors?: any;
   };
-  isEdit: boolean;
+  mode: ConnectionConfigurationMode;
 }
 
 export function ConnectionConfiguration({
@@ -59,7 +60,7 @@ export function ConnectionConfiguration({
   onConnectionCreate,
   onConnectionTest,
   initValues = {},
-  isEdit,
+  mode,
   testResults,
 }: IConnectionConfigurationProps) {
   if (!connectorProperties) {
@@ -83,7 +84,7 @@ export function ConnectionConfiguration({
             initName={initValues.initName}
             initDescription={initValues.initDescription}
             initProperties={initValues.initProperties}
-            isEdit={isEdit}
+            mode={mode}
             testResults={testResults}
           />
         ),

--- a/app/cdap/components/Connections/CreateConnectionModal/index.tsx
+++ b/app/cdap/components/Connections/CreateConnectionModal/index.tsx
@@ -18,6 +18,7 @@ import React from 'react';
 import { useState, useEffect } from 'react';
 import makeStyles from '@material-ui/core/styles/makeStyles';
 import { CreateConnection } from 'components/Connections/Create';
+import { ConnectionConfigurationMode } from 'components/Connections/types';
 import { createPortal } from 'react-dom';
 
 const useStyle = makeStyles((theme) => {
@@ -40,7 +41,7 @@ export default function CreateConnectionModal({
   onToggle,
   initialConfig = null,
   onCreate,
-  isEdit = false,
+  mode = ConnectionConfigurationMode.CREATE,
 }) {
   const classes = useStyle();
 
@@ -67,7 +68,7 @@ export default function CreateConnectionModal({
           onToggle={onToggle}
           initialConfig={initialConfig}
           onCreate={onCreate}
-          isEdit={isEdit}
+          mode={mode}
           enableRouting={false}
         />
       )}

--- a/app/cdap/components/Connections/types.ts
+++ b/app/cdap/components/Connections/types.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+export enum ConnectionConfigurationMode {
+  CREATE = 'CREATE',
+  EDIT = 'EDIT',
+  VIEW = 'VIEW',
+}

--- a/app/cdap/components/NamespaceAdmin/store/index.ts
+++ b/app/cdap/components/NamespaceAdmin/store/index.ts
@@ -64,6 +64,7 @@ export interface IConnection {
   connectionType: string;
   createdTimeMillis: number;
   description: string;
+  isDefault: boolean;
   name: string;
   preConfigured: boolean;
   updatedTimeMillis: number;

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -1521,6 +1521,7 @@ features:
       edit: Edit
       editConnection: 'Edit {connector} connection - "{connectionName}"'
       createConnection: "Create a {connector} connection"
+      viewConnection: 'View {connector} connection - "{connectionName}"'
       SourceParsing:
         ImportSchema:
           description: In most cases, schema is inferred automatically. Use the Import Schema button to override the inferred schema. It is also useful for specifying schema manually, for formats such as JSON where schema inference is not possible.


### PR DESCRIPTION
# CDAP-19198 CDAP-19200 Make pre-configured connections view-only

## Description
This removes all the current options for pre-configured connections, and replaces them with a View option. All the existing options are available for user-created connections (no View since that is possible by using Edit and not saving).

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: 
[CDAP-19198](https://cdap.atlassian.net/browse/CDAP-19198) Don't allow edit, etc. of pre-configured connections
[CDAP-19200](https://cdap.atlassian.net/browse/CDAP-19200) Make it possible to view or edit connections without an artifact version - necessary to view pre-configured connections

## Test Plan
Manually verify

## Screenshots
![image](https://user-images.githubusercontent.com/2728821/167959317-71bfb7e6-5dc2-4327-abcf-417c63287410.png)

![image](https://user-images.githubusercontent.com/2728821/167959371-b004b42e-cb15-4be8-8acd-01f65c9f5e4a.png)



