### PR TITLE
[CDAP-19221] Conversion of control center tests from cypress to selenium

### DIFF
--- a/app/cdap/components/EntityCard/index.js
+++ b/app/cdap/components/EntityCard/index.js
@@ -137,6 +137,7 @@ export default class EntityCard extends Component {
               className={classnames({ 'with-version': this.props.entity.version })}
               title={this.props.entity.id}
               data-cy={`${this.props.entity.id}-header`}
+              data-testid={`${this.props.entity.id}-header`}
             >
               {this.props.entity.id}
             </h4>

--- a/app/cdap/components/EntityListView/EntityListHeader/index.js
+++ b/app/cdap/components/EntityListView/EntityListHeader/index.js
@@ -209,7 +209,12 @@ export default class EntityListHeader extends Component {
         toggle={() => {}}
         onClick={this.handleFilterToggle.bind(this)}
       >
-        <DropdownToggle tag="div" className="filter-toggle" data-cy="filter-dropdown">
+        <DropdownToggle
+          tag="div"
+          className="filter-toggle"
+          data-cy="filter-dropdown"
+          data-testid="filter-dropdown"
+        >
           <span>{T.translate('features.EntityListView.Header.filterBy')}</span>
           <span className="float-right">
             <IconSVG name="icon-angle-down" />
@@ -226,6 +231,7 @@ export default class EntityListHeader extends Component {
                     checked={this.state.activeFilters.indexOf(option.id) !== -1}
                     onChange={this.onFilterClick.bind(this, option)}
                     data-cy={`${option.displayName}-input`}
+                    data-testid={`${option.displayName}-input`}
                   />
                   <label className="form-check-label" onClick={(e) => e.stopPropagation()}>
                     {option.displayName}

--- a/app/cdap/components/PipelineDetails/RunLevelInfo/RunStatus.js
+++ b/app/cdap/components/PipelineDetails/RunLevelInfo/RunStatus.js
@@ -54,7 +54,9 @@ const RunStatus = ({ runs, currentRun, pipelineId }) => {
       <span className={`run-status-bubble ${statusCSSClass}`}>
         <IconSVG name={statusIcon} />
       </span>
-      <span data-cy={statusLabel}>{statusLabel}</span>
+      <span data-cy={statusLabel} data-testid={statusLabel}>
+        {statusLabel}
+      </span>
       {runningRuns.length > 1 && status === PROGRAM_STATUSES.RUNNING ? (
         <RunningRunsPopover
           runs={runningRuns}

--- a/src/e2e-test/features/controlcenter.feature
+++ b/src/e2e-test/features/controlcenter.feature
@@ -1,0 +1,27 @@
+#
+# Copyright © 2022 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+@Integration_Tests
+Feature: Control Center - filter and find
+
+  @CONTROL_CENTER_FILTER_FIND
+  Scenario: Using control center to see and filter things
+    When Deploy and test pipeline "test_pipeline2_fll_airport" with pipeline JSON file "fll_airport_pipeline2.json"
+    When Open control center page
+    Then Find the pipeline "test_pipeline2_fll_airport" in the results
+    Then Find filter dropdown and unselect "applications"
+    Then Verify that pipeline "test_pipeline2_fll_airport" should not present
+    Then Clean up pipeline "test_pipeline2_fll_airport" which is created for testing

--- a/src/e2e-test/fixtures/fll_airport_pipeline2.json
+++ b/src/e2e-test/fixtures/fll_airport_pipeline2.json
@@ -1,0 +1,114 @@
+{
+    "name": "FLL_airport_pipeline2",
+    "description": "without wrangler",
+    "artifact": {
+        "name": "cdap-data-pipeline",
+        "version": "[6.1.0-SNAPSHOT, 7.0.0-SNAPSHOT]",
+        "scope": "SYSTEM"
+    },
+    "config": {
+        "resources": {
+            "memoryMB": 1024,
+            "virtualCores": 1
+        },
+        "driverResources": {
+            "memoryMB": 1024,
+            "virtualCores": 1
+        },
+        "connections": [
+            {
+                "from": "Airport_source",
+                "to": "Airport_sink"
+            }
+        ],
+        "comments": [],
+        "postActions": [],
+        "properties": {},
+        "processTimingEnabled": true,
+        "stageLoggingEnabled": true,
+        "stages": [
+            {
+                "name": "Airport_source",
+                "plugin": {
+                    "name": "File",
+                    "type": "batchsource",
+                    "label": "Airport_source",
+                    "artifact": {
+                        "name": "core-plugins",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
+                        "scope": "SYSTEM"
+                    },
+                    "properties": {
+                        "copyHeader": "true",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"body\",\"type\":\"string\"}]}",
+                        "path": "file:/tmp/cdap-ui-integration-fixtures/airports.csv",
+                        "format": "text",
+                        "ignoreNonExistingFolders": "false",
+                        "recursive": "false",
+                        "referenceName": "airports.csv",
+                        "filenameOnly": "false"
+                    }
+                },
+                "outputSchema": [
+                    {
+                        "name": "etlSchemaBody",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"body\",\"type\":\"string\"}]}"
+                    }
+                ],
+                "type": "batchsource",
+                "label": "Airport_source",
+                "icon": "icon-file",
+                "$$hashKey": "object:2277",
+                "_uiPosition": {
+                    "left": "473px",
+                    "top": "240px"
+                }
+            },
+            {
+                "name": "Airport_sink",
+                "plugin": {
+                    "name": "File",
+                    "type": "batchsink",
+                    "label": "Airport_sink",
+                    "artifact": {
+                        "name": "core-plugins",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
+                        "scope": "SYSTEM"
+                    },
+                    "properties": {
+                        "suffix": "yyyy-MM-dd-HH-mm-ss",
+                        "format": "csv",
+                        "referenceName": "Airport_sink",
+                        "path": "/tmp/cdap-ui-integration-fixtures",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"body\",\"type\":\"string\"}]}"
+                    }
+                },
+                "outputSchema": [
+                    {
+                        "name": "etlSchemaBody",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"body\",\"type\":\"string\"}]}"
+                    }
+                ],
+                "inputSchema": [
+                    {
+                        "name": "Airport_source",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"body\",\"type\":\"string\"}]}"
+                    }
+                ],
+                "type": "batchsink",
+                "label": "Airport_sink",
+                "icon": "icon-file",
+                "$$hashKey": "object:2278",
+                "_uiPosition": {
+                    "left": "773px",
+                    "top": "240px"
+                }
+            }
+        ],
+        "schedule": "0 * * * *",
+        "engine": "mapreduce",
+        "numOfRecordsPreview": 100,
+        "description": "without wrangler",
+        "maxConcurrentRuns": 1
+    }
+}

--- a/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/ComputeProfile.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/ComputeProfile.java
@@ -25,7 +25,6 @@ import io.cdap.e2e.utils.SeleniumDriver;
 import io.cdap.e2e.utils.WaitHelper;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 import java.io.IOException;
@@ -40,7 +39,7 @@ public class ComputeProfile {
 
     @When("Open default profiles create page")
     public void openDefaultProfilesCreate() {
-        SeleniumDriver.openPage(Constants.DEFAULT_PROFILES_CREATE_URL);
+        SeleniumDriver.openPage(Constants.BASE_STUDIO_URL + "profiles/create");
         WaitHelper.waitForPageToLoad();
     }
 

--- a/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/ControlCenter.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/ControlCenter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.ui.stepsdesign;
+import io.cdap.cdap.ui.utils.Constants;
+import io.cdap.cdap.ui.utils.Helper;
+import io.cdap.e2e.utils.ElementHelper;
+import io.cdap.e2e.utils.SeleniumDriver;
+import io.cdap.e2e.utils.WaitHelper;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.openqa.selenium.WebElement;
+
+public class ControlCenter {
+
+    @When("Deploy and test pipeline {string} with pipeline JSON file {string}")
+    public void deployAndTestPipeline(String pipelineName, String pipelineJSONfile) {
+        Helper.deployAndTestPipeline(pipelineJSONfile, pipelineName);
+    }
+
+    @When("Open control center page")
+    public void openControlCenterPage() {
+        SeleniumDriver.openPage(Constants.BASE_STUDIO_URL + "control");
+        WaitHelper.waitForPageToLoad();
+    }
+
+    @Then("Find the pipeline {string} in the results")
+    public void findPipelineInResults(String pipelineName) {
+        WebElement pipelineInResults = Helper.locateElementByCssSelector(
+                Helper.getCssSelectorByDataTestId(pipelineName + "-header"));
+    }
+
+    @Then("Find filter dropdown and unselect \"applications\"")
+    public void unCheckFilterOption() {
+        WebElement filterDropdown = Helper.locateElementByCssSelector(
+                Helper.getCssSelectorByDataTestId("filter-dropdown"));
+        ElementHelper.clickOnElement(filterDropdown);
+        ElementHelper.selectCheckbox(Helper.locateElementByCssSelector(
+                Helper.getCssSelectorByDataTestId("Applications-input")));
+    }
+
+    @Then("Verify that pipeline {string} should not present")
+    public void verifyPipeLineNotDisplayed(String pipelineName) {
+        String cssSelector = "div[class*='entities-all-list-container'] > "
+                + Helper.getCssSelectorByDataTestId(pipelineName + "-header");
+        boolean isPipelineFound = Helper.isElementExists(cssSelector);
+        if (isPipelineFound) {
+            throw new RuntimeException("Applications filter is not working.");
+        }
+    }
+
+    @Then("Clean up pipeline {string} which is created for testing")
+    public static void cleanupPipelinesCreatedForTesting(String pipelineName) {
+        Helper.cleanupPipelines(pipelineName);
+    }
+}

--- a/src/e2e-test/java/io/cdap/cdap/ui/utils/Constants.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/utils/Constants.java
@@ -30,8 +30,9 @@ public class Constants {
   public static final String BASE_URL = "http://localhost:11011/";
   public static final String BASE_SERVER_URL = "http://localhost:11015";
   public static final String CONFIGURATION_URL = "http://localhost:11011/cdap/administration/configuration";
+  public static final String BASE_STUDIO_URL = "http://localhost:11011/cdap/ns/default/";
   public static final String SYSTEM_PROFILES_CREATE_URL = "http://localhost:11011/cdap/ns/system/profiles/create";
-  public static final String DEFAULT_PROFILES_CREATE_URL = "http://localhost:11011/cdap/ns/default/profiles/create";
+  public static final String FIXTURES_DIR = "src/e2e-test/fixtures/";
 
   public static final String DEFAULT_GCS_CONNECTION_NAME = "gcs_" + String.valueOf(getRandomArbitrary(1, 10000));
   


### PR DESCRIPTION
# [CDAP-19221] Convert controlcenter.spec.ts tests from cypress to selenium

## Description
Conversion of controlcenter tests to selenium and added required helper methods.

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [x] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19221](https://cdap.atlassian.net/browse/CDAP-19221)

## Test Plan
Included in  cdap ui e2e tests.

## Screenshots
n/a




[CDAP-19221]: https://cdap.atlassian.net/browse/CDAP-19221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ