### PR TITLE
[CDAP-17619]Fix for REST imported pipelines are not exported

### DIFF
--- a/app/cdap/components/PipelineList/EmptyList/index.tsx
+++ b/app/cdap/components/PipelineList/EmptyList/index.tsx
@@ -17,7 +17,7 @@
 import * as React from 'react';
 import { getCurrentNamespace } from 'services/NamespaceStore';
 import { GLOBALS } from 'services/global-constants';
-import { validateImportJSON } from 'services/PipelineErrorFactory';
+import { validateImportJSON, adjustConfigNode } from 'services/PipelineErrorFactory';
 import { Input, Label } from 'reactstrap';
 import uuidV4 from 'uuid/v4';
 import { objectQuery } from 'services/helpers';
@@ -89,13 +89,13 @@ class EmptyList extends React.PureComponent<IProps, IState> {
         return;
       }
 
-      const fileDataString: string = evt.target.result;
+      let fileDataString: string = evt.target.result;
       const error = validateImportJSON(fileDataString);
       if (error) {
         this.onError(error);
         return;
       }
-
+      fileDataString = adjustConfigNode(fileDataString);
       this.onError(null);
       window.localStorage.setItem(resourceCenterId, fileDataString);
       window.location.href = pipelineImportLink;

--- a/app/cdap/components/ResourceCenterEntity/ResourceCenterPipelineEntity.js
+++ b/app/cdap/components/ResourceCenterEntity/ResourceCenterPipelineEntity.js
@@ -18,7 +18,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import PlusButtonStore from 'services/PlusButtonStore';
 import NamespaceStore from 'services/NamespaceStore';
-import { validateImportJSON } from 'services/PipelineErrorFactory';
+import { validateImportJSON, adjustConfigNode } from 'services/PipelineErrorFactory';
 import { objectQuery } from 'services/helpers';
 import IconSVG from 'components/shared/IconSVG';
 import { Input, Label } from 'reactstrap';
@@ -86,6 +86,7 @@ export default function ResourceCenterPipelineEntity({ onError }) {
         onError(T.translate(`${PREFIX}.errorLabel`), error);
         return;
       }
+      fileDataString = adjustConfigNode(fileDataString);
 
       onError(null, null);
       window.localStorage.setItem(resourceCenterId, fileDataString);

--- a/app/cdap/services/PipelineErrorFactory.js
+++ b/app/cdap/services/PipelineErrorFactory.js
@@ -337,6 +337,9 @@ let validateImportJSON = (configString) => {
 
   try {
     config = JSON.parse(configString);
+    if (!config.config && config.configuration) {
+      config.config = JSON.parse(config.configuration);
+    }
   } catch (e) {
     let messagePath = errorPath.concat(['INVALID-SYNTAX']);
     return objectQuery.apply(null, [GLOBALS].concat(messagePath));
@@ -361,6 +364,15 @@ let validateImportJSON = (configString) => {
   return false;
 };
 
+let adjustConfigNode = (configString) => { 
+  const configJSON = JSON.parse(configString);    
+  if (!configJSON.config && configJSON.configuration) {
+    configJSON.config = JSON.parse(configJSON.configuration);
+    return JSON.stringify(configJSON); 
+  }
+  return configString; 
+}
+
 export {
   isUniqueNodeNames,
   isRequiredFieldsFilled,
@@ -377,4 +389,5 @@ export {
   allConnectionsValid,
   connectionIsValid,
   validateImportJSON,
+  adjustConfigNode
 };

--- a/app/hydrator/services/hydrator-upgrade-service.js
+++ b/app/hydrator/services/hydrator-upgrade-service.js
@@ -270,6 +270,7 @@ class HydratorUpgradeService {
         return;
       }
 
+      fileDataString = this.NonStorePipelineErrorFactory.adjustConfigNode(fileDataString);
       this.openUpgradeModal(fileDataString);
     };
   }


### PR DESCRIPTION
# [CDAP-17619](https://cdap.atlassian.net/browse/CDAP-17619)Allow pipelines exported from REST api to be imported to UI.

## Description
Pipelines which are exported through REST api comes with 'configuration' to hold  pipeline's payload. 
So, parsing the 'configuration' node while importing  the pipelines which are exported through REST api.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
 [CDAP-17619](https://cdap.atlassian.net/browse/CDAP-17619)

## Test Plan
Tested all the scenarios manually.

## Screenshots


