### PR TITLE
[CDAP-19216] fix stop button not referring to the correct runid

### DIFF
--- a/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsButtons/PipelineStopButton/index.js
+++ b/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsButtons/PipelineStopButton/index.js
@@ -72,7 +72,7 @@ export default class PipelineStopButton extends Component {
     );
   };
 
-  stopRun = (runId = this.props.runs[0].runid) => {
+  stopRun = (runId = this.state.activeRuns[0].runid) => {
     let params = {
       graceful: 6 * 60 * 60,
       namespace: getCurrentNamespace(),


### PR DESCRIPTION
# [CDAP-19216] fix stop button not referring to the correct runid

## Description
~~Previously the stop button stops the run at index 0 by default, which is a weird implementation. Now it will corresponding to the current run. Also disable the stop button if the current run is not running~~

EDIT: Previous fix will change user behavior. Now it's a more suitable change

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19216](https://cdap.atlassian.net/browse/CDAP-19216)

## Test Plan
The issue mentioned in the ticket is addressed. But maybe require some more testing.



[CDAP-19216]: https://cdap.atlassian.net/browse/CDAP-19216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ