### PR TITLE
add data-testid tag for plugin properties with toggle switch

### DIFF
--- a/app/cdap/components/AbstractWidget/ToggleSwitchWidget/index.tsx
+++ b/app/cdap/components/AbstractWidget/ToggleSwitchWidget/index.tsx
@@ -52,6 +52,7 @@ const ToggleSwitchWidgetView: React.FC<IToggleToggleSwitchProps> = ({
   disabled,
   classes,
   dataCy,
+  dataTestId,
 }) => {
   const onValue = objectQuery(widgetProps, 'on', 'value') || 'on';
   const offValue = objectQuery(widgetProps, 'off', 'value') || 'off';
@@ -72,6 +73,7 @@ const ToggleSwitchWidgetView: React.FC<IToggleToggleSwitchProps> = ({
         onLabel={onLabel}
         offLabel={offLabel}
         dataCy={dataCy}
+        dataTestId={dataTestId}
       />
     </div>
   );

--- a/app/cdap/components/PushdownConfig/index.tsx
+++ b/app/cdap/components/PushdownConfig/index.tsx
@@ -22,7 +22,6 @@ import { MyPipelineApi } from 'api/pipeline';
 import { fetchPluginWidget } from 'services/PluginUtilities';
 import ConfigurationGroup from 'components/shared/ConfigurationGroup';
 import { objectQuery } from 'services/helpers';
-import ToggleSwitch from 'components/shared/ToggleSwitch';
 import LoadingSVG from 'components/shared/LoadingSVG';
 import VersionStore from 'services/VersionStore';
 import { catchError } from 'rxjs/operators';

--- a/app/cdap/components/shared/ToggleSwitch/index.js
+++ b/app/cdap/components/shared/ToggleSwitch/index.js
@@ -26,6 +26,7 @@ export default function ToggleSwitch({
   onLabel,
   offLabel,
   dataCy = null,
+  dataTestId = null,
 }) {
   return (
     <div className={classnames('toggle-switch-container', { disabled: disabled })}>
@@ -33,6 +34,7 @@ export default function ToggleSwitch({
         className={classnames('toggle-switch', { on: isOn, off: !isOn })}
         onClick={onToggle}
         data-cy={`switch-${dataCy}`}
+        data-testid={`switch-${dataTestId}`}
       >
         <div className="switch-button" />
         <div
@@ -58,4 +60,5 @@ ToggleSwitch.propTypes = {
   onLabel: PropTypes.string,
   offLabel: PropTypes.string,
   dataCy: PropTypes.string,
+  dataTestId: PropTypes.string,
 };


### PR DESCRIPTION
# Add data-testid tag for plugin properties with toggle switch

## Description
This PR adds a `data-testid` tag to plugin properties with toggle switch

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [X] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
N/A

## Test Plan
N/A

## Screenshots
N/A

