### PR TITLE
[CDAP-19299] fix modifying transformations not disable save button

### DIFF
--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/index.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/index.tsx
@@ -300,6 +300,13 @@ const SelectColumnsView = (props: ISelectColumnsProps) => {
     props.onSave(props.tableInfo, returnSelectedList());
   }, [state.selectedColumns, state.selectedReplication]);
 
+  useEffect(() => {
+    dispatch({
+      type: 'setSaveButtonDisabled',
+      payload: true,
+    });
+  }, [state.transformations]);
+
   const isSaveDisabled = () => {
     if (
       state.selectedReplication === ReplicateSelect.individual &&
@@ -314,7 +321,7 @@ const SelectColumnsView = (props: ISelectColumnsProps) => {
       return true;
     }
 
-    return state.loading;
+    return state.loading || state.saveButtonDisabled || props.assessmentLoading;
   };
 
   const renderLoading = () => {
@@ -368,13 +375,17 @@ const SelectColumnsView = (props: ISelectColumnsProps) => {
                 loading={props.assessmentLoading}
                 variant="outlined"
                 color="primary"
-                onClick={() =>
+                onClick={() => {
                   props.handleAssessTable(
                     props.tableInfo,
                     state.transformations,
                     returnSelectedList()
-                  )
-                }
+                  );
+                  dispatch({
+                    type: 'setSaveButtonDisabled',
+                    payload: false,
+                  });
+                }}
               >
                 <CachedIcon /> REFRESH
               </LoadingButton>

--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/reducer.ts
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/reducer.ts
@@ -83,6 +83,11 @@ export const reducer = (state: ISelectColumnsState, action) => {
         ...state,
         transformations: action.payload,
       };
+    case 'setSaveButtonDisabled':
+      return {
+        ...state,
+        saveButtonDisabled: action.payload,
+      };
     default:
       return state;
   }
@@ -100,4 +105,5 @@ export const initialState = {
   search: '',
   columnsWithErrors: '',
   transformations: [],
+  saveButtonDisabled: true,
 };

--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/types.ts
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/types.ts
@@ -75,6 +75,7 @@ export interface ISelectColumnsState {
   filterErrs: string[];
   search: string;
   transformations: IColumnTransformation[];
+  saveButtonDisabled: boolean;
 }
 
 export interface ITransformAddProps {


### PR DESCRIPTION
# [CDAP-19299] fix modifying transformations not disable save button

## Description
Added additional state to keep track if transformations have been modified, disable the save button accordingly

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19299](https://cdap.atlassian.net/browse/CDAP-19299)

## Screenshots
<img width="462" alt="image" src="https://user-images.githubusercontent.com/98125204/178658917-7e3c7ad5-b585-4e83-98b9-6885110a8816.png">
<img width="462" alt="image" src="https://user-images.githubusercontent.com/98125204/178658967-5f350cea-d0ac-4ed9-a1fe-03d237d73910.png">




[CDAP-19299]: https://cdap.atlassian.net/browse/CDAP-19299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ