### PR TITLE
CDAP-19588 Switch toppanel-ctrl polling to prepare for Websocket removal

### DIFF
--- a/app/services/data/my-polling-service.js
+++ b/app/services/data/my-polling-service.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+angular.module(PKG.name + '.services')
+  .factory('MyPollingService', function($rootScope, uuid, $window) {
+    function MyPollingService(scope) {
+      scope = scope || $rootScope.$new();
+
+      if (!(this instanceof MyPollingService)) {
+        return new MyPollingService(scope);
+      }
+
+      this.bindings = {};
+    }
+
+    MyPollingService.prototype.poll = function(pollFn, interval, cb, errorCb) {
+      const self = this;
+      const resource = {
+        pollFn,
+        id: $window.uuid.v4(),
+        interval,
+        timeoutId: null
+      };
+
+      function performPoll() {
+        self.bindings[resource.id].timeoutId = null;
+        pollFn().$promise.then((response) => {
+          cb(response, resource.id);
+
+          if (self.bindings[resource.id]) {
+            const timeoutId = setTimeout(performPoll, self.bindings[resource.id].interval);
+            self.bindings[resource.id].timeoutId = timeoutId;
+          }
+        }, (error) => {
+          errorCb(error, resource.id);
+
+          self.stopPoll(resource.id);
+        });
+      }
+
+      this.bindings[resource.id] = resource;
+
+      performPoll();
+    };
+
+    MyPollingService.prototype.stopPoll = function(resourceId) {
+      if (this.bindings[resourceId]) {
+        clearTimeout(this.bindings[resourceId].timeoutId);
+        delete this.bindings[resourceId];
+      }
+    };
+
+    return MyPollingService;
+  });

--- a/app/services/hydrator/my-pipeline-api.js
+++ b/app/services/hydrator/my-pipeline-api.js
@@ -94,6 +94,7 @@ angular.module(PKG.name + '.services')
 
         // PREVIEW
         runPreview: myHelpers.getConfig('POST', 'REQUEST', '/namespaces/:namespace/previews', false, { suppressErrors: true }),
+        getPreviewStatus: myHelpers.getConfig('GET', 'REQUEST', '/namespaces/:namespace/previews/:previewId/status', false, { suppressErrors: true }),
         stopPreview: myHelpers.getConfig('POST', 'REQUEST', '/namespaces/:namespace/previews/:previewId/stop', false, { suppressErrors: true }),
         getStagePreview: myHelpers.getConfig('POST', 'REQUEST', previewPath + '/:previewId/tracers', false, { suppressErrors: true }),
 


### PR DESCRIPTION
# CDAP-19588 Switch toppanel-ctrl polling to prepare for Websocket removal

## Description
Adds a new polling service for use in Angular network clients. This separates the polling functionality from the Websocket functionality (currently they're tied together in datasource.js).

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [X] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19588](https://cdap.atlassian.net/browse/CDAP-19588)

## Test Plan
Regression test

## Screenshots
N/A


