### PR TITLE
[CDAP-19524] LCM edit page

### DIFF
--- a/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/PipelineDetailsActionsButton/index.js
+++ b/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/PipelineDetailsActionsButton/index.js
@@ -25,7 +25,7 @@ import PipelineExportModal from 'components/PipelineExportModal';
 import TriggeredPipelineStore from 'components/TriggeredPipelines/store/TriggeredPipelineStore';
 import T from 'i18n-react';
 import classnames from 'classnames';
-import { duplicatePipeline } from 'services/PipelineUtils';
+import { duplicatePipeline, editPipeline } from 'services/PipelineUtils';
 import cloneDeep from 'lodash/cloneDeep';
 import downloadFile from 'services/download-file';
 import { santizeStringForHTMLID } from 'services/helpers';
@@ -63,6 +63,8 @@ export default class PipelineDetailsActionsButton extends Component {
     description: PropTypes.string,
     artifact: PropTypes.object,
     config: PropTypes.object,
+    version: PropTypes.string,
+    lifecycleManagementEditEnabled: PropTypes.bool,
   };
 
   state = {
@@ -89,10 +91,15 @@ export default class PipelineDetailsActionsButton extends Component {
     description: this.props.description,
     artifact: this.props.artifact,
     config: cloneDeep(this.props.config), // currently doing a cloneDeep because angular is mutating this state...
+    version: this.props.version,
   };
 
   duplicateConfigAndNavigate = () => {
     duplicatePipeline(this.props.pipelineName, sanitizeConfig(this.pipelineConfig));
+  };
+
+  editConfigAndNavigate = () => {
+    editPipeline(this.props.pipelineName, sanitizeConfig(this.pipelineConfig));
   };
 
   deletePipeline = () => {
@@ -250,6 +257,9 @@ export default class PipelineDetailsActionsButton extends Component {
           onTogglePopover={this.togglePopover}
         >
           <ul>
+            {this.props.lifecycleManagementEditEnabled && (
+              <li onClick={this.editConfigAndNavigate}>{T.translate(`${PREFIX}.edit`)}</li>
+            )}
             <li onClick={this.duplicateConfigAndNavigate}>{T.translate(`${PREFIX}.duplicate`)}</li>
             <li onClick={this.handlePipelineExport}>{T.translate(`${PREFIX}.export`)}</li>
             <hr />

--- a/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/index.js
+++ b/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/index.js
@@ -18,6 +18,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import PipelineDetailsActionsButton from 'components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/PipelineDetailsActionsButton';
+import { useFeatureFlagDefaultFalse } from 'services/react/customHooks/useFeatureFlag';
+
 require('./PipelineDetailsDetailsActions.scss');
 
 const mapDetailsStateToProps = (state) => {
@@ -26,10 +28,21 @@ const mapDetailsStateToProps = (state) => {
     description: state.description,
     artifact: state.artifact,
     config: state.config,
+    version: state.version,
   };
 };
 
-const PipelineDetailsDetailsActions = ({ pipelineName, description, artifact, config }) => {
+const PipelineDetailsDetailsActions = ({
+  pipelineName,
+  description,
+  artifact,
+  config,
+  version,
+}) => {
+  const lifecycleManagementEditEnabled = useFeatureFlagDefaultFalse(
+    'lifecycle.management.edit.enabled'
+  );
+
   return (
     <div className="pipeline-details-buttons pipeline-details-details-actions">
       <PipelineDetailsActionsButton
@@ -37,6 +50,8 @@ const PipelineDetailsDetailsActions = ({ pipelineName, description, artifact, co
         description={description}
         artifact={artifact}
         config={config}
+        version={version}
+        lifecycleManagementEditEnabled={lifecycleManagementEditEnabled}
       />
     </div>
   );
@@ -47,6 +62,7 @@ PipelineDetailsDetailsActions.propTypes = {
   description: PropTypes.string,
   artifact: PropTypes.object,
   config: PropTypes.object,
+  version: PropTypes.string,
 };
 
 const ConnectedPipelineDetailsDetailsActions = connect(mapDetailsStateToProps)(

--- a/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/index.js
+++ b/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/index.js
@@ -25,6 +25,7 @@ import PipelineConfigurationsStore, {
 } from 'components/PipelineConfigurations/Store';
 import PlusButton from 'components/shared/PlusButton';
 import { fetchAndUpdateRuntimeArgs } from 'components/PipelineConfigurations/Store/ActionCreator';
+import { FeatureProvider } from 'services/react/providers/featureFlagProvider';
 
 require('./PipelineDetailsTopPanel.scss');
 
@@ -68,14 +69,16 @@ export default class PipelineDetailsTopPanel extends Component {
   }
   render() {
     return (
-      <Provider store={PipelineDetailStore}>
-        <div className="pipeline-details-top-panel">
-          <PipelineDetailsMetadata />
-          <ConnectedPipelineDetailsButtons />
-          <PipelineDetailsDetailsActions />
-          <PlusButton mode={PlusButton.MODE.resourcecenter} />
-        </div>
-      </Provider>
+      <FeatureProvider>
+        <Provider store={PipelineDetailStore}>
+          <div className="pipeline-details-top-panel">
+            <PipelineDetailsMetadata />
+            <ConnectedPipelineDetailsButtons />
+            <PipelineDetailsDetailsActions />
+            <PlusButton mode={PlusButton.MODE.resourcecenter} />
+          </div>
+        </Provider>
+      </FeatureProvider>
     );
   }
 }

--- a/app/cdap/components/PipelineList/DeployedPipelineView/DeployedActions/index.tsx
+++ b/app/cdap/components/PipelineList/DeployedPipelineView/DeployedActions/index.tsx
@@ -19,7 +19,7 @@ import { deletePipeline } from 'components/PipelineList/DeployedPipelineView/sto
 import { Actions } from 'components/PipelineList/DeployedPipelineView/store';
 import { IPipeline } from 'components/PipelineList/DeployedPipelineView/types';
 import ActionsPopover, { IAction } from 'components/shared/ActionsPopover';
-import { duplicatePipeline, getPipelineConfig } from 'services/PipelineUtils';
+import { duplicatePipeline, editPipeline, getPipelineConfig } from 'services/PipelineUtils';
 import PipelineExportModal from 'components/PipelineExportModal';
 import ConfirmationModal from 'components/shared/ConfirmationModal';
 import { connect } from 'react-redux';
@@ -35,6 +35,7 @@ interface IProps {
   deleteError?: string;
   clearDeleteError: () => void;
   refetch: () => void;
+  lifecycleManagementEditEnabled?: boolean;
 }
 
 interface ITriggeredPipeline {
@@ -204,24 +205,47 @@ class DeployedActionsView extends React.PureComponent<IProps, IState> {
     }
   };
 
-  private actions: IAction[] = [
-    {
-      label: T.translate('commons.duplicate'),
-      actionFn: duplicatePipeline.bind(null, this.props.pipeline.name),
-    },
-    {
-      label: T.translate('commons.export'),
-      actionFn: this.handlePipelineExport,
-    },
-    {
-      label: 'separator',
-    },
-    {
-      label: T.translate('commons.delete'),
-      actionFn: this.showDeleteConfirmation,
-      className: 'delete',
-    },
-  ];
+  private actions: IAction[] = this.props.lifecycleManagementEditEnabled
+    ? [
+        {
+          label: T.translate('commons.edit'),
+          actionFn: editPipeline.bind(null, this.props.pipeline.name),
+        },
+        {
+          label: T.translate('commons.duplicate'),
+          actionFn: duplicatePipeline.bind(null, this.props.pipeline.name),
+        },
+        {
+          label: T.translate('commons.export'),
+          actionFn: this.handlePipelineExport,
+        },
+        {
+          label: 'separator',
+        },
+        {
+          label: T.translate('commons.delete'),
+          actionFn: this.showDeleteConfirmation,
+          className: 'delete',
+        },
+      ]
+    : [
+        {
+          label: T.translate('commons.duplicate'),
+          actionFn: duplicatePipeline.bind(null, this.props.pipeline.name),
+        },
+        {
+          label: T.translate('commons.export'),
+          actionFn: this.handlePipelineExport,
+        },
+        {
+          label: 'separator',
+        },
+        {
+          label: T.translate('commons.delete'),
+          actionFn: this.showDeleteConfirmation,
+          className: 'delete',
+        },
+      ];
 
   public render() {
     return (

--- a/app/cdap/components/PipelineList/DeployedPipelineView/PipelineTable/PipelineTableRow.tsx
+++ b/app/cdap/components/PipelineList/DeployedPipelineView/PipelineTable/PipelineTableRow.tsx
@@ -28,6 +28,7 @@ import { IPipeline } from 'components/PipelineList/DeployedPipelineView/types';
 interface IProps {
   pipeline: IPipeline;
   refetch: () => void;
+  lifecycleManagementEditEnabled?: boolean;
 }
 
 const PREFIX = 'features.PipelineList';
@@ -56,7 +57,11 @@ export default class PipelineTableRow extends React.PureComponent<IProps> {
         <NextRun pipeline={pipeline} />
         <RunsCount pipeline={pipeline} />
         <PipelineTags pipeline={pipeline} />
-        <DeployedActions pipeline={pipeline} refetch={this.props.refetch} />
+        <DeployedActions
+          pipeline={pipeline}
+          refetch={this.props.refetch}
+          lifecycleManagementEditEnabled={this.props.lifecycleManagementEditEnabled}
+        />
       </a>
     );
   }

--- a/app/cdap/components/PipelineList/DeployedPipelineView/PipelineTable/index.tsx
+++ b/app/cdap/components/PipelineList/DeployedPipelineView/PipelineTable/index.tsx
@@ -24,6 +24,7 @@ import EmptyMessageContainer from 'components/EmptyMessageContainer';
 import SortableHeader from 'components/PipelineList/DeployedPipelineView/PipelineTable/SortableHeader';
 import If from 'components/shared/If';
 import './PipelineTable.scss';
+import { useFeatureFlagDefaultFalse } from 'services/react/customHooks/useFeatureFlag';
 
 interface IProps {
   pipelines: IPipeline[];
@@ -35,6 +36,10 @@ interface IProps {
 const PREFIX = 'features.PipelineList';
 
 const PipelineTableView: React.SFC<IProps> = ({ pipelines, search, onClear, refetch }) => {
+  const lifecycleManagementEditEnabled = useFeatureFlagDefaultFalse(
+    'lifecycle.management.edit.enabled'
+  );
+
   function renderBody() {
     if (!pipelines || (Array.isArray(pipelines) && pipelines.length === 0)) {
       return (
@@ -56,7 +61,14 @@ const PipelineTableView: React.SFC<IProps> = ({ pipelines, search, onClear, refe
     return (
       <div className="grid-body">
         {pipelines.map((pipeline) => {
-          return <PipelineTableRow key={pipeline.name} pipeline={pipeline} refetch={refetch} />;
+          return (
+            <PipelineTableRow
+              key={pipeline.name}
+              pipeline={pipeline}
+              refetch={refetch}
+              lifecycleManagementEditEnabled={lifecycleManagementEditEnabled}
+            />
+          );
         })}
       </div>
     );

--- a/app/cdap/components/PipelineList/index.tsx
+++ b/app/cdap/components/PipelineList/index.tsx
@@ -26,6 +26,7 @@ import T from 'i18n-react';
 import ErrorBoundary from 'components/shared/ErrorBoundary';
 
 import './PipelineList.scss';
+import { FeatureProvider } from 'services/react/providers/featureFlagProvider';
 
 const PREFIX = 'features.PipelineList';
 
@@ -39,37 +40,39 @@ const PipelineList: React.SFC = () => {
   const pageTitle = `${productName} | ${featureName}`;
 
   return (
-    <div className="pipeline-list-view">
-      <Helmet title={pageTitle} />
-      <h4 className="view-header" data-cy="pipeline-list-view-header">
-        <NavLink exact to={basepath} className="option" activeClassName="active">
-          {T.translate(`${PREFIX}.deployed`)}
-        </NavLink>
+    <FeatureProvider>
+      <div className="pipeline-list-view">
+        <Helmet title={pageTitle} />
+        <h4 className="view-header" data-cy="pipeline-list-view-header">
+          <NavLink exact to={basepath} className="option" activeClassName="active">
+            {T.translate(`${PREFIX}.deployed`)}
+          </NavLink>
 
-        <span className="separator">|</span>
+          <span className="separator">|</span>
 
-        <NavLink exact to={`${basepath}/drafts`} className="option" activeClassName="active">
-          {T.translate(`${PREFIX}.draft`)}
-        </NavLink>
-      </h4>
+          <NavLink exact to={`${basepath}/drafts`} className="option" activeClassName="active">
+            {T.translate(`${PREFIX}.draft`)}
+          </NavLink>
+        </h4>
 
-      <ResourceCenterButton />
+        <ResourceCenterButton />
 
-      <Switch>
-        <Route
-          exact
-          path="/ns/:namespace/pipelines"
-          component={() => {
-            return (
-              <ErrorBoundary>
-                <DeployedPipelineView />
-              </ErrorBoundary>
-            );
-          }}
-        />
-        <Route exact path="/ns/:namespace/pipelines/drafts" component={DraftPipelineView} />
-      </Switch>
-    </div>
+        <Switch>
+          <Route
+            exact
+            path="/ns/:namespace/pipelines"
+            component={() => {
+              return (
+                <ErrorBoundary>
+                  <DeployedPipelineView />
+                </ErrorBoundary>
+              );
+            }}
+          />
+          <Route exact path="/ns/:namespace/pipelines/drafts" component={DraftPipelineView} />
+        </Switch>
+      </div>
+    </FeatureProvider>
   );
 };
 

--- a/app/cdap/components/hydrator/components/LeftPanel/LeftPanel.tsx
+++ b/app/cdap/components/hydrator/components/LeftPanel/LeftPanel.tsx
@@ -14,7 +14,7 @@
  * the License.
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import ChevronLeft from '@material-ui/icons/ChevronLeft';
 import ChevronRight from '@material-ui/icons/ChevronRight';
 import Select from '@material-ui/core/Select';
@@ -34,6 +34,7 @@ interface ILeftPanelProps {
   onPanelItemClick: (event: any, plugin: any) => void;
   toggleSideBar: () => void;
   isSideBarExpanded: boolean;
+  isEdit: boolean;
 }
 
 const StyledSelect = styled(Select)`
@@ -48,6 +49,7 @@ export const LeftPanel = ({
   groups,
   groupGenericName,
   onPanelItemClick,
+  isEdit,
 }: ILeftPanelProps) => {
   // angular has this saved in local storage - is this necessary?
   const [isExpanded, setIsExpanded] = useState<boolean>(true);
@@ -68,6 +70,7 @@ export const LeftPanel = ({
                   horizontal: 'left',
                 },
               }}
+              disabled={isEdit}
             >
               {artifacts.map((artifact) => {
                 return (

--- a/app/cdap/components/hydrator/components/TopPanel/NameAndDescription/index.tsx
+++ b/app/cdap/components/hydrator/components/TopPanel/NameAndDescription/index.tsx
@@ -19,6 +19,7 @@ import {
   ButtonsContainer,
   CustomTooltip,
   DescriptionTextField,
+  EditStatus,
   ErrorTooltip,
   HydratorMetadata,
   MetadataLeft,
@@ -40,6 +41,8 @@ interface INameAndDescriptionProps {
   saveMetadata?: (event: MouseEvent | KeyboardEvent) => void;
   resetMetadata?: (event: MouseEvent | KeyboardEvent) => void;
   openMetadata?: () => void;
+  isEdit?: boolean;
+  editStatus?: string;
 }
 
 export const NameAndDescription = ({
@@ -51,6 +54,8 @@ export const NameAndDescription = ({
   saveMetadata,
   resetMetadata,
   openMetadata,
+  isEdit,
+  editStatus,
 }: INameAndDescriptionProps) => {
   const [name, setName] = useState(state.metadata.name);
   const [description, setDescription] = useState(state.metadata.description);
@@ -79,73 +84,79 @@ export const NameAndDescription = ({
   const NameToolTip = invalidName ? ErrorTooltip : CustomTooltip;
 
   return (
-    <HydratorMetadata
-      expanded={metadataExpanded}
-      data-cy="pipeline-metadata"
-      data-testid="pipeline-metadata"
-    >
-      <PipelineType>
-        {eTLBatch && <StyledIconSVG name="icon-ETLBatch"></StyledIconSVG>}
-        {eTLRealtime && <StyledIconSVG name="icon-ETLRealtime"></StyledIconSVG>}
-        {sparkstreaming && <StyledIconSVG name="icon-sparkstreaming"></StyledIconSVG>}
-      </PipelineType>
-      <MetadataLeft>
-        {metadataExpanded ? (
-          <>
-            <NameTextField
-              id="pipeline-name-input"
-              variant="outlined"
-              placeholder="Name your pipeline"
-              onKeyUp={onEnterOnMetadata}
-              onChange={handleNameChange}
-              value={name}
-            />
-            <DescriptionTextField
-              multiline
-              variant="outlined"
-              rows={2}
-              value={description}
-              placeholder="Enter a description for your pipeline."
-              data-cy="pipeline-description-input"
-              data-testid="pipeline-description-input"
-              onChange={handleDescriptionChange}
-            />
-            <ButtonsContainer>
-              <PrimaryContainedButton
-                onClick={saveMetadata}
-                data-cy="pipeline-metadata-ok-btn"
-                data-testid="pipeline-metadata-ok-btn"
+    <>
+      <HydratorMetadata
+        expanded={metadataExpanded}
+        disabled={isEdit}
+        data-cy="pipeline-metadata"
+        data-testid="pipeline-metadata"
+      >
+        <PipelineType>
+          {eTLBatch && <StyledIconSVG name="icon-ETLBatch"></StyledIconSVG>}
+          {eTLRealtime && <StyledIconSVG name="icon-ETLRealtime"></StyledIconSVG>}
+          {sparkstreaming && <StyledIconSVG name="icon-sparkstreaming"></StyledIconSVG>}
+        </PipelineType>
+        <MetadataLeft>
+          {metadataExpanded ? (
+            <>
+              <NameTextField
+                id="pipeline-name-input"
+                variant="outlined"
+                placeholder="Name your pipeline"
+                onKeyUp={onEnterOnMetadata}
+                onChange={handleNameChange}
+                value={name}
+              />
+              <DescriptionTextField
+                multiline
+                variant="outlined"
+                rows={2}
+                value={description}
+                placeholder="Enter a description for your pipeline."
+                data-cy="pipeline-description-input"
+                data-testid="pipeline-description-input"
+                onChange={handleDescriptionChange}
+              />
+              <ButtonsContainer>
+                <PrimaryContainedButton
+                  onClick={saveMetadata}
+                  data-cy="pipeline-metadata-ok-btn"
+                  data-testid="pipeline-metadata-ok-btn"
+                >
+                  Save
+                </PrimaryContainedButton>
+                <PrimaryContainedButton
+                  color="default"
+                  onClick={resetMetadata}
+                  data-cy="pipeline-metadata-cancel-btn"
+                  data-testid="pipeline-metadata-cancel-btn"
+                >
+                  Cancel
+                </PrimaryContainedButton>
+              </ButtonsContainer>
+            </>
+          ) : (
+            <div onClick={openMetadata} role="button">
+              <NameToolTip
+                title={invalidName ? 'Invalid Name' : name}
+                arrow
+                open={!!invalidName}
+                placement="bottom-start"
               >
-                Save
-              </PrimaryContainedButton>
-              <PrimaryContainedButton
-                color="default"
-                onClick={resetMetadata}
-                data-cy="pipeline-metadata-cancel-btn"
-                data-testid="pipeline-metadata-cancel-btn"
-              >
-                Cancel
-              </PrimaryContainedButton>
-            </ButtonsContainer>
-          </>
-        ) : (
-          <div onClick={openMetadata} role="button">
-            <NameToolTip
-              title={invalidName ? 'Invalid Name' : name}
-              arrow
-              open={!!invalidName}
-              placement="bottom-start"
-            >
-              <PipelineName errorName={!!invalidName}>{name || 'Name your pipeline'}</PipelineName>
-            </NameToolTip>
-            <CustomTooltip title={parsedDescription} arrow placement="bottom-start">
-              <PipelineDescription>
-                {parsedDescription || 'Enter a description for your pipeline'}
-              </PipelineDescription>
-            </CustomTooltip>
-          </div>
-        )}
-      </MetadataLeft>
-    </HydratorMetadata>
+                <PipelineName errorName={!!invalidName}>
+                  {name || 'Name your pipeline'}
+                </PipelineName>
+              </NameToolTip>
+              <CustomTooltip title={parsedDescription} arrow placement="bottom-start">
+                <PipelineDescription>
+                  {parsedDescription || 'Enter a description for your pipeline'}
+                </PipelineDescription>
+              </CustomTooltip>
+            </div>
+          )}
+        </MetadataLeft>
+      </HydratorMetadata>
+      <EditStatus>{editStatus}</EditStatus>
+    </>
   );
 };

--- a/app/cdap/components/hydrator/components/TopPanel/NameAndDescription/styles.ts
+++ b/app/cdap/components/hydrator/components/TopPanel/NameAndDescription/styles.ts
@@ -91,7 +91,7 @@ export const MetadataLeft = styled.div`
 `;
 
 export const HydratorMetadata = styled.div`
-  width: calc(100vw - 805px);
+  width: calc(80vw - 700px);
   flex-wrap: wrap;
   display: flex;
   background-color: transparent;
@@ -107,6 +107,11 @@ export const HydratorMetadata = styled.div`
     width: calc(100% - 70px);
     position: absolute;
     box-shadow: 0 7px 7px rgb(0 0 0 / 10%), 0 19px 59px rgb(0 0 0 / 20%);`}
+
+  ${({ disabled }) =>
+    disabled &&
+    `pointer-events: none;
+    opacity: 0.7;`}
 `;
 
 export const NameTextField = styled(TextField)`
@@ -121,4 +126,13 @@ export const DescriptionTextField = styled(TextField)`
   width: 100%;
   max-width: 100%;
   margin: 12px 0 15px 0;
+`;
+
+export const EditStatus = styled.div`
+  width: calc(20vw - 110px);
+  flex-wrap: wrap;
+  display: flex;
+  background-color: transparent;
+  padding-top: 10px;
+  box-shadow: none;
 `;

--- a/app/cdap/components/shared/Alert/index.js
+++ b/app/cdap/components/shared/Alert/index.js
@@ -39,6 +39,7 @@ export default class Alert extends Component {
     onClose: PropTypes.func,
     type: PropTypes.oneOf(['success', 'error', 'info']),
     canEditPageWhileOpen: PropTypes.bool,
+    actionElements: PropTypes.element,
   };
 
   alertTimeout = null;
@@ -122,6 +123,7 @@ export default class Alert extends Component {
       >
         <div className={this.state.type} data-cy="alert">
           {msgElem}
+          {this.props.actionElements}
           <IconSVG name="icon-close" onClick={this.onClose} dataCy="alert-close" />
         </div>
       </Modal>

--- a/app/cdap/components/shared/ErrorBanner/index.tsx
+++ b/app/cdap/components/shared/ErrorBanner/index.tsx
@@ -22,9 +22,10 @@ interface IErrorProps {
   error: object | string | null;
   onClose?: () => void;
   canEditPageWhileOpen?: boolean;
+  actionElements?: Element;
 }
 
-const ErrorBanner = ({ error, onClose, canEditPageWhileOpen }: IErrorProps) => {
+const ErrorBanner = ({ error, onClose, canEditPageWhileOpen, actionElements }: IErrorProps) => {
   if (!error) {
     return null;
   }
@@ -38,6 +39,7 @@ const ErrorBanner = ({ error, onClose, canEditPageWhileOpen }: IErrorProps) => {
       type="error"
       showAlert={true}
       onClose={onClose}
+      actionElements={actionElements}
       canEditPageWhileOpen={canEditPageWhileOpen}
     />
   );

--- a/app/cdap/services/react/providers/featureFlagProvider.tsx
+++ b/app/cdap/services/react/providers/featureFlagProvider.tsx
@@ -22,6 +22,7 @@ type IStringBoolean = 'true' | 'false';
 export interface IFeatureFlags {
   'replication.transformations.enabled'?: IStringBoolean;
   'pipeline.composite.triggers.enabled'?: IStringBoolean;
+  'lifecycle.management.edit.enabled'?: IStringBoolean;
 }
 
 export const FeatureFlagsContext = createContext(null);

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -1937,6 +1937,12 @@ features:
 
   licenseText: Licensed under the Apache License, Version 2.0
 
+  LifeCycleManagement:
+    errors:
+      noEditChangeError: You have not made any changes to the pipeline, deployment is not allowed.
+      outdatedDraftError: A new version of pipeline "{pipelineName}" has been deployed. 
+        This draft is outdated and please export the draft for manual reconciliation.
+
   LoadingIndicator:
     contactadmin: It could take a few minutes for the system to self-heal.
     defaultMessage: 'Loading...'
@@ -2437,6 +2443,7 @@ features:
       deleteError: There was a problem with the pipeline you were trying to delete
       details: Details
       duplicate: Duplicate
+      edit: Edit
       export: Export
       exportModalTitle: Export pipeline configuration
       run: Run

--- a/app/hydrator/controllers/create/leftpanel-ctrl.js
+++ b/app/hydrator/controllers/create/leftpanel-ctrl.js
@@ -56,6 +56,7 @@ class HydratorPlusPlusLeftPanelCtrl {
     this.availablePluginMap = this.AvailablePluginsStore.getState().plugins.pluginsMap;
     this.onV2ItemClicked = this.onV2ItemClicked.bind(this);
     this.onArtifactChangeV2 = this.onArtifactChangeV2.bind(this);
+    this.isEdit = this.$stateParams.isEdit ? this.$stateParams.isEdit === 'true' : false;
     this.init();
 
     var sub = this.leftpanelStore.subscribe( () => {

--- a/app/hydrator/controllers/create/toppanel-ctrl.js
+++ b/app/hydrator/controllers/create/toppanel-ctrl.js
@@ -110,12 +110,15 @@ class HydratorPlusPlusTopPanelCtrl {
     );
     this.getPostActions = this.getPostActions.bind(this);
     this.applyAndRunPipeline = this.applyAndRunPipeline.bind(this);
+    this.saveChangeSummary = this.saveChangeSummary.bind(this);
     this.applyBatchConfigFromReactStore = this.applyBatchConfigFromReactStore.bind(this);
     this.applyRealtimeConfigFromReactStore = this.applyRealtimeConfigFromReactStore.bind(this);
     this.validatePluginProperties = this.validatePluginProperties.bind(this);
     this.getRuntimeArgumentsV2 = this.getRuntimeArgumentsV2.bind(this);
     this.getStoreConfig = this.getStoreConfig.bind(this);
     this.getScheduleInfo = this.getScheduleInfo.bind(this);
+    this.getConfigForExport = this.getConfigForExport.bind(this);
+    this.getParentVersion = this.getParentVersion.bind(this);
 
     this.setState();
     this.setActiveNodes();
@@ -134,6 +137,7 @@ class HydratorPlusPlusTopPanelCtrl {
     this.showSchedule =
       this.state.artifact.name === this.GLOBALS.etlDataPipeline &&
       themeShowSchedule;
+    this.isEdit = this.$stateParams.isEdit ? this.$stateParams.isEdit === "true" : false;
 
     if ($stateParams.isClone) {
       this.openMetadata();
@@ -305,14 +309,18 @@ class HydratorPlusPlusTopPanelCtrl {
         this.myAlertOnValium.show({
           type: "danger",
           content:
-            typeof err === "object"
-              ? JSON.stringify(err)
-              : "Updating pipeline failed: " + err,
+            typeof err === "object" ? 
+              JSON.stringify(err) : 
+              "Updating pipeline failed: " + err,
         });
       });
     } else {
       applyAndRun.call(this);
     }
+  }
+
+  saveChangeSummary(changeSummary) {
+    this.HydratorPlusPlusConfigStore.setChangeSummary(changeSummary);
   }
 
   applyBatchConfigFromReactStore(
@@ -397,7 +405,15 @@ class HydratorPlusPlusTopPanelCtrl {
   }
 
   getStoreConfig() {
-    return this.HydratorPlusPlusConfigStore.state.config
+    return this.HydratorPlusPlusConfigStore.state.config;
+  }
+
+  getConfigForExport() {
+    return this.HydratorPlusPlusConfigStore.getConfigForExport();
+  }
+
+  getParentVersion() {
+    return this.HydratorPlusPlusConfigStore.getParentVersion();
   }
 
   validatePluginProperties(action, errorCb) {
@@ -555,15 +571,6 @@ class HydratorPlusPlusTopPanelCtrl {
   onClickLogs() {
     this.viewLogs = !this.viewLogs;
   }
-  onSaveDraftV2() {
-    this.HydratorPlusPlusConfigActions.saveAsDraft();
-    this.checkNameError();
-    this.$window.localStorage.setItem('LastDraftId', this.HydratorPlusPlusConfigStore.getDraftId());
-    this.$window.localStorage.setItem('LastPreviewId', this.currentPreviewId);
-  }
-  onClickLogs() {
-    this.viewLogs = !this.viewLogs;
-  }
   checkNameError() {
     let messages = this.consoleStore.getMessages() || [];
     let filteredMessages = messages.filter((message) => {
@@ -576,8 +583,8 @@ class HydratorPlusPlusTopPanelCtrl {
     this.HydratorPlusPlusConfigActions.publishPipeline();
     this.checkNameError();
   }
-  onPublishV2() {
-    this.HydratorPlusPlusConfigActions.publishPipeline();
+  onPublishV2(isEdit = false) {
+    this.HydratorPlusPlusConfigActions.publishPipeline(isEdit);
     this.checkNameError();
   }
   showSettings() {
@@ -1040,13 +1047,6 @@ class HydratorPlusPlusTopPanelCtrl {
 
   toggleConfigV2() {
     this.getRuntimeArguments().then(() => {
-      this.viewConfig = !this.viewConfig;
-    });
-  }
-
-  toggleConfigV2() {
-    this.getRuntimeArguments()
-    .then(() => {
       this.viewConfig = !this.viewConfig;
     });
   }
@@ -1563,5 +1563,5 @@ class HydratorPlusPlusTopPanelCtrl {
   }
 }
 
-angular.module(PKG.name + '.feature.hydrator')
-  .controller('HydratorPlusPlusTopPanelCtrl', HydratorPlusPlusTopPanelCtrl);
+angular.module(PKG.name + ".feature.hydrator")
+  .controller("HydratorPlusPlusTopPanelCtrl", HydratorPlusPlusTopPanelCtrl);

--- a/app/hydrator/routes.js
+++ b/app/hydrator/routes.js
@@ -83,7 +83,7 @@ angular.module(PKG.name + '.feature.hydrator')
         }
       })
         .state('hydrator.create', {
-          url: '/studio?artifactType&draftId&workspaceId&configParams&rulesengineid&resourceCenterId&cloneId',
+          url: '/studio?artifactType&draftId&workspaceId&configParams&rulesengineid&resourceCenterId&cloneId&isEdit',
           onEnter: function() {
             document.title = `${productName} | Studio`;
           },

--- a/app/hydrator/services/create/actions/config-actions.js
+++ b/app/hydrator/services/create/actions/config-actions.js
@@ -82,8 +82,8 @@ class HydratorPlusPlusConfigActions {
   setMaxConcurrentRuns(num) {
     this.dispatcher.dispatch('onSetMaxConcurrentRuns', num);
   }
-  publishPipeline() {
-    this.dispatcher.dispatch('onPublishPipeline');
+  publishPipeline(isEdit) {
+    this.dispatcher.dispatch('onPublishPipeline', isEdit);
   }
 }
 

--- a/app/hydrator/services/create/stores/config-store.js
+++ b/app/hydrator/services/create/stores/config-store.js
@@ -60,6 +60,7 @@ class HydratorPlusPlusConfigStore {
     this.hydratorPlusPlusConfigDispatcher.register('onDeletePostAction', this.deletePostAction.bind(this));
     this.hydratorPlusPlusConfigDispatcher.register('onSetMaxConcurrentRuns', this.setMaxConcurrentRuns.bind(this));
     this.hydratorPlusPlusConfigDispatcher.register('onPublishPipeline', this.publishPipeline.bind(this));
+    this.hydratorPlusPlusConfigDispatcher.register('onSetChangeSummary', this.setChangeSummary.bind(this));
   }
   registerOnChangeListener(callback) {
     // index of the listener to be removed while un-subscribing
@@ -84,6 +85,10 @@ class HydratorPlusPlusConfigStore {
       },
       description: '',
       name: '',
+      changeSummary: {
+        description: '',
+      },
+      parentVersion: '',
     };
     Object.assign(this.state, { config: this.getDefaultConfig() });
 
@@ -202,7 +207,7 @@ class HydratorPlusPlusConfigStore {
           _backendProperties: node._backendProperties,
         },
         information: node.information,
-        outputSchema: node.outputSchema,
+        outputSchema: angular.isArray(node.outputSchema) ? node.outputSchema[0].schema : node.outputSchema,
         inputSchema: node.inputSchema
       };
 
@@ -1118,6 +1123,21 @@ class HydratorPlusPlusConfigStore {
     return this.getState().config.serviceAccountPath;
   }
 
+  setChangeSummary(changeSummaryDesc) {
+    this.state.changeSummary.description = changeSummaryDesc;
+    this.emitChange();
+  }
+  getChangeSummary() {
+    return this.getState().changeSummary.description;
+  }
+
+  setParentVersion(parentVersion) {
+    this.state.parentVersion = parentVersion;
+  }
+  getParentVersion() {
+    return this.getState().parentVersion;
+  }
+
   setForceDynamicExecution(forceDynamicExecution) {
     const keysToClear = [
       window.CaskCommon.PipelineConfigConstants.SPARK_DYNAMIC_ALLOCATION,
@@ -1218,7 +1238,7 @@ class HydratorPlusPlusConfigStore {
         });
   }
 
-  publishPipeline() {
+  publishPipeline(isEdit) {
     this.HydratorPlusPlusConsoleActions.resetMessages();
     let error = this.validateState({
       showConsoleMessage: true
@@ -1308,16 +1328,22 @@ class HydratorPlusPlusConfigStore {
       .list({ namespace: this.$state.params.namespace })
       .$promise
       .then( (apps) => {
-        var appNames = apps.map( (app) => { return app.name; } );
-
-        if (appNames.indexOf(config.name) !== -1) {
-          this.HydratorPlusPlusConsoleActions.addMessage([{
-            type: 'error',
-            content: this.GLOBALS.en.hydrator.studio.error['NAME-ALREADY-EXISTS']
-          }]);
-          this.EventPipe.emit('hideLoadingIcon.immediate');
-        } else {
+        if (isEdit) {
           publish(config.name);
+        } else {
+          var appNames = apps.map( (app) => { return app.name; } );
+          if (appNames.indexOf(config.name) !== -1) {
+            this.HydratorPlusPlusConsoleActions.addMessage([{
+              type: 'error',
+              content: this.GLOBALS.en.hydrator.studio.error['NAME-ALREADY-EXISTS']
+            }]);
+            this.EventPipe.emit('hideLoadingIcon.immediate');
+          } else {
+            // normal deployment does not need these fields
+            delete config.changeSummary;
+            delete config.parentVersion;
+            publish(config.name);
+          }
         }
       });
   }

--- a/app/hydrator/templates/create/reactleftpanel.html
+++ b/app/hydrator/templates/create/reactleftpanel.html
@@ -24,5 +24,6 @@
   item-generic-name="plugins"
   group-generic-name="artifacts"
   on-panel-item-click="HydratorPlusPlusLeftPanelCtrl.onV2ItemClicked"
+  is-edit="HydratorPlusPlusLeftPanelCtrl.isEdit"
 >
 </left-panel-react>

--- a/app/hydrator/templates/create/reacttoppanel.html
+++ b/app/hydrator/templates/create/reacttoppanel.html
@@ -60,4 +60,8 @@
   validate-plugin-properties="HydratorPlusPlusTopPanelCtrl.validatePluginProperties"
   get-runtime-args="HydratorPlusPlusTopPanelCtrl.getRuntimeArgumentsV2"
   get-store-config="HydratorPlusPlusTopPanelCtrl.getStoreConfig"
+  get-config-for-export="HydratorPlusPlusTopPanelCtrl.getConfigForExport"
+  is-edit="HydratorPlusPlusTopPanelCtrl.isEdit"
+  save-change-summary="HydratorPlusPlusTopPanelCtrl.saveChangeSummary"
+  get-parent-version="HydratorPlusPlusTopPanelCtrl.getParentVersion"
 ></top-panel-react>


### PR DESCRIPTION
# [CDAP-19524] LCM Edit page

## Description
* Added edit button to deployed pipeline lists and detail actions button

<img width="1687" alt="image" src="https://user-images.githubusercontent.com/98125204/186277328-58273bc9-08c6-43c4-9619-f246c9aa6f1c.png">
<img width="1672" alt="image" src="https://user-images.githubusercontent.com/98125204/186277359-bbd78b14-d891-44b9-8fd9-4a01f3008fc6.png">

* Disable some elements in edit mode on studio page (WIP)

<img width="558" alt="image" src="https://user-images.githubusercontent.com/98125204/186277460-054bb376-6c54-4d2e-acc3-e9814cbc7f9b.png">

* Add change summary modal on clicking deploy
<img width="1324" alt="image" src="https://user-images.githubusercontent.com/98125204/186732710-1fc9ec3c-657b-4de9-a1fa-188a28f6068b.png">

* Added required new field to request body
![image](https://user-images.githubusercontent.com/98125204/187273665-37c306fe-ca74-4e92-aee3-3bb0fabc343e.png)

* Added error banner if the user try to deploy the pipeline without making any changes
<img width="544" alt="image" src="https://user-images.githubusercontent.com/98125204/188791118-6b6b6332-b8ab-4a4e-9cd4-acd1ae05dbc3.png">

* Added editing status polling in studio
![image](https://user-images.githubusercontent.com/98125204/191125040-fb9d36dd-7ff4-4389-a9e7-fe05bedf073d.png)

* Added manual reconciliation (export and rebase)
![image](https://user-images.githubusercontent.com/98125204/191125196-e518bcca-7f9c-42e7-9f21-c3a99bafbb71.png)




## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19524](https://cdap.atlassian.net/browse/CDAP-19524)





[CDAP-19524]: https://cdap.atlassian.net/browse/CDAP-19524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ