### PR TITLE
Testing/cdap 19219

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ cypress/screenshots
 cypress/snapshots/actual/
 cypress/snapshots/diff/
 sandboxjs/node_modules/
+.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,19 @@
       Only update this when releasing a new UI pack.
     -->
     <ui.pack.version>4.3.4_p7</ui.pack.version>
+    <guava.version>27.0.1-jre</guava.version>
+    <testSourceLocation>${project.basedir}/src/test/java/</testSourceLocation>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>${guava.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -68,6 +80,7 @@
   </dependencies>
 
   <build>
+    <testSourceDirectory>${testSourceLocation}</testSourceDirectory>
     <plugins>
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>
@@ -537,5 +550,82 @@
       </build>
     </profile>
 
+    <profile>
+      <id>e2e-tests</id>
+      <properties>
+        <testSourceLocation>src/e2e-test/java</testSourceLocation>
+      </properties>
+      <build>
+        <testResources>
+          <testResource>
+            <directory>src/e2e-test/resources</directory>
+          </testResource>
+        </testResources>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skipTests>true</skipTests>
+            </configuration>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>TestRunner.java</include>
+              </includes>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>net.masterthought</groupId>
+            <artifactId>maven-cucumber-reporting</artifactId>
+            <version>5.5.0</version>
+
+            <executions>
+              <execution>
+                <id>execution</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>generate</goal>
+                </goals>
+                <configuration>
+                  <projectName>Cucumber Reports</projectName> <!-- Replace with project name -->
+                  <outputDirectory>target/cucumber-reports/advanced-reports</outputDirectory>
+                  <buildNumber>1</buildNumber>
+                  <skip>false</skip>
+                  <inputDirectory>${project.build.directory}/cucumber-reports</inputDirectory>
+                  <jsonFiles> <!-- supports wildcard or name pattern -->
+                    <param>**/*.json</param>
+                  </jsonFiles> <!-- optional, defaults to outputDirectory if not specified -->
+                  <classificationDirectory>${project.build.directory}/cucumber-reports</classificationDirectory>
+                  <checkBuildResult>true</checkBuildResult>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+
+      <dependencies>
+        <dependency>
+          <groupId>io.cdap.tests.e2e</groupId>
+          <artifactId>cdap-e2e-framework</artifactId>
+          <version>0.0.1-SNAPSHOT</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+
+    </profile>
   </profiles>
 </project>

--- a/src/e2e-test/features/admin.feature
+++ b/src/e2e-test/features/admin.feature
@@ -1,0 +1,40 @@
+#
+# Copyright © 2022 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+@Integration_Tests
+Feature: Admin - Validate profile setting
+
+  @ADMIN_TEST
+  Scenario: Show error message if user tries to set profile at the instance level
+    When Open configuration page
+    Then Click on "System Preferences" accordion
+    Then Click on "Edit System Preferences" button
+    Then Add "system.profile.name" as key
+    Then Add "hello" as value
+    Then Click on "Save Preferences" button
+    Then Verify failure in saving changes
+
+
+  @ADMIN_TEST
+  Scenario: Allow user to save valid preference at instance level after fixing error
+    When Open configuration page
+    Then Click on "System Preferences" accordion
+    Then Click on "Edit System Preferences" button
+    Then Add "name" as key
+    Then Add "hello" as value
+    Then Click on "Save Preferences" button
+    Then Verify successful saving of preferences with "name" as key and "hello" as value
+    

--- a/src/e2e-test/features/pipeline.hierarchy.feature
+++ b/src/e2e-test/features/pipeline.hierarchy.feature
@@ -1,0 +1,61 @@
+#
+# Copyright © 2022 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+@Integration_Tests
+Feature: Pipeline Hierarchy - Hierarchy Widgets
+
+  @PIPELINE_HIERARCHY_TEST
+  Scenario: Render file and duplicate record
+    Given Open Datafusion Project to configure pipeline
+    Then Add "File" node to canvas
+    Then Open transform panel
+    Then Add "CloneRecord" node to canvas
+    Then Cleanup pipeline graph control
+    Then Fit pipeline to screen
+    Then Connect the two added nodes
+    Then Open "File" node property
+    Then Close node property
+
+  @PIPELINE_HIERARCHY_TEST
+  Scenario: Add schema with simple files
+    Then Open "File" node property
+    Then Add field at row "0" and name "column1"
+    Then Add field at row "1" and name "column2"
+    Then Add field at row "2" and name "column3"
+    Then Add field at row "3" and name "column4"
+    Then Add field at row "4" and name "column5"
+    Then Add field at row "5" and name "column6"
+    Then Add field at row "6" and name "column7"
+    Then Add field at row "7" and name "column8"
+    Then Add field at row "8" and name "column9"
+    Then Add field at row "9" and name "column10"
+    Then Close node property
+
+  @PIPELINE_HIERARCHY_TEST
+  Scenario: Get The Schema
+    Then Open "File" node property
+    Then Click on "Get Schema" button
+    Then Close node property
+
+  @ignore
+  Scenario: Render "Duplicate Record" node
+    Then Open "Record Duplicator" node property
+    Then Verify field mapping exists
+
+  @ignore
+  Scenario: Add a new row
+    Then Add a new field mapping row
+    Then Verify field mapping exists

--- a/src/e2e-test/java/io/cdap/cdap/ui/runners/TestRunner.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/runners/TestRunner.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.ui.runners;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+/**
+ * Test Runner to execute namespace creation related test cases.
+ */
+@RunWith(Cucumber.class)
+@CucumberOptions(
+  features = {"src/e2e-test/features"},
+  glue = {"io.cdap.cdap.ui.stepsdesign", "stepsdesign"},
+  tags = {"not @ignore"},
+  plugin = {"pretty", "html:target/cucumber-html-report/tethering",
+    "json:target/cucumber-reports/cucumber-tethering.json",
+    "junit:target/cucumber-reports/cucumber-tethering.xml"}
+)
+public class TestRunner {
+}

--- a/src/e2e-test/java/io/cdap/cdap/ui/runners/package-info.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/runners/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Package contains the runner(s) class(es) for integration tests.
+ */
+package io.cdap.cdap.ui.runners;

--- a/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/Admin.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/Admin.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.ui.stepsdesign;
+
+import io.cdap.cdap.ui.utils.Constants;
+import io.cdap.cdap.ui.utils.Helper;
+import io.cdap.e2e.utils.ElementHelper;
+import io.cdap.e2e.utils.SeleniumDriver;
+import io.cdap.e2e.utils.WaitHelper;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+
+
+public class Admin {
+
+  @When("Open configuration page")
+  public void openCdap() {
+    SeleniumDriver.openPage(Constants.CONFIGURATION_URL);
+    WaitHelper.waitForPageToLoad();
+  }
+
+  @Then("Click on \"System Preferences\" accordion")
+  public void openSystemPreferences()  {
+    ElementHelper.clickOnElement(
+      Helper.locateElementByCssSelector(Helper.getCssSelectorByDataTestId("system-prefs-accordion"))
+    );
+  }
+
+  @Then("Click on \"Edit System Preferences\" button")
+  public void editSystemPreferences() {
+    ElementHelper.clickOnElement(
+      Helper.locateElementByCssSelector(Helper.getCssSelectorByDataTestId("edit-system-prefs-btn"))
+    );
+  }
+
+  @Then("Add {string} as key")
+  public void addInputKey(String keyValue) {
+    WebElement keyInput = Helper.locateElementByCssSelector(
+      "div[class='key-value-pair-preference'] > input[class='form-control key-input']"
+    );
+    ElementHelper.clearElementValue(keyInput);
+    ElementHelper.sendKeys(keyInput, keyValue);
+  }
+
+  @Then("Add {string} as value")
+  public void addInputValue(String value) {
+    WebElement valueInput = Helper.locateElementByCssSelector(
+      "div[class='key-value-pair-preference'] > input[class='form-control value-input']"
+    );
+    ElementHelper.clearElementValue(valueInput);
+    ElementHelper.sendKeys(valueInput, value);
+  }
+
+  @Then("Click on \"Save Preferences\" button")
+  public void saveSystemPreferences() {
+    ElementHelper.clickOnElement(
+      Helper.locateElementByCssSelector(Helper.getCssSelectorByDataTestId("save-prefs-btn"))
+    );
+  }
+
+  @Then("Verify failure in saving changes")
+  public void checkForErrorInSavingPreferences() {
+    ElementHelper.clickOnElement(
+      Helper.locateElementByCssSelector("div[class=\"preferences-error\"]")
+    );
+  }
+
+  @Then("Verify successful saving of preferences with {string} as key and {string} as value")
+  public void checkForSuccessfulSavingOfPreferences(String key, String value) throws RuntimeException {
+    String addedKeyCssLocator = "div[class*='grid-row'] > div";
+    String addedKey = ElementHelper.getElementText(
+      WaitHelper.waitForElementToBePresent(By.cssSelector(addedKeyCssLocator))
+    );
+    String addedValue = ElementHelper.getElementText(
+      WaitHelper.waitForElementToBePresent(By.cssSelector(addedKeyCssLocator + "+ div"))
+    );
+    if (!addedKey.equals(key) || !addedValue.equals(value)) {
+      throw new RuntimeException(
+        "Saved key-value pair does not match with user provided key-value pair" +
+          "\nUser provided \"" + key + "\" for key and \"" + value + "\" for value." +
+          "\nSaved values are \"" + addedKey + "\" for key and \"" + addedValue + "\" for value."
+      );
+    }
+  }
+
+}

--- a/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/PipelineHierarchy.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/PipelineHierarchy.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.ui.stepsdesign;
+
+import com.google.common.base.Strings;
+import io.cdap.cdap.ui.types.NodeInfo;
+import io.cdap.cdap.ui.utils.Commands;
+import io.cdap.cdap.ui.utils.Helper;
+import io.cdap.e2e.pages.actions.CdfPluginPropertiesActions;
+import io.cdap.e2e.pages.actions.CdfStudioActions;
+import io.cdap.e2e.utils.ElementHelper;
+import io.cucumber.java.en.Then;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebElement;
+
+public class PipelineHierarchy {
+  private String property = "fieldMapping";
+  private NodeInfo cloneRecord = new NodeInfo("CloneRecord", "transform", "1");
+  private NodeInfo fileSource = new NodeInfo("File", "batchsource", "0");
+  private String propertySelector = Helper.getCssSelectorByDataTestId(property);
+
+  private void addField (String row, String name, String type) {
+    WebElement field = Helper.locateElementByCssSelector(
+      "div" + Helper.getCssSelectorByDataTestId("schema-row-" + row) + " input[placeholder=\"Field name\"]"
+    );
+    ElementHelper.clearElementValue(field);
+    field.sendKeys(name, Keys.ENTER);
+
+    String dropdownCssLocator = "div" +
+      Helper.getCssSelectorByDataTestId("schema-row-" + row) +
+      " div" +
+      Helper.getCssSelectorByDataTestId("select-undefined");
+
+    if (!Strings.isNullOrEmpty(type)) {
+      ElementHelper.clickOnElement(
+        Helper.locateElementByCssSelector(dropdownCssLocator)
+      );
+      Helper.locateElementByCssSelector(dropdownCssLocator + " > select > option[value=" + type + "]");
+    }
+  };
+
+  private void removeField (String row) {
+    ElementHelper.clickOnElement(
+      Helper.locateElementByCssSelector(
+        "div" + Helper.getCssSelectorByDataTestId("schema-row-" + row)
+          + "button" + Helper.getCssSelectorByDataTestId("schema-field-remove-button"))
+    );
+  };
+
+  @Then("Add \"File\" node to canvas")
+  public void addFileNodeToCanvas()  {
+    Commands.addNodeToCanvas(fileSource);
+  }
+
+  @Then("Open transform panel")
+  public void openTransformPanel() {
+    CdfStudioActions.expandPluginGroupIfNotAlreadyExpanded("Transform");
+  }
+
+  @Then("Add \"CloneRecord\" node to canvas")
+  public void addCloneRecordNodeToCanvas()  {
+    Commands.addNodeToCanvas(cloneRecord);
+  }
+
+  @Then("Cleanup pipeline graph control")
+  public void cleanupPipelineGraphControl() {
+    Commands.pipelineCleanUpGraphControl();
+  }
+
+  @Then("Fit pipeline to screen")
+  public void fitPipelineToScreen() {
+    Commands.fitPipelineToScreen();
+  }
+
+  @Then("Connect the two added nodes")
+  public void connectAddedNodes() {
+    Commands.connectTwoNodes(fileSource, cloneRecord);
+  }
+
+  @Then("Open {string} node property")
+  public void openNodeProperty(String nodeName) {
+    CdfStudioActions.navigateToPluginPropertiesPage(nodeName);
+  }
+
+  @Then("Close node property")
+  public void closeNodeProperty() throws InterruptedException {
+    CdfPluginPropertiesActions.clickCloseButton();
+  }
+
+  @Then("Add field at row {string} and name {string}")
+  public void addFieldToNodeProperty(String row, String name) {
+    addField(row, name, "");
+  }
+
+  @Then("Click on \"Get Schema\" button")
+  public void getSchema() {
+    CdfPluginPropertiesActions.clickGetSchemaButton();
+  }
+
+  @Then("Verify field mapping exists")
+  public void verifyFieldMappingExists() {
+    int numOfFieldMappingEls = ElementHelper.countNumberOfElements(By.cssSelector(propertySelector));
+
+    if (numOfFieldMappingEls <= 0) {
+      throw new RuntimeException(
+        "Unable to find any field mapping elements for node " + cloneRecord.getNodeName()
+      );
+    }
+  }
+
+  @Then("Add a new field mapping row")
+  public void addNewFieldMappingRow() {
+    ElementHelper.clickOnElement(Helper.locateElementByCssSelector(
+      "div" + propertySelector + " div" + Helper.getCssSelectorByDataTestId("add")
+    ));
+  }
+
+}

--- a/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/package-info.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Package contains the integration tests classes.
+ */
+package io.cdap.cdap.ui.stepsdesign;

--- a/src/e2e-test/java/io/cdap/cdap/ui/types/NodeInfo.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/types/NodeInfo.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.ui.types;
+
+public class NodeInfo {
+  private String nodeName;
+  private String nodeType;
+  private String nodeId;
+
+  public NodeInfo(String nodeName, String nodeType, String nodeId) {
+    this.nodeName = nodeName;
+    this.nodeType = nodeType;
+    this.nodeId = nodeId;
+  }
+
+  public String getNodeName() {
+    return nodeName;
+  }
+
+  public String getNodeType() {
+    return nodeType;
+  }
+
+  public String getNodeId() {
+    return nodeId;
+  }
+}

--- a/src/e2e-test/java/io/cdap/cdap/ui/types/package-info.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/types/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Package contains the custom types for integration tests.
+ */
+package io.cdap.cdap.ui.types;

--- a/src/e2e-test/java/io/cdap/cdap/ui/utils/Commands.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/utils/Commands.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.ui.utils;
+
+import io.cdap.cdap.ui.types.NodeInfo;
+import io.cdap.e2e.pages.locators.CdfStudioLocators;
+import io.cdap.e2e.utils.CdfHelper;
+import io.cdap.e2e.utils.ElementHelper;
+import org.openqa.selenium.WebElement;
+
+public class Commands implements CdfHelper {
+  public static void addNodeToCanvas(NodeInfo node) {
+    ElementHelper.clickOnElement(
+      Helper.locateElementByCssSelector(
+        "[data-testid=\"plugin-" + node.getNodeName() + "-" + node.getNodeType() + "\"]"
+      )
+    );
+  }
+
+  private static WebElement getNode (NodeInfo element) {
+    return Helper.locateElementByCssSelector(Helper.getNodeSelectorFromNodeIndentifier(element));
+  };
+
+  public static void moveNode (String node, int toX, int toY) {
+    WebElement element = Helper.locateElementByCssSelector(node);
+    ElementHelper.dragAndDropByOffset(element, toX, toY);
+  };
+
+  public static void moveNode (NodeInfo node, int toX, int toY) {
+    moveNode(Helper.getNodeSelectorFromNodeIndentifier(node), toX, toY);
+  };
+
+  public static void connectTwoNodes (NodeInfo source, NodeInfo target) {
+    ElementHelper.dragAndDrop(
+      CdfStudioLocators.locateSourceEndpointInCanvas(source.getNodeName()),
+      getNode(target));
+  }
+
+  public static void pipelineCleanUpGraphControl() {
+    ElementHelper.clickOnElement(
+      Helper.locateElementByCssSelector("[data-testid=\"pipeline-clean-up-graph-control\"]")
+    );
+  };
+
+  public static void fitPipelineToScreen() {
+    ElementHelper.clickOnElement(
+      Helper.locateElementByCssSelector("[data-testid=\"pipeline-fit-to-screen-control\"]")
+    );
+  };
+
+}

--- a/src/e2e-test/java/io/cdap/cdap/ui/utils/Constants.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/utils/Constants.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.ui.utils;
+
+public class Constants {
+  private static double getRandomArbitrary(int min, int max) {
+    return Math.floor(Math.random() * (max - min + 1) + min);
+  }
+
+  public static final int TEST_TIMEOUT_TIME = 10000;
+  public static final int RETRY_INTERVAL = 2000;
+  public static final String TEST_TIMEOUT_MESSAGE = "Timed out after" +
+    String.valueOf(TEST_TIMEOUT_TIME / 1000) +
+    "seconds";
+
+  public static final String BASE_URL = "http://localhost:11011/";
+  public static final String BASE_SERVER_URL = "http://localhost:11015";
+  public static final String CONFIGURATION_URL = "http://localhost:11011/cdap/administration/configuration";
+
+  public static final String DEFAULT_GCS_CONNECTION_NAME = "gcs_" + String.valueOf(getRandomArbitrary(1, 10000));
+  
+  // 000 to keep this bucket in the first 1000 entries
+  // TODO Change back when we support > 1000 entries
+  public static final String DEFAULT_GCS_FOLDER = "000cdap-gcp-ui-test";
+  public static final String DEFAULT_GCS_FILE = "purchase_bad.csv";
+
+  public static final String DEFAULT_BIGQUERY_CONNECTION_NAME = "bigquery_" +
+    String.valueOf(getRandomArbitrary(1, 10000));
+  public static final String DEFAULT_BIGQUERY_DATASET = "cdap_gcp_ui_test";
+  public static final String DEFAULT_BIGQUERY_TABLE = "users";
+
+  public static final String DEFAULT_SPANNER_INSTANCE = "cdap-gcp-ui-test";
+  public static final String DEFAULT_SPANNER_DATABASE = "test";
+  public static final String DEFAULT_SPANNER_TABLE = "users";
+  public static final String DEFAULT_SPANNER_CONNECTION_NAME = "spanner_" +
+    String.valueOf(getRandomArbitrary(1, 10000));
+
+  public static final String RUNTIME_ARGS_DEPLOYED_SELECTOR = "runtimeargs-deployed";
+  public static final String RUNTIME_ARGS_KEY_SELECTOR = "runtimeargs-key";
+  public static final String RUNTIME_ARGS_VALUE_SELECTOR = "runtimeargs-value";
+}

--- a/src/e2e-test/java/io/cdap/cdap/ui/utils/Helper.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/utils/Helper.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.ui.utils;
+
+import io.cdap.cdap.ui.types.NodeInfo;
+import io.cdap.e2e.utils.CdfHelper;
+import io.cdap.e2e.utils.SeleniumDriver;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+public class Helper implements CdfHelper {
+
+  public static WebElement locateElementByCssSelector(String cssSelector) {
+    return SeleniumDriver.getDriver()
+      .findElement(By.cssSelector(cssSelector));
+  }
+
+  public static String getCssSelectorByDataTestId (String dataTestId) {
+    return "[data-testid=" + dataTestId + "]";
+  }
+
+  public static String getNodeSelectorFromNodeIndentifier (NodeInfo node) {
+    return "[data-testid=\"plugin-node-" +
+      node.getNodeName() + "-" +
+      node.getNodeType() + "-" +
+      node.getNodeId() + "\"]";
+  }
+}

--- a/src/e2e-test/java/io/cdap/cdap/ui/utils/package-info.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/utils/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Package contains utility classes for integration tests.
+ */
+package io.cdap.cdap.ui.utils;

--- a/src/main/java/io/cdap/cdap/ui/ConfigurationJsonTool.java
+++ b/src/main/java/io/cdap/cdap/ui/ConfigurationJsonTool.java
@@ -18,7 +18,7 @@ package io.cdap.cdap.ui;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.google.common.io.NullOutputStream;
+import com.google.common.io.ByteStreams;
 import com.google.gson.GsonBuilder;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Configuration;
@@ -69,7 +69,7 @@ public class ConfigurationJsonTool {
     PrintStream stdout = System.out;
 
     // Redirect the stdout to null to suppress any log outputs generated during the json generation
-    System.setOut(new PrintStream(new NullOutputStream()));
+    System.setOut(new PrintStream(ByteStreams.nullOutputStream()));
     StringBuilder output = new StringBuilder();
     exportToJson(args[0], output);
 


### PR DESCRIPTION
# Convert admin.spec.ts to selenium

## Description
This PR converts `admin.spec.ts` to use the E2E test framework.

** UPDATE TO THE STEPS BELOW: You can skip the first three steps and start at step 4. In case of failure, run the first three steps.

Steps to run the tests locally:

1. Clone the `cdap-e2e-tests` repo from [here](https://github.com/cdapio/cdap-e2e-tests)
2. `cd` into the `cdap-e2e-tests` directory and run the following command: `mvn clean install`
3. Make sure `cdap sandbox` and `cdap-ui server` are running
4. `cd` into `cdap-ui` directory
5. Make sure you are on `testing/CDAP/19219` branch
6. Try running the following command: `mvn clean verify -P e2e-tests`

In case of failure, you most likely need to do the following if it's your first time running tests using `cdap-e2e-tests`:
- open `cdap-ui` project with `intelliJ`
- click on the Maven taskbar on the right side of the window
- expand `profiles` and make sure `e2e-test` is checked. Then click on `Reload all Maven Projects`
![Screen Shot 2022-07-28 at 9 26 49 AM](https://user-images.githubusercontent.com/94018249/181517137-356c735b-b21d-438d-938f-a1ca6f50357a.png)

- right click on the `TestRunner` class in `src/e2e-test/java/io.cdap.cdap.ui/runners/TestRunner`, and click on `Run 'Test Runner'`
![Screen Shot 2022-07-28 at 9 30 36 AM](https://user-images.githubusercontent.com/94018249/181517474-19be4060-fb28-4827-92b1-021ed9057e3f.png)

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [X] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19219](https://cdap.atlassian.net/browse/CDAP-19219)

## Test Plan
Automated

## Screenshots


