### PR TITLE
fix issue with collapsible config groups

### DIFF
--- a/app/cdap/components/shared/ConfigurationGroup/utilities/index.ts
+++ b/app/cdap/components/shared/ConfigurationGroup/utilities/index.ts
@@ -144,9 +144,11 @@ function addPluginFunctions(configurationGroups) {
   const updatedConfigurationGroups = [];
 
   configurationGroups.forEach((group) => {
+    const { label, description, hideByDefault } = group;
     const newGroup = {
-      label: group.label,
-      description: group.description,
+      label,
+      description,
+      hideByDefault,
       properties: [],
     };
 


### PR DESCRIPTION
# Fix issue with collapsible config groups

## Description
Cherry-pick for ensuring `hideByDefault` prop is added to filtered config groups

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [X] Cherry Pick

## Links
Jira: [CDAP-18541](https://cdap.atlassian.net/browse/CDAP-18541)

## Test Plan
Manually tested with a customized plugin to have the `hideByDefault` in its json

## Screenshots


