### PR TITLE
fix the top panel name and description border issue

### DIFF
--- a/app/cdap/components/hydrator/components/TopPanel/NameAndDescription/styles.ts
+++ b/app/cdap/components/hydrator/components/TopPanel/NameAndDescription/styles.ts
@@ -86,7 +86,7 @@ export const PipelineType = styled.div`
 
 export const MetadataLeft = styled.div`
   margin-left: 10px;
-  width: calc(100% - 50px);
+  width: calc(100% - 310px);
   text-align: left !important;
 `;
 


### PR DESCRIPTION
# TITLE

## Description
The right border is extending out of window, need to adjust the width

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19414](https://cdap.atlassian.net/browse/CDAP-19414)

## Test Plan

## Screenshots

Before:
<img width="1724" alt="image" src="https://user-images.githubusercontent.com/20428112/179635641-44528113-0afa-420f-9147-c9fb74d0bea5.png">



After:
![image](https://user-images.githubusercontent.com/20428112/179635573-99ea4461-cfc6-4da9-bf07-ea209c205c8c.png)


