### PR TITLE
Add HTTP request handler to e2e tests

### DIFF
--- a/app/cdap/components/PipelineSummary/__tests__/RunsGraphHelpers.test.ts
+++ b/app/cdap/components/PipelineSummary/__tests__/RunsGraphHelpers.test.ts
@@ -14,7 +14,10 @@
  * the License.
  */
 
-import { getResolution, getGapFilledAccumulatedData } from 'components/PipelineSummary/RunsGraphHelpers';
+import {
+  getResolution,
+  getGapFilledAccumulatedData,
+} from 'components/PipelineSummary/RunsGraphHelpers';
 const secondsi18nLabel = 'features.PipelineSummary.pipelineNodesMetricsGraph.seconds';
 const minutesi18nLabel = 'features.PipelineSummary.pipelineNodesMetricsGraph.minutes';
 const hoursi18nLabel = 'features.PipelineSummary.pipelineNodesMetricsGraph.hours';
@@ -49,42 +52,57 @@ describe('RunsGraphHelper', () => {
 
   describe.only('getGapFilledAccumulatedData', () => {
     it('should return the same elements if there are no gaps', () => {
-      expect(getGapFilledAccumulatedData([
-        {x: 1000, y: 500},
-        {x: 1001, y: 550},
-        {x: 1002, y: 575}
-      ], 0)).toStrictEqual([
-        {x: 1000, y: 500},
-        {x: 1001, y: 550},
-        {x: 1002, y: 575}
+      expect(
+        getGapFilledAccumulatedData(
+          [
+            { x: 1000, y: 500 },
+            { x: 1001, y: 550 },
+            { x: 1002, y: 575 },
+          ],
+          0
+        )
+      ).toStrictEqual([
+        { x: 1000, y: 500 },
+        { x: 1001, y: 550 },
+        { x: 1002, y: 575 },
       ]);
     });
 
     it('should fill a gap in the middle of the series', () => {
-      expect(getGapFilledAccumulatedData([
-        {x: 1000, y: 500},
-        {x: 1001, y: 550},
-        {x: 1003, y: 575}
-      ], 0)).toStrictEqual([
-        {x: 1000, y: 500},
-        {x: 1001, y: 550},
-        {x: 1002, y: 550},
-        {x: 1003, y: 575}
+      expect(
+        getGapFilledAccumulatedData(
+          [
+            { x: 1000, y: 500 },
+            { x: 1001, y: 550 },
+            { x: 1003, y: 575 },
+          ],
+          0
+        )
+      ).toStrictEqual([
+        { x: 1000, y: 500 },
+        { x: 1001, y: 550 },
+        { x: 1002, y: 550 },
+        { x: 1003, y: 575 },
       ]);
     });
 
     it('should add new entries at the end of the series', () => {
-      expect(getGapFilledAccumulatedData([
-        {x: 1000, y: 500},
-        {x: 1001, y: 550},
-        {x: 1002, y: 575}
-      ], 5)).toStrictEqual([
-        {x: 1000, y: 500},
-        {x: 1001, y: 550},
-        {x: 1002, y: 575},
-        {x: 1003, y: 575},
-        {x: 1004, y: 575}
+      expect(
+        getGapFilledAccumulatedData(
+          [
+            { x: 1000, y: 500 },
+            { x: 1001, y: 550 },
+            { x: 1002, y: 575 },
+          ],
+          5
+        )
+      ).toStrictEqual([
+        { x: 1000, y: 500 },
+        { x: 1001, y: 550 },
+        { x: 1002, y: 575 },
+        { x: 1003, y: 575 },
+        { x: 1004, y: 575 },
       ]);
-    })
+    });
   });
 });

--- a/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/Admin.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/Admin.java
@@ -27,7 +27,6 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 
-
 public class Admin {
 
   @When("Open configuration page")

--- a/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/BeforeActions.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/BeforeActions.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.ui.stepsdesign;
+
+import io.cdap.cdap.ui.utils.Helper;
+import io.cucumber.java.Before;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class BeforeActions {
+  private static final Logger logger = LoggerFactory.getLogger(stepsdesign.BeforeActions.class);
+
+  @Before(order = 0)
+  public void loginIfRequired() throws IOException {
+    logger.info("-----------------Logging in if required------------------");
+    Helper.loginIfRequired();
+  }
+}

--- a/src/e2e-test/java/io/cdap/cdap/ui/utils/Helper.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/utils/Helper.java
@@ -16,13 +16,61 @@
 
 package io.cdap.cdap.ui.utils;
 
+import com.google.gson.Gson;
 import io.cdap.cdap.ui.types.NodeInfo;
+import io.cdap.common.http.HttpMethod;
+import io.cdap.common.http.HttpResponse;
 import io.cdap.e2e.utils.CdfHelper;
 import io.cdap.e2e.utils.SeleniumDriver;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Cookie;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
 public class Helper implements CdfHelper {
+  private static final Gson gson = new Gson();
+  private static final String USERNAME = "admin";
+  private static final String PASSWORD = "admin";
+  private static boolean isAuthEnabled = false;
+  private static String authToken = null;
+
+  public static void loginIfRequired() throws IOException {
+    WebDriver driver = SeleniumDriver.getDriver();
+    if (isAuthEnabled && authToken != null) {
+      driver.manage().addCookie(new Cookie("CDAP_Auth_Token", authToken));
+      driver.manage().addCookie(new Cookie("CDAP_Auth_User", USERNAME));
+      return;
+    }
+    HttpResponse response = HttpRequestHandler.makeHttpRequest(
+      HttpMethod.GET, Constants.BASE_SERVER_URL + "/v3/namespaces", null, null, null
+    );
+    if (response.getResponseCode() == 401) {
+      isAuthEnabled = true;
+      try {
+        Map<String, String> reqHeaders = new HashMap<>();
+        reqHeaders.put("Accept", "application/json");
+        reqHeaders.put("Content-Type", "application/json");
+        Map<String, String> reqBody = new HashMap<>();
+        reqBody.put("username", USERNAME);
+        reqBody.put("password", PASSWORD);
+        HttpResponse authResponse = HttpRequestHandler.makeHttpRequest(
+          HttpMethod.POST, Constants.BASE_URL + "/login", reqHeaders, reqBody, null
+        );
+        Map<String, String> authResponseMap
+          = gson.fromJson(authResponse.getResponseBodyAsString(),
+                          Map.class);
+        authToken = authResponseMap.get("access_token");
+        driver.manage().addCookie(new Cookie("CDAP_Auth_Token", authToken));
+        driver.manage().addCookie(new Cookie("CDAP_Auth_User", USERNAME));
+      } catch (IOException e) {
+        throw new IOException(e.getMessage());
+      }
+    }
+  }
 
   public static WebElement locateElementByCssSelector(String cssSelector) {
     return SeleniumDriver.getDriver()

--- a/src/e2e-test/java/io/cdap/cdap/ui/utils/HttpRequestHandler.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/utils/HttpRequestHandler.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.ui.utils;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.Multimap;
+import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
+import io.cdap.common.ContentProvider;
+import io.cdap.common.http.HttpMethod;
+import io.cdap.common.http.HttpRequest;
+import io.cdap.common.http.HttpRequests;
+import io.cdap.common.http.HttpResponse;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+public class HttpRequestHandler {
+  public static HttpResponse makeHttpRequest(HttpMethod method, String urlStr,
+                                             @Nullable Map<String, String> headers,
+                                             @Nullable Map<String, String> body,
+                                             @Nullable Long bodyLength) throws IOException {
+    ContentProvider reqBody = body != null
+      ? buildHttpReqBody(body)
+      : null;
+    Multimap<String, String> reqHeaders = headers != null
+      ? castMapToMultiMap(headers)
+      : null;
+    HttpRequest request = new HttpRequest(method, new URL(urlStr), reqHeaders, reqBody, bodyLength);
+    HttpResponse httpResponse = HttpRequests.execute(request, new DefaultHttpRequestConfig(false));
+    if (httpResponse.getResponseCode() != HttpURLConnection.HTTP_OK) {
+      throw new IOException(httpResponse.getResponseBodyAsString());
+    }
+    return httpResponse;
+  }
+
+  private static ContentProvider buildHttpReqBody(Map<String, String> body) {
+    String bodyStr = Joiner.on(",").withKeyValueSeparator("=").join(body);
+    return new ContentProvider<InputStream>() {
+      @Override
+      public InputStream getInput() {
+        return new ByteArrayInputStream(bodyStr.getBytes());
+      }
+    };
+  }
+
+  private static Multimap<String, String> castMapToMultiMap(Map<String, String> header) {
+    Multimap<String, String> reqHeaders = LinkedListMultimap.create();
+    for (Map.Entry<String, String> entry : header.entrySet()) {
+      reqHeaders.put(entry.getKey(), entry.getValue());
+    }
+    return reqHeaders;
+  }
+}


### PR DESCRIPTION
# Add HTTP request handler to e2e tests

## Description
This PR adds a HTTP request handler class for the e2e tests to use.

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [X] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
N/A

## Test Plan
N/A

## Screenshots
N/A

