### PR TITLE
CDAP-19009 Switch Studio to use HTTP instead of Websockets

### DIFF
--- a/app/hydrator/main.js
+++ b/app/hydrator/main.js
@@ -39,8 +39,8 @@ angular
       ]).name,
       'mgcrea.ngStrap.datepicker',
       'mgcrea.ngStrap.timepicker',
-      
-      'mgcrea.ngStrap.core', 
+
+      'mgcrea.ngStrap.core',
       'mgcrea.ngStrap.helpers.dimensions',
 
       'mgcrea.ngStrap.alert',
@@ -122,55 +122,6 @@ angular
   .run(function(myNamespace) {
     myNamespace.getList();
   })
-  .config(function($provide) {
-
-    $provide.decorator('$http', function($delegate, MyCDAPDataSource) {
-
-
-      function newHttp(config) {
-        var promise,
-            myDataSrc;
-        if (config.options) {
-          // Can/Should make use of my<whatever>Api service in another service.
-          // So in that case the service will not have a scope. Hence the check
-          if (config.params && config.params.scope && angular.isObject(config.params.scope)) {
-            myDataSrc = MyCDAPDataSource(config.params.scope);
-            delete config.params.scope;
-          } else {
-            myDataSrc = MyCDAPDataSource();
-          }
-          // We can use MyCDAPDataSource directly or through $resource'y way.
-          // If we use $resource'y way then we need to make some changes to
-          // the data we get for $resource.
-          config.$isResource = true;
-          switch (config.options.type) {
-            case 'POLL':
-              promise = myDataSrc.poll(config);
-              break;
-            case 'REQUEST':
-              promise = myDataSrc.request(config);
-              break;
-            case 'POLL-STOP':
-              promise = myDataSrc.stopPoll(config);
-              break;
-          }
-          return promise;
-        } else {
-          return $delegate(config);
-        }
-      }
-
-      newHttp.get = $delegate.get;
-      newHttp.delete = $delegate.delete;
-      newHttp.save = $delegate.save;
-      newHttp.query = $delegate.query;
-      newHttp.remove = $delegate.remove;
-      newHttp.post = $delegate.post;
-      newHttp.put = $delegate.put;
-      return newHttp;
-    });
-  })
-
   .config(function($httpProvider) {
     $httpProvider.interceptors.push(function($rootScope, myHelpers) {
       return {

--- a/app/hydrator/main.js
+++ b/app/hydrator/main.js
@@ -232,10 +232,9 @@ angular
    * attached to the <body> tag, mostly responsible for
    *  setting the className based events from $state and caskTheme
    */
-  .controller('BodyCtrl', function ($scope, $cookies, $cookieStore, caskTheme, CASK_THEME_EVENT, $rootScope, $state, $log, MYSOCKET_EVENT, MyCDAPDataSource, MY_CONFIG, MYAUTH_EVENT, EventPipe, myAuth, $window, myAlertOnValium, myLoadingService, myHelpers) {
+  .controller('BodyCtrl', function ($scope, $cookies, $cookieStore, caskTheme, CASK_THEME_EVENT, $rootScope, $state, $log, MYSOCKET_EVENT, MyCDAPDataSource, MY_CONFIG, MYAUTH_EVENT, EventPipe, myAuth, $window, myAlertOnValium, myLoadingService, myHelpers, $http) {
     window.CaskCommon.CDAPHelpers.setupExperiments();
     var activeThemeClass = caskTheme.getClassName();
-    var dataSource = new MyCDAPDataSource($scope);
     getVersion();
     $rootScope.stores = window.ReactStores;
     this.eventEmitter = window.CaskCommon.ee(window.CaskCommon.ee);
@@ -271,17 +270,20 @@ angular
     $scope.copyrightYear = new Date().getFullYear();
 
     function getVersion() {
-      dataSource.request({
-        _cdapPath: '/version'
+      $http({
+        method: 'GET',
+        url: '/api/v3/version'
       })
         .then(function(res) {
-          $scope.version = res.version;
+          var data = res.data;
+
+          $scope.version = data.version;
           $rootScope.cdapVersion = $scope.version;
 
           window.CaskCommon.VersionStore.dispatch({
             type: window.CaskCommon.VersionActions.updateVersion,
             payload: {
-              version: res.version
+              version: data.version
             }
           });
         });

--- a/app/services/app-uploader.js
+++ b/app/services/app-uploader.js
@@ -20,7 +20,7 @@ angular.module(PKG.name + '.services')
 
       for (var i = 0; i < files.length; i++) {
         myFileUploader.upload({
-          path: '/namespaces/' + ($state.params.namespace || namespace) + '/apps',
+          path: '/api/v3/namespaces/' + ($state.params.namespace || namespace) + '/apps',
           file: files[i]
 
         }, {

--- a/app/services/apps/my-apps-api.js
+++ b/app/services/apps/my-apps-api.js
@@ -18,7 +18,7 @@ angular.module(PKG.name + '.services')
   .factory('myAppsApi', function(myCdapUrl, $resource, myAuth, myHelpers) {
 
     var url = myCdapUrl.constructUrl,
-        basePath = '/namespaces/:namespace/apps',
+        basePath = '/api/v3/namespaces/:namespace/apps',
         listPath = basePath,
         detailPath = basePath + '/:appId';
 

--- a/app/services/helpers.js
+++ b/app/services/helpers.js
@@ -208,10 +208,14 @@ angular.module(PKG.name+'.services')
       message = error.data;
     } else if (typeof error.response === 'string') {
       message = error.response;
+    } else if (error.statusText) {
+      message = error.statusText;
     }
 
     if (error.statusCode) {
       errorCode = error.statusCode;
+    } else if(error.status) {
+      errorCode = error.status;
     } else {
       // If we don't know about the error type, showing a 500 level error
       errorCode = 500;

--- a/app/services/hydrator/my-pipeline-api.js
+++ b/app/services/hydrator/my-pipeline-api.js
@@ -17,27 +17,27 @@
 angular.module(PKG.name + '.services')
   .factory('myPipelineApi', function($resource, myHelpers, GLOBALS) {
     var templatePath = '/templates',
-        pipelinePath = '/namespaces/:namespace/apps/:pipeline',
+        pipelinePath = '/api/v3/namespaces/:namespace/apps/:pipeline',
         macrosPath = pipelinePath + '/plugins',
 
-        loadArtifactPath = '/namespaces/:namespace/artifacts/:artifactName',
+        loadArtifactPath = '/api/v3/namespaces/:namespace/artifacts/:artifactName',
         loadArtifactJSON = loadArtifactPath + '/versions/:version/properties',
-        listPath = '/namespaces/:namespace/apps?artifactName=' + GLOBALS.etlBatch + ',' + GLOBALS.etlRealtime + ',' + GLOBALS.etlDataPipeline + ',' + GLOBALS.etlDataStreams,
-        artifactsPath = '/namespaces/:namespace/artifacts?scope=SYSTEM',
-        artifactsBasePath = '/namespaces/:namespace/artifacts',
-        extensionsFetchBase = '/namespaces/:namespace/artifacts/:pipelineType/versions/:version/extensions',
+        listPath = '/api/v3/namespaces/:namespace/apps?artifactName=' + GLOBALS.etlBatch + ',' + GLOBALS.etlRealtime + ',' + GLOBALS.etlDataPipeline + ',' + GLOBALS.etlDataStreams,
+        artifactsPath = '/api/v3/namespaces/:namespace/artifacts?scope=SYSTEM',
+        artifactsBasePath = '/api/v3/namespaces/:namespace/artifacts',
+        extensionsFetchBase = '/api/v3/namespaces/:namespace/artifacts/:pipelineType/versions/:version/extensions',
         pluginFetchBase = extensionsFetchBase + '/:extensionType',
         pluginsFetchPath = pluginFetchBase + '?scope=system',
         extensionsFetchPath = extensionsFetchBase + '?scope=system',
         pluginDetailFetch = pluginFetchBase + '/plugins/:pluginName?scope=system',
         postActionDetailFetch = pluginFetchBase + '/plugins/:pluginName',
-        artifactPropertiesPath = '/namespaces/:namespace/artifacts/:artifactName/versions/:artifactVersion/properties',
-        pluginMethodsPath = '/namespaces/:namespace/artifacts/:artifactName/versions/:version/plugintypes/:pluginType/plugins/:pluginName/methods/:methodName',
-        previewPath = '/namespaces/:namespace/previews',
-        runsCountPath = '/namespaces/:namespace/runcount',
-        latestRuns = '/namespaces/:namespace/runs';
+        artifactPropertiesPath = '/api/v3/namespaces/:namespace/artifacts/:artifactName/versions/:artifactVersion/properties',
+        pluginMethodsPath = '/api/v3/namespaces/:namespace/artifacts/:artifactName/versions/:version/plugintypes/:pluginType/plugins/:pluginName/methods/:methodName',
+        previewPath = '/api/v3/namespaces/:namespace/previews',
+        runsCountPath = '/api/v3/namespaces/:namespace/runcount',
+        latestRuns = '/api/v3/namespaces/:namespace/runs';
 
-    var pipelineAppPath = '/namespaces/system/apps/pipeline/services/studio/methods/v1';
+    var pipelineAppPath = '/api/v3/namespaces/system/apps/pipeline/services/studio/methods/v1';
 
     return $resource(
       '',
@@ -70,7 +70,7 @@ angular.module(PKG.name + '.services')
         fetchPostActionProperties: myHelpers.getConfig('GET', 'REQUEST', postActionDetailFetch, true),
 
         // Batch fetching plugin properties
-        fetchAllPluginsProperties: myHelpers.getConfig('POST', 'REQUEST', '/namespaces/:namespace/artifactproperties', true),
+        fetchAllPluginsProperties: myHelpers.getConfig('POST', 'REQUEST', '/api/v3/namespaces/:namespace/artifactproperties', true),
 
 
         // FIXME: This needs to be replaced with fetching etl-batch & etl-realtime separately.
@@ -93,9 +93,9 @@ angular.module(PKG.name + '.services')
         deletePluginMethod: myHelpers.getConfig('DELETE', 'REQUEST', pluginMethodsPath, false, { suppressErrors: true }),
 
         // PREVIEW
-        runPreview: myHelpers.getConfig('POST', 'REQUEST', '/namespaces/:namespace/previews', false, { suppressErrors: true }),
-        getPreviewStatus: myHelpers.getConfig('GET', 'REQUEST', '/namespaces/:namespace/previews/:previewId/status', false, { suppressErrors: true }),
-        stopPreview: myHelpers.getConfig('POST', 'REQUEST', '/namespaces/:namespace/previews/:previewId/stop', false, { suppressErrors: true }),
+        runPreview: myHelpers.getConfig('POST', 'REQUEST', '/api/v3/namespaces/:namespace/previews', false, { suppressErrors: true }),
+        getPreviewStatus: myHelpers.getConfig('GET', 'REQUEST', '/api/v3/namespaces/:namespace/previews/:previewId/status', false, { suppressErrors: true }),
+        stopPreview: myHelpers.getConfig('POST', 'REQUEST', '/api/v3/namespaces/:namespace/previews/:previewId/stop', false, { suppressErrors: true }),
         getStagePreview: myHelpers.getConfig('POST', 'REQUEST', previewPath + '/:previewId/tracers', false, { suppressErrors: true }),
 
 

--- a/app/services/logsApi/my-preview-logs-api.js
+++ b/app/services/logsApi/my-preview-logs-api.js
@@ -18,7 +18,7 @@ angular.module(PKG.name + '.services')
   .factory('myPreviewLogsApi', function(myCdapUrl, $resource, myAuth, myHelpers) {
 
     var url = myCdapUrl.constructUrl,
-        basepath = '/namespaces/:namespace/previews/:previewId',
+        basepath = '/api/v3/namespaces/:namespace/previews/:previewId',
         logsPath = basepath + '/logs?';
 
     return $resource(

--- a/app/services/namespace.js
+++ b/app/services/namespace.js
@@ -18,8 +18,7 @@ angular.module(PKG.name + '.services')
   .service('myNamespace', function myNamespace($q, MyCDAPDataSource, EventPipe, $http, $rootScope, myAuth, myHelpers, $state) {
 
     this.namespaceList = [];
-    var data = new MyCDAPDataSource(),
-        prom,
+    var prom,
         queryInProgress = null;
 
 
@@ -31,21 +30,22 @@ angular.module(PKG.name + '.services')
       if (!queryInProgress) {
         prom = $q.defer();
         queryInProgress = true;
-        data.request(
+        $http(
           {
-            _cdapPath: '/namespaces',
+            url: '/api/v3/namespaces',
             method: 'GET'
           })
             .then(
               (function(res) {
+                var data = res.data;
 
-                if (!res.length && !$state.includes('admin.**')) {
+                if (!data.length && !$state.includes('admin.**')) {
                   $state.go('unauthorized');
                 }
 
-                this.namespaceList = res;
+                this.namespaceList = data;
                 EventPipe.emit('namespace.update');
-                prom.resolve(res);
+                prom.resolve(data);
                 queryInProgress = null;
               }).bind(this),
               function (err) {

--- a/app/services/preference/my-preference-api.js
+++ b/app/services/preference/my-preference-api.js
@@ -18,7 +18,7 @@ angular.module(PKG.name + '.services')
   .factory('myPreferenceApi', function(myCdapUrl, $resource, myAuth, myHelpers) {
 
     var url = myCdapUrl.constructUrl,
-        basepath = '/namespaces/:namespace';
+        basepath = '/api/v3/namespaces/:namespace';
 
     return $resource(
       url({ _cdapPath: basepath }),


### PR DESCRIPTION
# CDAP-19009 Switch Studio to use HTTP instead of Websockets

## Description
Removes the monkey-patch on `$http` so that HTTP will be used for requests on the Studio page instead of Websockets.

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [X] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19009](https://cdap.atlassian.net/browse/CDAP-19009)

## Test Plan
Regression testing

## Screenshots
N/A


