### PR TITLE
CDAP-19313 Fix HTTP migration E2E test failures

### DIFF
--- a/app/cdap/api/market.js
+++ b/app/cdap/api/market.js
@@ -16,13 +16,13 @@
 
 import DataSourceConfigurer from 'services/datasource/DataSourceConfigurer';
 import { apiCreatorAbsPath } from 'services/resource-helper';
+import { REQUEST_ORIGIN_MARKET } from 'services/datasource/requestTypes';
 
 let dataSrc = DataSourceConfigurer.getInstance();
 const basepaths = window.CDAP_CONFIG.marketUrls;
 // FIXME (CDAP-14836): Right now this is scattered across node and client. Need to consolidate this.
-const REQUEST_TYPE_MARKET = 'MARKET';
 const requestOptions = {
-  requestOrigin: REQUEST_TYPE_MARKET,
+  requestOrigin: REQUEST_ORIGIN_MARKET,
 };
 
 function getVerifiedMarketHost(host) {

--- a/app/cdap/services/datasource/DataSourceConfigurer.js
+++ b/app/cdap/services/datasource/DataSourceConfigurer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -20,7 +20,7 @@ import { objectQuery } from 'services/helpers';
 
 export function isHttpEnabled() {
   const featureFlags = objectQuery(window, 'CDAP_CONFIG', 'featureFlags');
-  if (featureFlags && featureFlags['network.client.useHttp'] !== 'true') {
+  if (featureFlags && featureFlags['network.client.useHttp'] === 'false') {
     return false;
   }
   return true;

--- a/app/cdap/services/datasource/requestTypes.ts
+++ b/app/cdap/services/datasource/requestTypes.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+export const REQUEST_ORIGIN_ROUTER = 'ROUTER';
+export const REQUEST_ORIGIN_MARKET = 'MARKET';


### PR DESCRIPTION
# CDAP-19313 Fix HTTP migration E2E test failures

## Description
Running the E2E (Cypress, for now) tests on the HTTP migration reviewed 2 significant issues:
* The error handling was not fully baked
* The Hub requires special handling

I've addressed those issues and successfully run most of the E2E tests locally.

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19313](https://cdap.atlassian.net/browse/CDAP-19313)

## Test Plan
Run E2E tests

## Screenshots
N/A


