### PR TITLE
Avoid manual navigation to tethering page

### DIFF
--- a/app/cdap/components/Administration/TetheringTabContent/index.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/index.tsx
@@ -80,39 +80,41 @@ const AdminTetheringTabContent = () => {
   }, []);
 
   return (
-    <>
-      <Helmet
-        title={T.translate(`${I18NPREFIX}.pageTitle`, {
-          productName: Theme.productName,
-        })}
-      />
-      <AdminTetheringTabContainer>
-        {Theme.onPremTetheredInstance ? (
-          <OnpremTetheringConnections
-            establishedConnections={establishedConnections}
-            pendingRequests={pendingRequests}
-            handleEdit={handleEdit}
-            handleDelete={handleDelete}
-          />
-        ) : (
-          <CdfTetheringConnections
-            establishedConnections={establishedConnections}
-            newRequests={pendingRequests}
-            handleEdit={handleEdit}
-            handleDelete={handleDelete}
-            handleAcceptOrReject={handleAcceptOrReject}
-          />
-        )}
-        {error && (
-          <Alert
-            message={error}
-            type={'error'}
-            showAlert={Boolean(error)}
-            onClose={() => setError(null)}
-          />
-        )}
-      </AdminTetheringTabContainer>
-    </>
+    Theme.tethering && (
+      <>
+        <Helmet
+          title={T.translate(`${I18NPREFIX}.pageTitle`, {
+            productName: Theme.productName,
+          })}
+        />
+        <AdminTetheringTabContainer>
+          {Theme.onPremTetheredInstance ? (
+            <OnpremTetheringConnections
+              establishedConnections={establishedConnections}
+              pendingRequests={pendingRequests}
+              handleEdit={handleEdit}
+              handleDelete={handleDelete}
+            />
+          ) : (
+            <CdfTetheringConnections
+              establishedConnections={establishedConnections}
+              newRequests={pendingRequests}
+              handleEdit={handleEdit}
+              handleDelete={handleDelete}
+              handleAcceptOrReject={handleAcceptOrReject}
+            />
+          )}
+          {error && (
+            <Alert
+              message={error}
+              type={'error'}
+              showAlert={Boolean(error)}
+              onClose={() => setError(null)}
+            />
+          )}
+        </AdminTetheringTabContainer>
+      </>
+    )
   );
 };
 


### PR DESCRIPTION
# Avoid manual navigation to tethering page

## Description
This PR prevents user from manually entering the tethering url and accessing the page when tethering is disabled.

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [Jira issue #](fill-in.org)

## Test Plan

## Screenshots


