### PR TITLE
CDAP-19313 Disable HTTP-to-Websocket migration while troubleshooting error handling

### DIFF
--- a/app/cdap/services/datasource/DataSourceConfigurer.js
+++ b/app/cdap/services/datasource/DataSourceConfigurer.js
@@ -20,7 +20,7 @@ import { objectQuery } from 'services/helpers';
 
 export function isHttpEnabled() {
   const featureFlags = objectQuery(window, 'CDAP_CONFIG', 'featureFlags');
-  if (featureFlags && featureFlags['network.client.useHttp'] === 'false') {
+  if (featureFlags && featureFlags['network.client.useHttp'] !== 'true') {
     return false;
   }
   return true;


### PR DESCRIPTION
# CDAP-19313 Disable HTTP-to-Websocket migration while troubleshooting error handling

## Description
There are some issues with handling error responses with the HTTP code. Since they may take some time to fix, I'm disabling the migration for now.

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19313](https://cdap.atlassian.net/browse/CDAP-19313)

## Test Plan
Covered by E2E tests

## Screenshots
N/A


