### PR TITLE
CDAP-19357: Display instance url in the tethering tables

### DIFF
--- a/app/cdap/components/Administration/TetheringTabContent/TetheringTable/constants.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/TetheringTable/constants.tsx
@@ -19,7 +19,7 @@ import T from 'i18n-react';
 import { StyledIcon } from '../shared.styles';
 
 export const PREFIX = 'features.Administration.Tethering';
-export const DESC_COLUMN_TEMPLATE = '50px 200px 5fr 200px 1.5fr 280px 225px';
+export const DESC_COLUMN_TEMPLATE = '50px 200px 8fr 170px 2fr 280px 20px';
 
 export const ICONS = {
   active: {
@@ -62,6 +62,10 @@ export const CONNECTIONS_TABLE_HEADERS = [
   {
     property: 'instanceName',
     label: T.translate(`${PREFIX}.ColumnHeaders.instanceName`),
+  },
+  {
+    property: 'instanceUrl',
+    label: T.translate(`${PREFIX}.ColumnHeaders.instanceUrl`),
   },
   {
     property: 'region',

--- a/app/cdap/components/Administration/TetheringTabContent/TetheringTable/index.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/TetheringTable/index.tsx
@@ -21,7 +21,7 @@ import { IConnection, ITableData } from '../types';
 import { trimMemoryLimit } from '../utils';
 import { getIconForStatus, renderAllocationsHeader, getTransformedTableData } from './utils';
 
-const COLUMN_TEMPLATE = '50px 200px 2fr 1.5fr 1.5fr 200px 1.5fr 140px 140px 225px';
+const COLUMN_TEMPLATE = '50px 200px 2fr 2fr 2fr 2fr 170px 2fr 140px 140px 20px';
 
 interface ITetheringTableProps {
   tableData: IConnection[];
@@ -36,7 +36,11 @@ const renderTableHeader = (showAllocationHeader: boolean) => (
     <GridHeader>
       <GridRow columnTemplate={COLUMN_TEMPLATE}>
         {CONNECTIONS_TABLE_HEADERS.map((header, i) => {
-          return <GridCell key={i}>{header.label}</GridCell>;
+          return (
+            <GridCell key={i} title={header.label}>
+              {header.label}
+            </GridCell>
+          );
         })}
       </GridRow>
     </GridHeader>
@@ -100,6 +104,7 @@ const TetheringTable = ({
       gcloudProject,
       description,
       instanceName,
+      instanceUrl,
       region,
       highlighted,
     } = conn;
@@ -123,6 +128,7 @@ const TetheringTable = ({
           <GridCell title={description}>{isFirst ? description : ''}</GridCell>
           <GridCell title={gcloudProject}>{isFirst ? gcloudProject : ''}</GridCell>
           <GridCell title={instanceName}>{isFirst ? instanceName : ''}</GridCell>
+          <GridCell title={instanceUrl}>{isFirst ? instanceUrl : ''}</GridCell>
           <GridCell>{isFirst ? region : ''}</GridCell>
           <GridCell title={namespace} border={!isLast}>
             {namespace}

--- a/app/cdap/components/Administration/TetheringTabContent/TetheringTable/utils.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/TetheringTable/utils.tsx
@@ -76,6 +76,7 @@ export const getTransformedTableData = (tableData: IConnection[]) => {
         minute: 'numeric',
       }),
       instanceName: conn.name,
+      instanceUrl: conn.endpoint,
       status: conn.connectionStatus,
       description,
       gcloudProject,

--- a/app/cdap/components/Administration/TetheringTabContent/types.ts
+++ b/app/cdap/components/Administration/TetheringTabContent/types.ts
@@ -42,6 +42,7 @@ export interface ITableData {
   description: string;
   gcloudProject: string;
   instanceName: string;
+  instanceUrl: string;
   region: string;
   status: string;
   allocationData: INamespaceAllocations[];

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -245,6 +245,7 @@ features:
          description: Description
          gcp: Google cloud project
          instanceName: Instance name
+         instanceUrl: Instance URL
          region: Region
          tetheredNamespace: Tethered namespace
          cpu: CPU (# of cores)


### PR DESCRIPTION
# Display instance url in the tethering tables

## Description
This PR adds the instance url as a new column in the tables displayed on the tethering page. 

## PR Type
- [ ] Bug Fix
- [X] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19357](https://cdap.atlassian.net/browse/CDAP-19357)

## Test Plan
N/A

## Screenshots
<img width="1769" alt="Screen Shot 2022-06-16 at 3 20 11 PM" src="https://user-images.githubusercontent.com/94018249/174189474-5397900c-b067-4b95-9bbe-63bdf151bd85.png">



