### PR TITLE
remove matrix from the workflow file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: build
+name: Build with Unit and Integration Tests
 
 on:
   workflow_run:
@@ -27,11 +27,6 @@ jobs:
     runs-on: ubuntu-latest
 
     if: ${{ github.event.workflow_run.conclusion != 'skipped' }}
-    
-    strategy:
-      matrix:
-        node-version: [10.16]
-        java-version: [8]
 
     # Cancel ongoing runs
     concurrency: 
@@ -50,10 +45,10 @@ jobs:
     - name: Install Ubuntu debendency
       run: sudo apt-get install -y libgif-dev
 
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 10.16
       uses: actions/setup-node@v1
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 10.16
 
     - uses: actions/cache@v2
       with:
@@ -61,11 +56,11 @@ jobs:
         key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
     # installing Java 8 to run the sandbox
-    - name: Setup Java ${{ matrix.java-version }}
+    - name: Setup Java 8
       uses: actions/setup-java@v2
       with:
         distribution: 'temurin'
-        java-version: ${{ matrix.java-version }}
+        java-version: 8
 
     - name: Download CDAP Sandbox and Start it
       env:


### PR DESCRIPTION
# Remove version matrix from the workflow

## Description
Looks like having the version matrix in our workflow file conflicts with `haya14busa/action-workflow_run-status` action that we need to keep our PRs in sync with the status of the github action.

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [X] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
N/A

## Test Plan

## Screenshots


