### PR TITLE
[CDAP-19543] create schedule using api

### DIFF
--- a/app/hydrator/services/create/stores/config-store.js
+++ b/app/hydrator/services/create/stores/config-store.js
@@ -1116,6 +1116,26 @@ class HydratorPlusPlusConfigStore {
     this.state.config.maxConcurrentRuns = num;
   }
 
+  getSchedulePayload() {
+    return {
+      'program': {
+        'programName': 'DataPipelineWorkflow',
+        'programType': 'WORKFLOW'
+      },
+      'trigger': {
+        'cronExpression': this.getSchedule(),
+        'type': 'TIME'
+      },
+      'constraints': [
+        {
+          'maxConcurrency': this.getMaxConcurrentRuns(),
+          'type': 'CONCURRENCY',
+          'waitUntilMet': false
+        }
+      ]
+    }
+  }
+
   setServiceAccountPath(path) {
     this.state.config.serviceAccountPath = path;
   }
@@ -1279,7 +1299,18 @@ class HydratorPlusPlusConfigStore {
         ).then(navigateToDetailedView.bind(this, adapterName));
     };
 
-    let removeFromUserDrafts = (adapterName) => {
+    let postDeploymentCleanUp = (adapterName) => {
+      // create schedule only on first deploy
+      if (!isEdit) {
+        this.myPipelineApi.createSchedule(
+          {
+            namespace: this.$state.params.namespace,
+            pipeline: adapterName,
+            scheduleId: this.GLOBALS.defaultScheduleId
+          },
+          this.getSchedulePayload()
+        ).$promise.then(() => {console.log('successfully created schedule')})
+      }
       const draftId = this.getDraftId();
       if (!draftId) {
         return navigateToDetailedView.call(this, adapterName);
@@ -1310,7 +1341,7 @@ class HydratorPlusPlusConfigStore {
       )
       .$promise
       .then(
-        removeFromUserDrafts.bind(this, pipelineName),
+        postDeploymentCleanUp.bind(this, pipelineName),
         (err) => {
           this.EventPipe.emit('hideLoadingIcon.immediate');
           this.HydratorPlusPlusConsoleActions.addMessage([{
@@ -1322,6 +1353,7 @@ class HydratorPlusPlusConfigStore {
     };
 
     var config = this.getConfigForExport();
+    config['app.deploy.update.schedules'] = false
 
     // Checking if Pipeline name already exist
     this.myAppsApi

--- a/app/services/hydrator/my-pipeline-api.js
+++ b/app/services/hydrator/my-pipeline-api.js
@@ -106,6 +106,9 @@ angular.module(PKG.name + '.services')
         saveDraft: myHelpers.getConfig('PUT', 'REQUEST', pipelineAppPath + '/contexts/:context/drafts/:draftId', false),
         getDraft: myHelpers.getConfig('GET', 'REQUEST', pipelineAppPath + '/contexts/:context/drafts/:draftId', false),
         deleteDraft: myHelpers.getConfig('DELETE', 'REQUEST', pipelineAppPath + '/contexts/:context/drafts/:draftId', false),
+
+        // save schedule
+        createSchedule: myHelpers.getConfig('PUT', 'REQUEST', pipelinePath + '/schedules/:scheduleId', false),
       }
     );
   });


### PR DESCRIPTION
# [CDAP-19543] create schedule using api

## Description
Per requirements of life cycle management, we want to remove schedule creation from the deployment api. UI should make an api call to create schedule individually once the pipeline has been created.

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19543](https://cdap.atlassian.net/browse/CDAP-19543)

## Test Plan
manual test works




[CDAP-19543]: https://cdap.atlassian.net/browse/CDAP-19543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ