### PR TITLE
[CDAP-19479] Add editing stage column to deployed pipeline list

### DIFF
--- a/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/PipelineDetailsActionsButton/index.js
+++ b/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/PipelineDetailsActionsButton/index.js
@@ -29,6 +29,8 @@ import { duplicatePipeline, editPipeline } from 'services/PipelineUtils';
 import cloneDeep from 'lodash/cloneDeep';
 import downloadFile from 'services/download-file';
 import { santizeStringForHTMLID } from 'services/helpers';
+import { deleteEditDraft } from 'components/PipelineList/DeployedPipelineView/store/ActionCreator';
+import { DiscardDraftModal } from 'components/shared/DiscardDraftModal';
 require('./PipelineDetailsActionsButton.scss');
 
 const PREFIX = 'features.PipelineDetails.TopPanel';
@@ -65,12 +67,14 @@ export default class PipelineDetailsActionsButton extends Component {
     config: PropTypes.object,
     version: PropTypes.string,
     lifecycleManagementEditEnabled: PropTypes.bool,
+    editDraftId: PropTypes.string,
   };
 
   state = {
     showExportModal: false,
     showDeleteConfirmationModal: false,
     showPopover: false,
+    showDiscardConfirmation: false,
   };
 
   togglePopover = (showPopover = !this.state.showPopover) => {
@@ -98,8 +102,38 @@ export default class PipelineDetailsActionsButton extends Component {
     duplicatePipeline(this.props.pipelineName, sanitizeConfig(this.pipelineConfig));
   };
 
-  editConfigAndNavigate = () => {
-    editPipeline(this.props.pipelineName, sanitizeConfig(this.pipelineConfig));
+  toggleDiscardConfirmation = () => {
+    this.setState({
+      showDiscardConfirmation: !this.state.showDiscardConfirmation,
+    });
+  };
+
+  discardAndStartNewEdit = () => {
+    this.toggleDiscardConfirmation();
+    editPipeline(this.props.pipelineName);
+  };
+
+  handlePipelineEdit = () => {
+    if (!this.props.editDraftId) {
+      editPipeline(this.props.pipelineName, sanitizeConfig(this.pipelineConfig));
+      return;
+    }
+    this.setState({
+      showPopover: false,
+    });
+    this.toggleDiscardConfirmation();
+  };
+
+  continueSameDraft = () => {
+    const link = window.getHydratorUrl({
+      stateName: 'hydrator.create',
+      stateParams: {
+        namespace: getCurrentNamespace(),
+        draftId: this.props.editDraftId,
+        isEdit: true,
+      },
+    });
+    window.location.href = link;
   };
 
   deletePipeline = () => {
@@ -258,7 +292,7 @@ export default class PipelineDetailsActionsButton extends Component {
         >
           <ul>
             {this.props.lifecycleManagementEditEnabled && (
-              <li onClick={this.editConfigAndNavigate}>{T.translate(`${PREFIX}.edit`)}</li>
+              <li onClick={this.handlePipelineEdit}>{T.translate(`${PREFIX}.edit`)}</li>
             )}
             <li onClick={this.duplicateConfigAndNavigate}>{T.translate(`${PREFIX}.duplicate`)}</li>
             <li onClick={this.handlePipelineExport}>{T.translate(`${PREFIX}.export`)}</li>
@@ -274,6 +308,16 @@ export default class PipelineDetailsActionsButton extends Component {
         </Popover>
         {this.renderExportPipelineModal()}
         {this.renderDeleteConfirmationModal()}
+        <DiscardDraftModal
+          isOpen={this.state.showDiscardConfirmation}
+          toggleModal={this.toggleDiscardConfirmation}
+          discardFn={deleteEditDraft.bind(
+            null,
+            this.props.editDraftId,
+            this.discardAndStartNewEdit
+          )}
+          continueFn={this.continueSameDraft}
+        />
       </div>
     );
   }

--- a/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/index.js
+++ b/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/index.js
@@ -29,6 +29,7 @@ const mapDetailsStateToProps = (state) => {
     artifact: state.artifact,
     config: state.config,
     version: state.version,
+    editDraftId: state.editDraftId,
   };
 };
 
@@ -38,6 +39,7 @@ const PipelineDetailsDetailsActions = ({
   artifact,
   config,
   version,
+  editDraftId,
 }) => {
   const lifecycleManagementEditEnabled = useFeatureFlagDefaultFalse(
     'lifecycle.management.edit.enabled'
@@ -52,6 +54,7 @@ const PipelineDetailsDetailsActions = ({
         config={config}
         version={version}
         lifecycleManagementEditEnabled={lifecycleManagementEditEnabled}
+        editDraftId={editDraftId}
       />
     </div>
   );
@@ -63,6 +66,7 @@ PipelineDetailsDetailsActions.propTypes = {
   artifact: PropTypes.object,
   config: PropTypes.object,
   version: PropTypes.string,
+  editDraftId: PropTypes.string,
 };
 
 const ConnectedPipelineDetailsDetailsActions = connect(mapDetailsStateToProps)(

--- a/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/index.js
+++ b/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/index.js
@@ -26,6 +26,7 @@ import PipelineConfigurationsStore, {
 import PlusButton from 'components/shared/PlusButton';
 import { fetchAndUpdateRuntimeArgs } from 'components/PipelineConfigurations/Store/ActionCreator';
 import { FeatureProvider } from 'services/react/providers/featureFlagProvider';
+import { setEditDraftId } from '../store/ActionCreator';
 
 require('./PipelineDetailsTopPanel.scss');
 
@@ -66,6 +67,10 @@ export default class PipelineDetailsTopPanel extends Component {
       payload: { ...pipelineDetailStoreConfig },
     });
     fetchAndUpdateRuntimeArgs();
+    if (window.localStorage.getItem('editDraftId')) {
+      setEditDraftId(window.localStorage.getItem('editDraftId'));
+      window.localStorage.removeItem('editDraftId');
+    }
   }
   render() {
     return (

--- a/app/cdap/components/PipelineDetails/store/ActionCreator.js
+++ b/app/cdap/components/PipelineDetails/store/ActionCreator.js
@@ -369,6 +369,13 @@ const setStopError = (error) => {
   });
 };
 
+const setEditDraftId = (draftId) => {
+  PipelineDetailStore.dispatch({
+    type: ACTIONS.SET_EDIT_DRAFT_ID,
+    payload: { draftId },
+  });
+};
+
 const reset = () => {
   PipelineDetailStore.dispatch({
     type: ACTIONS.RESET,
@@ -414,5 +421,6 @@ export {
   setScheduleError,
   setStopButtonLoading,
   setStopError,
+  setEditDraftId,
   reset,
 };

--- a/app/cdap/components/PipelineDetails/store/index.js
+++ b/app/cdap/components/PipelineDetails/store/index.js
@@ -45,6 +45,9 @@ const ACTIONS = {
   SET_STOP_BUTTON_LOADING: 'SET_STOP_BUTTON_LOADING',
   SET_STOP_ERROR: 'SET_STOP_ERROR',
 
+  // lifecycle management draftid
+  SET_EDIT_DRAFT_ID: 'SET_EDIT_DRAFT_ID',
+
   RESET: 'RESET',
 };
 
@@ -80,6 +83,7 @@ const DEFAULT_PIPELINE_DETAILS = {
   scheduleError: '',
   stopButtonLoading: true,
   stopError: '',
+  editDraftId: null,
 };
 
 const pipelineDetails = (state = DEFAULT_PIPELINE_DETAILS, action = defaultAction) => {
@@ -226,6 +230,11 @@ const pipelineDetails = (state = DEFAULT_PIPELINE_DETAILS, action = defaultActio
       return {
         ...state,
         stopError: action.payload.error,
+      };
+    case ACTIONS.SET_EDIT_DRAFT_ID:
+      return {
+        ...state,
+        editDraftId: action.payload.draftId,
       };
     case ACTIONS.RESET:
       return DEFAULT_PIPELINE_DETAILS;

--- a/app/cdap/components/PipelineList/DeployedPipelineView/DeployedActions/index.tsx
+++ b/app/cdap/components/PipelineList/DeployedPipelineView/DeployedActions/index.tsx
@@ -15,7 +15,10 @@
  */
 
 import * as React from 'react';
-import { deletePipeline } from 'components/PipelineList/DeployedPipelineView/store/ActionCreator';
+import {
+  deleteEditDraft,
+  deletePipeline,
+} from 'components/PipelineList/DeployedPipelineView/store/ActionCreator';
 import { Actions } from 'components/PipelineList/DeployedPipelineView/store';
 import { IPipeline } from 'components/PipelineList/DeployedPipelineView/types';
 import ActionsPopover, { IAction } from 'components/shared/ActionsPopover';
@@ -28,6 +31,7 @@ import { MyScheduleApi } from 'api/schedule';
 import { GLOBALS } from 'services/global-constants';
 import T from 'i18n-react';
 import downloadFile from 'services/download-file';
+import { DiscardDraftModal } from 'components/shared/DiscardDraftModal';
 const PREFIX = 'features.PipelineList.DeleteConfirmation';
 
 interface IProps {
@@ -36,6 +40,7 @@ interface IProps {
   clearDeleteError: () => void;
   refetch: () => void;
   lifecycleManagementEditEnabled?: boolean;
+  draftId: string;
 }
 
 interface ITriggeredPipeline {
@@ -47,6 +52,7 @@ interface IState {
   showDeleteConfirmation: boolean;
   triggeredPipelines: ITriggeredPipeline[];
   showPopover?: boolean;
+  showDiscardConfirmation: boolean;
 }
 
 class DeployedActionsView extends React.PureComponent<IProps, IState> {
@@ -55,6 +61,7 @@ class DeployedActionsView extends React.PureComponent<IProps, IState> {
     showDeleteConfirmation: false,
     triggeredPipelines: [],
     showPopover: false,
+    showDiscardConfirmation: false,
   };
 
   private pipelineConfig = {};
@@ -205,11 +212,45 @@ class DeployedActionsView extends React.PureComponent<IProps, IState> {
     }
   };
 
+  private toggleDiscardConfirmation = () => {
+    this.setState({
+      showDiscardConfirmation: !this.state.showDiscardConfirmation,
+    });
+  };
+
+  private discardAndStartNewEdit = () => {
+    this.toggleDiscardConfirmation();
+    editPipeline(this.props.pipeline.name);
+  };
+
+  private handlePipelineEdit = () => {
+    if (!this.props.draftId) {
+      editPipeline(this.props.pipeline.name);
+      return;
+    }
+    this.setState({
+      showPopover: false,
+    });
+    this.toggleDiscardConfirmation();
+  };
+
+  private continueSameDraft = () => {
+    const link = window.getHydratorUrl({
+      stateName: 'hydrator.create',
+      stateParams: {
+        namespace: getCurrentNamespace(),
+        draftId: this.props.draftId,
+        isEdit: true,
+      },
+    });
+    window.location.href = link;
+  };
+
   private actions: IAction[] = this.props.lifecycleManagementEditEnabled
     ? [
         {
           label: T.translate('commons.edit'),
-          actionFn: editPipeline.bind(null, this.props.pipeline.name),
+          actionFn: this.handlePipelineEdit,
         },
         {
           label: T.translate('commons.duplicate'),
@@ -266,6 +307,12 @@ class DeployedActionsView extends React.PureComponent<IProps, IState> {
         />
 
         {this.renderDeleteConfirmation()}
+        <DiscardDraftModal
+          isOpen={this.state.showDiscardConfirmation}
+          toggleModal={this.toggleDiscardConfirmation}
+          discardFn={deleteEditDraft.bind(null, this.props.draftId, this.discardAndStartNewEdit)}
+          continueFn={this.continueSameDraft}
+        />
       </div>
     );
   }

--- a/app/cdap/components/PipelineList/DeployedPipelineView/PipelineTable/PipelineTableRow.tsx
+++ b/app/cdap/components/PipelineList/DeployedPipelineView/PipelineTable/PipelineTableRow.tsx
@@ -14,7 +14,7 @@
  * the License.
  */
 
-import * as React from 'react';
+import React, { useEffect, useState } from 'react';
 import NextRun from 'components/PipelineList/DeployedPipelineView/NextRun';
 import PipelineTags from 'components/PipelineList/DeployedPipelineView/PipelineTags';
 import { getCurrentNamespace } from 'services/NamespaceStore';
@@ -24,6 +24,7 @@ import LastStart from 'components/PipelineList/DeployedPipelineView/LastStart';
 import RunsCount from 'components/PipelineList/DeployedPipelineView/RunsCount';
 import DeployedActions from 'components/PipelineList/DeployedPipelineView/DeployedActions';
 import { IPipeline } from 'components/PipelineList/DeployedPipelineView/types';
+import { useSelector } from 'react-redux';
 
 interface IProps {
   pipeline: IPipeline;
@@ -33,36 +34,56 @@ interface IProps {
 
 const PREFIX = 'features.PipelineList';
 
-export default class PipelineTableRow extends React.PureComponent<IProps> {
-  public render() {
-    const pipeline = this.props.pipeline;
-    const namespace = getCurrentNamespace();
+export const PipelineTableRow = ({ pipeline, refetch, lifecycleManagementEditEnabled }: IProps) => {
+  const [draftId, setDraftId] = useState(null);
+  const { drafts } = useSelector(({ deployed }) => deployed);
+  const namespace = getCurrentNamespace();
 
-    const pipelineLink = window.getHydratorUrl({
-      stateName: 'hydrator.detail',
-      stateParams: {
-        namespace,
-        pipelineId: pipeline.name,
-      },
-    });
+  const pipelineLink = window.getHydratorUrl({
+    stateName: 'hydrator.detail',
+    stateParams: {
+      namespace,
+      pipelineId: pipeline.name,
+    },
+  });
 
-    return (
-      <a href={pipelineLink} className=" grid-row">
-        <div className="name" title={pipeline.name}>
-          {pipeline.name}
-        </div>
-        <div className="type">{T.translate(`${PREFIX}.${pipeline.artifact.name}`)}</div>
-        <Status pipeline={pipeline} />
-        <LastStart pipeline={pipeline} />
-        <NextRun pipeline={pipeline} />
-        <RunsCount pipeline={pipeline} />
-        <PipelineTags pipeline={pipeline} />
-        <DeployedActions
-          pipeline={pipeline}
-          refetch={this.props.refetch}
-          lifecycleManagementEditEnabled={this.props.lifecycleManagementEditEnabled}
-        />
-      </a>
+  const saveDraftIdToLocalStorage = () => {
+    if (draftId) {
+      window.localStorage.setItem('editDraftId', draftId);
+    }
+  };
+
+  useEffect(() => {
+    const filteredDraft = drafts.filter(
+      (draft) =>
+        draft.name === pipeline.name &&
+        draft.artifact.name === pipeline.artifact.name &&
+        draft.parentVersion
     );
-  }
-}
+    if (filteredDraft.length === 0) {
+      // currently there's no edit draft saved for this pipeline
+      return;
+    }
+    setDraftId(filteredDraft[0].id);
+  }, []);
+
+  return (
+    <a href={pipelineLink} onClick={saveDraftIdToLocalStorage} className="grid-row">
+      <div className="name" title={pipeline.name}>
+        {pipeline.name}
+      </div>
+      <div className="type">{T.translate(`${PREFIX}.${pipeline.artifact.name}`)}</div>
+      <Status pipeline={pipeline} />
+      <LastStart pipeline={pipeline} />
+      <NextRun pipeline={pipeline} />
+      <RunsCount pipeline={pipeline} />
+      <PipelineTags pipeline={pipeline} />
+      <DeployedActions
+        pipeline={pipeline}
+        refetch={refetch}
+        lifecycleManagementEditEnabled={lifecycleManagementEditEnabled}
+        draftId={draftId}
+      />
+    </a>
+  );
+};

--- a/app/cdap/components/PipelineList/DeployedPipelineView/PipelineTable/index.tsx
+++ b/app/cdap/components/PipelineList/DeployedPipelineView/PipelineTable/index.tsx
@@ -15,7 +15,7 @@
  */
 
 import * as React from 'react';
-import PipelineTableRow from 'components/PipelineList/DeployedPipelineView/PipelineTable/PipelineTableRow';
+import { PipelineTableRow } from './PipelineTableRow';
 import { connect } from 'react-redux';
 import T from 'i18n-react';
 import { IPipeline } from 'components/PipelineList/DeployedPipelineView/types';

--- a/app/cdap/components/PipelineList/DeployedPipelineView/index.tsx
+++ b/app/cdap/components/PipelineList/DeployedPipelineView/index.tsx
@@ -15,13 +15,14 @@
  */
 
 import * as React from 'react';
-import { useEffect, useReducer } from 'react';
+import { useEffect } from 'react';
 import PipelineTable from 'components/PipelineList/DeployedPipelineView/PipelineTable';
 import {
   reset,
   setPipelines,
   nextPage,
   prevPage,
+  setDrafts,
 } from 'components/PipelineList/DeployedPipelineView/store/ActionCreator';
 import PipelineCount from 'components/PipelineList/DeployedPipelineView/PipelineCount';
 import SearchBox from 'components/PipelineList/DeployedPipelineView/SearchBox';
@@ -36,13 +37,13 @@ import If from 'components/shared/If';
 import { categorizeGraphQlErrors } from 'services/helpers';
 import ErrorBanner from 'components/shared/ErrorBanner';
 import T from 'i18n-react';
-import { useDebounce } from 'services/react/customHooks/useDebounce';
 
 import './DeployedPipelineView.scss';
 const I18N_PREFIX = 'features.PipelineList.DeployedPipelineView';
 
 import PaginationStepper from 'components/shared/PaginationStepper';
 import styled from 'styled-components';
+import { MyPipelineApi } from 'api/pipeline';
 
 const PaginationContainer = styled.div`
   margin-right: 50px;
@@ -130,6 +131,7 @@ const DeployedPipeline: React.FC = () => {
             id
             time
           }
+          version
         }
         nextPageToken
       }
@@ -158,6 +160,12 @@ const DeployedPipeline: React.FC = () => {
     },
   });
   const bannerMessage = checkError(error);
+
+  useEffect(() => {
+    MyPipelineApi.getDrafts({ context: getCurrentNamespace() }).subscribe((res) => {
+      setDrafts(res);
+    });
+  }, []);
 
   useEffect(() => {
     if (loading || networkStatus === 4) {

--- a/app/cdap/components/PipelineList/DeployedPipelineView/store/ActionCreator.ts
+++ b/app/cdap/components/PipelineList/DeployedPipelineView/store/ActionCreator.ts
@@ -16,15 +16,11 @@
 
 import { getCurrentNamespace } from 'services/NamespaceStore';
 import { MyPipelineApi } from 'api/pipeline';
-import Store, {
-  Actions,
-  SORT_ORDER,
-  IStore,
-} from 'components/PipelineList/DeployedPipelineView/store';
+import Store, { Actions, SORT_ORDER } from 'components/PipelineList/DeployedPipelineView/store';
 import { IPipeline } from 'components/PipelineList/DeployedPipelineView/types';
-import { objectQuery } from 'services/helpers';
-import { PROGRAM_STATUSES, GLOBALS } from 'services/global-constants';
+import { GLOBALS } from 'services/global-constants';
 import debounce from 'lodash/debounce';
+import { IDraft } from 'components/PipelineList/DraftPipelineView/types';
 
 export function deletePipeline(pipeline: IPipeline, refetch: () => void) {
   const namespace = getCurrentNamespace();
@@ -191,4 +187,22 @@ export function setSort(columnName: string) {
     },
   });
   getRunsForPipelines();
+}
+
+export function setDrafts(drafts: IDraft[]) {
+  Store.dispatch({
+    type: Actions.setDrafts,
+    payload: {
+      drafts,
+    },
+  });
+}
+
+export function deleteEditDraft(draftId: string, callbackFn: () => void) {
+  MyPipelineApi.deleteDraft({
+    context: getCurrentNamespace(),
+    draftId,
+  }).subscribe((res) => {
+    callbackFn();
+  });
 }

--- a/app/cdap/components/PipelineList/DeployedPipelineView/store/index.ts
+++ b/app/cdap/components/PipelineList/DeployedPipelineView/store/index.ts
@@ -19,6 +19,7 @@ import { composeEnhancers } from 'services/helpers';
 import { Reducer, Store as StoreInterface } from 'redux';
 import { IAction } from 'services/redux-helpers';
 import { IPipeline } from 'components/PipelineList/DeployedPipelineView/types';
+import { IDraft } from 'components/PipelineList/DraftPipelineView/types';
 
 enum SORT_ORDER {
   asc = 'asc',
@@ -38,6 +39,7 @@ interface IState {
   pageLimit: number;
   pipelines: IPipeline[];
   ready: boolean;
+  drafts: IDraft[];
 }
 
 interface IStore {
@@ -55,6 +57,7 @@ const Actions = {
   reset: 'DEPLOYED_PIPELINE_RESET',
   setPipelines: 'DEPLOYED_PIPELINE_SET_PIPELINES',
   updatePipelines: 'DEPLOYED_PIPELINE_UPDATE_PIPELINES',
+  setDrafts: 'DEPLOYED_PIPELINE_SET_DRAFTS',
 };
 
 const defaultInitialState: IState = {
@@ -70,6 +73,7 @@ const defaultInitialState: IState = {
   pipelines: null,
   hasMultiple: false,
   ready: false,
+  drafts: [],
 };
 
 const deployed: Reducer<IState> = (state = defaultInitialState, action: IAction) => {
@@ -142,6 +146,11 @@ const deployed: Reducer<IState> = (state = defaultInitialState, action: IAction)
       return {
         ...state,
         pipelines: action.payload.pipelines,
+      };
+    case Actions.setDrafts:
+      return {
+        ...state,
+        drafts: action.payload.drafts,
       };
     case Actions.reset:
       return defaultInitialState;

--- a/app/cdap/components/PipelineList/DeployedPipelineView/types.ts
+++ b/app/cdap/components/PipelineList/DeployedPipelineView/types.ts
@@ -28,4 +28,5 @@ export interface IPipeline {
     id: string;
     time: string;
   };
+  version?: string;
 }

--- a/app/cdap/components/PipelineList/DraftPipelineView/DraftTable/DraftTable.scss
+++ b/app/cdap/components/PipelineList/DraftPipelineView/DraftTable/DraftTable.scss
@@ -21,6 +21,7 @@ $table-bg-color: $grey-08;
 $row-hover-color: white;
 $row-color: $grey-01;
 
+$status-width: 20%;
 $type-width: 20%;
 $last-saved-width: 20%;
 $action-width: 60px;
@@ -51,7 +52,7 @@ $action-width: 60px;
     }
 
     .grid-row {
-      grid-template-columns: 1fr $type-width $last-saved-width $action-width;
+      grid-template-columns: 1fr $status-width $type-width $last-saved-width $action-width;
 
       > div {
         padding-top: 5px;

--- a/app/cdap/components/PipelineList/DraftPipelineView/DraftTable/DraftTableRow.tsx
+++ b/app/cdap/components/PipelineList/DraftPipelineView/DraftTable/DraftTableRow.tsx
@@ -20,6 +20,9 @@ import { getCurrentNamespace } from 'services/NamespaceStore';
 import { humanReadableDate } from 'services/helpers';
 import DraftActions from 'components/PipelineList/DraftPipelineView/DraftActions';
 import { IDraft } from 'components/PipelineList/DraftPipelineView/types';
+import { useEffect, useState } from 'react';
+import { MyPipelineApi } from 'api/pipeline';
+import { useFeatureFlagDefaultFalse } from 'services/react/customHooks/useFeatureFlag';
 
 interface IProps {
   draft: IDraft;
@@ -27,31 +30,64 @@ interface IProps {
 
 const PREFIX = 'features.PipelineList';
 
-export default class DraftTableRow extends React.PureComponent<IProps> {
-  public render() {
-    const draft = this.props.draft;
-    const namespace = getCurrentNamespace();
-    const lastSaved = humanReadableDate(
-      draft.needsUpgrade ? draft.__ui__.lastSaved : draft.updatedTimeMillis,
-      true
-    );
+export const DraftTableRow = ({ draft }: IProps) => {
+  const lifecycleManagementEditEnabled = useFeatureFlagDefaultFalse(
+    'lifecycle.management.edit.enabled'
+  );
+  const [editStageMessage, setEditStageMessage] = useState('--');
 
-    const link = window.getHydratorUrl({
-      stateName: 'hydrator.create',
-      stateParams: {
-        namespace,
-        draftId: draft.needsUpgrade ? draft.__ui__.draftId : draft.id,
-      },
-    });
+  const namespace = getCurrentNamespace();
+  const lastSaved = humanReadableDate(
+    draft.needsUpgrade ? draft.__ui__.lastSaved : draft.updatedTimeMillis,
+    true
+  );
 
-    return (
-      <a href={link} className="grid-row" data-cy={`draft-${draft.name}`}>
-        <div title={draft.name}>{draft.name}</div>
-        <div>{T.translate(`${PREFIX}.${draft.artifact.name}`)}</div>
-        <div>{lastSaved}</div>
+  const stateParams = {
+    namespace,
+    draftId: draft.needsUpgrade ? draft.__ui__.draftId : draft.id,
+  };
 
-        <DraftActions draft={this.props.draft} />
-      </a>
-    );
+  if (draft.parentVersion) {
+    Object.assign(stateParams, { isEdit: true });
   }
-}
+
+  const link = window.getHydratorUrl({
+    stateName: 'hydrator.create',
+    stateParams,
+  });
+
+  useEffect(() => {
+    if (draft.parentVersion) {
+      // check the status of the draft
+      const params = {
+        namespace: getCurrentNamespace(),
+        appId: draft.name,
+      };
+      MyPipelineApi.get(params).subscribe(
+        (res) => {
+          if (res.appVersion === draft.parentVersion) {
+            // draft parentVersion is the same as the latest appVersion
+            setEditStageMessage('In-Progress');
+          } else {
+            setEditStageMessage('Obsolete');
+          }
+        },
+        (err) => {
+          // Draft's corresponding pipeline is deleted/missing
+          setEditStageMessage('Orphaned');
+        }
+      );
+    }
+  }, []);
+
+  return (
+    <a href={link} className="grid-row" data-cy={`draft-${draft.name}`}>
+      <div title={draft.name}>{draft.name}</div>
+      {lifecycleManagementEditEnabled ? <div>{editStageMessage}</div> : <div></div>}
+      <div>{T.translate(`${PREFIX}.${draft.artifact.name}`)}</div>
+      <div>{lastSaved}</div>
+
+      <DraftActions draft={draft} />
+    </a>
+  );
+};

--- a/app/cdap/components/PipelineList/DraftPipelineView/DraftTable/index.tsx
+++ b/app/cdap/components/PipelineList/DraftPipelineView/DraftTable/index.tsx
@@ -15,12 +15,13 @@
  */
 
 import * as React from 'react';
-import DraftTableRow from 'components/PipelineList/DraftPipelineView/DraftTable/DraftTableRow';
+import { DraftTableRow } from './DraftTableRow';
 import { connect } from 'react-redux';
 import { IDraft } from 'components/PipelineList/DraftPipelineView/types';
 import EmptyList, { VIEW_TYPES } from 'components/PipelineList/EmptyList';
 import SortableHeader from 'components/PipelineList/DraftPipelineView/DraftTable/SortableHeader';
-import If from 'components/shared/If';
+import { useFeatureFlagDefaultFalse } from 'services/react/customHooks/useFeatureFlag';
+import T from 'i18n-react';
 
 interface IProps {
   drafts: IDraft[];
@@ -30,7 +31,13 @@ interface IProps {
 
 require('./DraftTable.scss');
 
+const PREFIX = 'features.PipelineList';
+
 const DraftTableView: React.SFC<IProps> = ({ drafts, currentPage, pageLimit }) => {
+  const lifecycleManagementEditEnabled = useFeatureFlagDefaultFalse(
+    'lifecycle.management.edit.enabled'
+  );
+
   function renderBody() {
     if (drafts.length === 0) {
       return <EmptyList type={VIEW_TYPES.draft} />;
@@ -55,16 +62,21 @@ const DraftTableView: React.SFC<IProps> = ({ drafts, currentPage, pageLimit }) =
   return (
     <div className="draft-table grid-wrapper" data-cy="draft-pipeline-table">
       <div className="grid grid-container">
-        <If condition={drafts && drafts.length > 0}>
+        {drafts && drafts.length > 0 && (
           <div className="grid-header">
             <div className="grid-row">
               <SortableHeader columnName="name" />
+              {lifecycleManagementEditEnabled ? (
+                <strong>{T.translate(`${PREFIX}.editStatus`)}</strong>
+              ) : (
+                <strong></strong>
+              )}
               <SortableHeader columnName="type" />
               <SortableHeader columnName="lastSaved" />
               <strong />
             </div>
           </div>
-        </If>
+        )}
         {renderBody()}
       </div>
     </div>

--- a/app/cdap/components/PipelineList/DraftPipelineView/types.ts
+++ b/app/cdap/components/PipelineList/DraftPipelineView/types.ts
@@ -30,4 +30,5 @@ export interface IDraft {
   description?: string;
   config?: any;
   needsUpgrade?: boolean;
+  parentVersion?: string;
 }

--- a/app/cdap/components/PipelineTriggers/EnabledTriggersTab/EnabledCompositeTriggerRow.tsx
+++ b/app/cdap/components/PipelineTriggers/EnabledTriggersTab/EnabledCompositeTriggerRow.tsx
@@ -133,6 +133,7 @@ const EnabledCompositeTriggerRowView = ({
           confirmButtonText={T.translate(`${TRIGGER_PREFIX}.EnabledTriggers.deleteConfirm`)}
           confirmFn={handleConfirmModal}
           cancelFn={handleConfirmModalClose}
+          toggleModal={handleConfirmModalClose}
           isOpen={showDeleteModal}
           errorMessage={disableError}
           isLoading={loading}

--- a/app/cdap/components/shared/ConfirmationModal/index.js
+++ b/app/cdap/components/shared/ConfirmationModal/index.js
@@ -153,7 +153,7 @@ export default class ConfirmationModal extends Component {
         <ModalHeader>
           {this.props.headerTitle}
           <If condition={this.props.closeable}>
-            <div className="close-section float-right" onClick={this.props.cancelFn}>
+            <div className="close-section float-right" onClick={this.props.toggleModal}>
               <IconSVG name="icon-close" />
             </div>
           </If>

--- a/app/cdap/components/shared/DiscardDraftModal/index.tsx
+++ b/app/cdap/components/shared/DiscardDraftModal/index.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React from 'react';
+import ConfirmationModal from '../ConfirmationModal';
+import T from 'i18n-react';
+
+const PREFIX = 'features.LifeCycleManagement';
+
+interface IDiscardDraftModalProps {
+  isOpen: boolean;
+  continueFn: () => void;
+  toggleModal: () => void;
+  discardFn: () => void;
+}
+
+export const DiscardDraftModal = ({
+  isOpen,
+  continueFn,
+  toggleModal,
+  discardFn,
+}: IDiscardDraftModalProps) => {
+  return (
+    <ConfirmationModal
+      headerTitle="Edit draft exists"
+      isOpen={isOpen}
+      cancelFn={continueFn}
+      cancelButtonText="Continue"
+      confirmButtonText="Discard"
+      toggleModal={toggleModal}
+      confirmationElem={T.translate(`${PREFIX}.discardModalText`)}
+      confirmFn={discardFn}
+      closeable={true}
+    />
+  );
+};

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -1938,6 +1938,8 @@ features:
   licenseText: Licensed under the Apache License, Version 2.0
 
   LifeCycleManagement:
+    discardModalText: An edit draft exists for this pipeline. Click 'Discard' to discard the changes
+      that were made and start a new draft. Click 'Continue' to continue editing the existing draft.
     errors:
       noEditChangeError: You have not made any changes to the pipeline, deployment is not allowed.
       outdatedDraftError: A new version of pipeline "{pipelineName}" has been deployed. 
@@ -2489,6 +2491,7 @@ features:
         1: "{context} pipeline you saved"
         _: "{context} pipelines you saved"
     duration: Duration
+    editStatus: Status
     EmptyList:
       actionTitle: "You can try to:"
       aPipeline: a pipeline


### PR DESCRIPTION
# [CDAP-19479] Add editing stage column to pipeline draft list

## Description
* When there's no draft saved
<img width="768" alt="image" src="https://user-images.githubusercontent.com/98125204/191671894-06a55b2c-f97e-4b56-8a3a-5c0b60c736b7.png">
* When there's a draft
<img width="746" alt="image" src="https://user-images.githubusercontent.com/98125204/191672050-276402de-2cde-45dc-a4c5-5871ab7c1709.png">
* When draft is outdated
<img width="732" alt="image" src="https://user-images.githubusercontent.com/98125204/191672736-45e42b18-fe8a-40f8-bc8e-75ff3c3acb9f.png">
* When there's a draft and the user click edit
<img width="750" alt="image" src="https://user-images.githubusercontent.com/98125204/191673134-b4deb8d1-6aca-4dfd-91ec-0e13e42bff2a.png">



## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19479](https://cdap.atlassian.net/browse/CDAP-19479)




[CDAP-19479]: https://cdap.atlassian.net/browse/CDAP-19479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ