### PR TITLE
CDAP-19285 Fix compute profile customizations

### DIFF
--- a/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ConfigModelessActionButtons/index.js
+++ b/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ConfigModelessActionButtons/index.js
@@ -20,9 +20,11 @@ import {
   updatePipeline,
   runPipeline,
   schedulePipeline,
+  updatePreferences,
 } from 'components/PipelineConfigurations/Store/ActionCreator';
 import { setRunError } from 'components/PipelineDetails/store/ActionCreator';
 import ConfigModelessSaveBtn from 'components/PipelineConfigurations/ConfigurationsContent/ConfigModelessActionButtons/ConfigModelessSaveBtn';
+import { Observable } from 'rxjs/Observable';
 
 require('./ConfigModelessActionButtons.scss');
 
@@ -63,7 +65,7 @@ export default class ConfigModelessActionButtons extends Component {
     this.setState({
       [loadingState]: true,
     });
-    updatePipeline().subscribe(
+    Observable.forkJoin(updatePipeline(), updatePreferences()).subscribe(
       () => {
         actionFn();
         this.setState({


### PR DESCRIPTION
# CDAP-19285 Fix compute profile customizations

## Description
The change in #468 broke customizations for the compute profile. We'll need to find another way to fix that bug.

Revert "CDAP-18912 Don't save preferences when pipeline configuration is updated"

This reverts commit 2df14def87fe836e373a0019d5b4283c35db0439.

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19285](https://cdap.atlassian.net/browse/CDAP-19285)

## Test Plan
Manually verify

## Screenshots
N/A


