### PR TITLE
fix sandbox build issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,6 +235,8 @@
         <package.deb.arch>amd64</package.deb.arch>
         <package.rpm.arch>x86_64</package.rpm.arch>
         <ui.build.name>cdap-prod-build</ui.build.name>
+        <stage.dir>${project.build.directory}/stage-packaging</stage.dir>
+        <stage.opt.dir>${stage.dir}/opt/cdap/ui</stage.opt.dir>
       </properties>
       <build>
         <plugins>


### PR DESCRIPTION
# Fix sandbox build issue

## Description
This PR fixes a sandbox build issue that started happening after removing cdap as a parent.

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [X] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
N/A

## Test Plan
Manual

## Screenshots


