### PR TITLE
CDAP-19008 Enable HTTP requests for Redux code by default

### DIFF
--- a/app/cdap/services/datasource/DataSourceConfigurer.js
+++ b/app/cdap/services/datasource/DataSourceConfigurer.js
@@ -20,7 +20,10 @@ import { objectQuery } from 'services/helpers';
 
 export function isHttpEnabled() {
   const featureFlags = objectQuery(window, 'CDAP_CONFIG', 'featureFlags');
-  return featureFlags && featureFlags['network.client.useHttp'] === 'true';
+  if (featureFlags && featureFlags['network.client.useHttp'] === 'false') {
+    return false;
+  }
+  return true;
 }
 
 const DatasourceConfigurer = {

--- a/app/cdap/services/datasource/DataSourceHttp.ts
+++ b/app/cdap/services/datasource/DataSourceHttp.ts
@@ -232,7 +232,7 @@ export default class Datasource implements IDataSource {
       generatedResource.requestOrigin = REQUEST_ORIGIN_ROUTER;
     }
 
-    if (window.CDAP_CONFIG.securityEnabled) {
+    if (objectQuery(window, 'CDAP_CONFIG', 'securityEnabled')) {
       const token = cookie.get('CDAP_Auth_Token');
       if (!isNil(token)) {
         generatedResource.headers.Authorization = `Bearer ${token}`;


### PR DESCRIPTION
# CDAP-19008 Enable HTTP requests for Redux code by default

## Description
This makes HTTP requests enabled by default - can be disabled by feature flag

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [X] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19008](https://cdap.atlassian.net/browse/CDAP-19008)

## Test Plan
Covered by automated tests (sandbox). Manually verify for other authentication modes

## Screenshots
N/A


