### PR TITLE
CDAP-19450 Fix metric graph gap handling

### DIFF
--- a/app/cdap/components/PipelineSummary/RunsGraphHelpers.js
+++ b/app/cdap/components/PipelineSummary/RunsGraphHelpers.js
@@ -174,12 +174,15 @@ export function getDuration(time) {
 }
 
 export function getGapFilledAccumulatedData(data, numOfDataPoints) {
-  let { x: minx, y: miny } = data[0];
-  let maxx = data[data.length - 1].x;
-  let numberOfEntries = maxx - minx;
+  const { x: minx, y: miny } = data[0];
+  const maxx = data[data.length - 1].x;
+  const numberOfEntries = maxx - minx;
   let lasty = miny;
-  let finalData = Array(numberOfEntries + 1).map((i, index) => {
-    let matchInActualData = data.find((d) => d.x === minx + index);
+  // Create an array with numberOfEntries + 1 undefined values
+  const arrayOfSize = [...Array(numberOfEntries + 1)];
+  // Map arrayOfSize to fill in gaps in data
+  const finalData = arrayOfSize.map((i, index) => {
+    const matchInActualData = data.find((d) => d.x === minx + index);
     if (!isNil(matchInActualData)) {
       lasty = matchInActualData.y;
     }
@@ -190,10 +193,10 @@ export function getGapFilledAccumulatedData(data, numOfDataPoints) {
     };
   });
   if (finalData.length < numOfDataPoints) {
-    let diff = numOfDataPoints - finalData.length;
-    let lastDataPoint = finalData[finalData.length - 1];
-    for (var i = 0; i < diff; i++) {
-      let currDataPoint = {
+    const diff = numOfDataPoints - finalData.length;
+    const lastDataPoint = finalData[finalData.length - 1];
+    for (let i = 1; i <= diff; i++) {
+      const currDataPoint = {
         ...lastDataPoint,
         x: lastDataPoint.x + i,
         y: lastDataPoint.y,

--- a/app/cdap/components/PipelineSummary/__tests__/RunsGraphHelpers.test.ts
+++ b/app/cdap/components/PipelineSummary/__tests__/RunsGraphHelpers.test.ts
@@ -14,33 +14,77 @@
  * the License.
  */
 
-import { getResolution } from 'components/PipelineSummary/RunsGraphHelpers';
+import { getResolution, getGapFilledAccumulatedData } from 'components/PipelineSummary/RunsGraphHelpers';
 const secondsi18nLabel = 'features.PipelineSummary.pipelineNodesMetricsGraph.seconds';
 const minutesi18nLabel = 'features.PipelineSummary.pipelineNodesMetricsGraph.minutes';
 const hoursi18nLabel = 'features.PipelineSummary.pipelineNodesMetricsGraph.hours';
-describe('Resolving resolution in plugin metrics graph', () => {
-  it('Should return default if no input is provided', () => {
-    expect(getResolution('')).toBe(secondsi18nLabel);
-  });
-  it('Should return seconds if resolution is < 60s', () => {
-    expect(getResolution('1s')).toBe(secondsi18nLabel);
-    expect(getResolution('20s')).toBe(secondsi18nLabel);
-    expect(getResolution('59s')).toBe(secondsi18nLabel);
-  });
-  it('Should return minutes if resolution is between 60 and 3600s', () => {
-    expect(getResolution('60s')).toBe(minutesi18nLabel);
-    expect(getResolution('2300s')).toBe(minutesi18nLabel);
-    expect(getResolution('2599s')).toBe(minutesi18nLabel);
+
+describe('RunsGraphHelper', () => {
+  describe('getResolution Resolving resolution in plugin metrics graph', () => {
+    it('Should return default if no input is provided', () => {
+      expect(getResolution('')).toBe(secondsi18nLabel);
+    });
+    it('Should return seconds if resolution is < 60s', () => {
+      expect(getResolution('1s')).toBe(secondsi18nLabel);
+      expect(getResolution('20s')).toBe(secondsi18nLabel);
+      expect(getResolution('59s')).toBe(secondsi18nLabel);
+    });
+    it('Should return minutes if resolution is between 60 and 3600s', () => {
+      expect(getResolution('60s')).toBe(minutesi18nLabel);
+      expect(getResolution('2300s')).toBe(minutesi18nLabel);
+      expect(getResolution('2599s')).toBe(minutesi18nLabel);
+    });
+
+    it('Should return hours if resolution is > 3600s', () => {
+      expect(getResolution('3600s')).toBe(hoursi18nLabel);
+      expect(getResolution('6000s')).toBe(hoursi18nLabel);
+    });
+
+    it('Should not error out if given an invalid resolution', () => {
+      expect(getResolution('unknown')).toBe(secondsi18nLabel);
+      expect(getResolution(10 as any)).toBe(secondsi18nLabel);
+      expect(getResolution('-100s')).toBe(secondsi18nLabel);
+    });
   });
 
-  it('Should return hours if resolution is > 3600s', () => {
-    expect(getResolution('3600s')).toBe(hoursi18nLabel);
-    expect(getResolution('6000s')).toBe(hoursi18nLabel);
-  });
+  describe.only('getGapFilledAccumulatedData', () => {
+    it('should return the same elements if there are no gaps', () => {
+      expect(getGapFilledAccumulatedData([
+        {x: 1000, y: 500},
+        {x: 1001, y: 550},
+        {x: 1002, y: 575}
+      ], 0)).toStrictEqual([
+        {x: 1000, y: 500},
+        {x: 1001, y: 550},
+        {x: 1002, y: 575}
+      ]);
+    });
 
-  it('Should not error out if given an invalid resolution', () => {
-    expect(getResolution('unknown')).toBe(secondsi18nLabel);
-    expect(getResolution(10 as any)).toBe(secondsi18nLabel);
-    expect(getResolution('-100s')).toBe(secondsi18nLabel);
+    it('should fill a gap in the middle of the series', () => {
+      expect(getGapFilledAccumulatedData([
+        {x: 1000, y: 500},
+        {x: 1001, y: 550},
+        {x: 1003, y: 575}
+      ], 0)).toStrictEqual([
+        {x: 1000, y: 500},
+        {x: 1001, y: 550},
+        {x: 1002, y: 550},
+        {x: 1003, y: 575}
+      ]);
+    });
+
+    it('should add new entries at the end of the series', () => {
+      expect(getGapFilledAccumulatedData([
+        {x: 1000, y: 500},
+        {x: 1001, y: 550},
+        {x: 1002, y: 575}
+      ], 5)).toStrictEqual([
+        {x: 1000, y: 500},
+        {x: 1001, y: 550},
+        {x: 1002, y: 575},
+        {x: 1003, y: 575},
+        {x: 1004, y: 575}
+      ]);
+    })
   });
 });


### PR DESCRIPTION
# CDAP-19450 Fix metric graph gap handling

## Description
This fixes a regression from #211. That fix had a subtle semantic change - it moved from an array of length N of `undefined` entries to an empty array of length N. Empty slots in an array aren't enumerated during `map` so the graph functions were handed an empty array instead of one with data.

I added unit tests to cover this area and found one more bug.

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19450](https://cdap.atlassian.net/browse/CDAP-19450)

## Test Plan
Manually verify

## Screenshots
N/A


