### PR TITLE
CDAP-19297: Automatically delete rejected request after rejection in cdf

### DIFF
--- a/app/cdap/components/Administration/TetheringTabContent/CdfTetheringConnections/NewReqLastColumn.tsx
+++ b/app/cdap/components/Administration/TetheringTabContent/CdfTetheringConnections/NewReqLastColumn.tsx
@@ -34,6 +34,11 @@ const GridCellButton = styled(StyledButton)`
   height: 18px;
 `;
 
+const connectionActions = {
+  ACCEPT: 'accept',
+  REJECT: 'reject',
+};
+
 interface INewReqLastColumnProps {
   instanceName: string;
   handleAcceptOrReject: (action: string, peer: string) => void;
@@ -48,7 +53,7 @@ const NewReqLastColumn = ({ instanceName, handleAcceptOrReject }: INewReqLastCol
 
   const confirmReject = () => {
     toggleModalOpen();
-    handleAcceptOrReject('reject', instanceName);
+    handleAcceptOrReject(connectionActions.REJECT, instanceName);
   };
   const confirmRejectElem = (
     <div>{T.translate(`${PREFIX}.ConfirmationModal.rejectRequestCopy`)}</div>
@@ -58,7 +63,7 @@ const NewReqLastColumn = ({ instanceName, handleAcceptOrReject }: INewReqLastCol
     <>
       <ButtonsContainer>
         <GridCellButton
-          onClick={() => handleAcceptOrReject('accept', instanceName)}
+          onClick={() => handleAcceptOrReject(connectionActions.ACCEPT, instanceName)}
           data-testid="accept-connection"
         >
           {T.translate(`${PREFIX}.PendingRequests.acceptButton`)}

--- a/app/cdap/components/Administration/TetheringTabContent/reducer.ts
+++ b/app/cdap/components/Administration/TetheringTabContent/reducer.ts
@@ -36,6 +36,11 @@ export const initialConnectionsState = {
   establishedConnections: [],
 };
 
+const apiConnectionActions = {
+  ACCEPT: 'accept',
+  REJECT: 'reject',
+};
+
 enum IConnectionsActions {
   SET_CONNECTIONS,
   DELETE_CONNECTION,
@@ -95,6 +100,13 @@ export const acceptOrRejectTetheringConnectionReq = async (
   { action, peer }
 ) => {
   await TetheringApi.acceptOrRejectTethering({ peer }, { action }).toPromise();
+  if (action === apiConnectionActions.REJECT) {
+    await TetheringApi.deleteTethering({ peer }).toPromise();
+    dispatch({
+      type: IConnectionsActions.DELETE_CONNECTION,
+      payload: { connGroup: CONNECTION_GROUPS.PENDING, peer },
+    });
+  }
   await fetchConnections(dispatch);
 };
 


### PR DESCRIPTION
# TITLE

## Description
This PR automatically deletes the rejected requests on cdf side to enable hdf to retry the connection upon rejection.

## PR Type
- [ ] Bug Fix
- [X] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19297](https://cdap.atlassian.net/browse/CDAP-19297)

## Test Plan
Manual

## Screenshots
N/A

