### PR TITLE
CDAP-19407 Fix redirect-to-login for HTTP migration

### DIFF
--- a/server.js
+++ b/server.js
@@ -192,6 +192,10 @@ getCDAPConfig()
      */
     let authToken, userid;
     sockServer.on('connection', function(c) {
+      if (!c) {
+        log.error('Connection requested, but no connection available');
+        return;
+      }
       log.debug('[SOCKET OPEN] Connection to client "' + c.id + '" opened');
       // @ts-ignore
       var a = new Aggregator(c, { ...cdapConfig, ...securityConfig });


### PR DESCRIPTION
# CDAP-19407 Fix redirect-to-login for HTTP migration

## Description
The HTTP migration missed the handler which redirects to the login page on a `401` response. Also, an issue with the holdover WebSocket connection was found.

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: CDAP-19407(https://cdap.atlassian.net/browse/CDAP-19407)

## Test Plan
Resume tests with Auth enabled

## Screenshots
N/A


