### PR TITLE
Expand Calculate Options

### DIFF
--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -723,6 +723,11 @@ features:
           CROSSMAX: Max
           CROSSMIN: Min
           CROSSAVG: Average
+          MULTIADD: Add
+          MULTIMULTIPLY: Multiply
+          MULTIEQUAL: Equal
+          MULTIMAX: Max
+          MULTIMIN: Min
           MULTIAVG: Average
         title: Calculate
       ChangeDataType:


### PR DESCRIPTION
# Expand Calculate Options

## Description
Adjusted some cross-column arithmetic operations (`add`, `multiply`, `equal`, `max`, `min`) to take in >2 columns and added support for all cross-column arithmetic operations except `equal` to take in multiple types. This PR depends on PR [#569](https://github.com/data-integrations/wrangler/pull/569) in [wrangler](https://github.com/data-integrations/wrangler).

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: none

## Screenshots
![image](https://user-images.githubusercontent.com/67025898/179578413-32f1676a-31a4-47be-b827-dc6057f5a561.png)
![image](https://user-images.githubusercontent.com/67025898/179578606-43d088bb-684b-47ad-bb63-e4b6d2805bca.png)