### PR TITLE
CDAP-19559 Add deprecated messaging to Checkpointing for streaming pipelines

### DIFF
--- a/app/cdap/components/DataPrep/Directives/Parse/Modals/CSVModal.js
+++ b/app/cdap/components/DataPrep/Directives/Parse/Modals/CSVModal.js
@@ -21,7 +21,7 @@ import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 import classnames from 'classnames';
 import T from 'i18n-react';
 import MouseTrap from 'mousetrap';
-import WarningIcon from '@material-ui/icons/Warning';
+import DeprecatedMessage from 'components/shared/DeprecatedMessage';
 
 const PREFIX = 'features.DataPrep.Directives.Parse';
 
@@ -153,10 +153,7 @@ export default class CSVModal extends Component {
                   'fa-check-square': this.state.firstRowHeader,
                 })}
               />
-              <span className="deprecated-warning">
-                <WarningIcon size="small" />
-                [{T.translate(`${PREFIX}.Parsers.CSV.deprecatedWarning`)}]
-              </span>
+              <DeprecatedMessage />
               <span>{T.translate(`${PREFIX}.Parsers.CSV.firstRowHeader`)}</span>
             </span>
           </div>

--- a/app/cdap/components/PipelineConfigurations/ConfigurationsContent/EngineConfigTabContent/index.js
+++ b/app/cdap/components/PipelineConfigurations/ConfigurationsContent/EngineConfigTabContent/index.js
@@ -27,10 +27,10 @@ import CustomConfig from 'components/PipelineConfigurations/ConfigurationsConten
 import { connect } from 'react-redux';
 import T from 'i18n-react';
 import classnames from 'classnames';
-import WarningIcon from '@material-ui/icons/Warning';
 import { GLOBALS } from 'services/global-constants';
 import { Theme } from 'services/ThemeHelper';
 import SelectWithOptions from 'components/shared/SelectWithOptions';
+import DeprecatedMessage from 'components/shared/DeprecatedMessage';
 
 require('./EngineConfigTabContent.scss');
 
@@ -78,10 +78,7 @@ class EngineConfigTabContent extends Component {
           </label>
           <label className="radio-inline radio-mapReduce">
             <EngineRadioInput value={ENGINE_OPTIONS.MAPREDUCE} />
-            <WarningIcon fontSize="inherit" />
-            <span className="deprecated-warning">
-              [{T.translate(`${PREFIX}.mapreduce.deprecated`)}]
-            </span>
+            <DeprecatedMessage />
             {T.translate('commons.entity.mapreduce.singular')}
           </label>
         </div>

--- a/app/cdap/components/PipelineConfigurations/ConfigurationsContent/PipelineConfigTabContent/Checkpointing.js
+++ b/app/cdap/components/PipelineConfigurations/ConfigurationsContent/PipelineConfigTabContent/Checkpointing.js
@@ -21,6 +21,7 @@ import IconSVG from 'components/shared/IconSVG';
 import ToggleSwitch from 'components/shared/ToggleSwitch';
 import Popover from 'components/shared/Popover';
 import { ACTIONS as PipelineConfigurationsActions } from 'components/PipelineConfigurations/Store';
+import DeprecatedMessage from 'components/shared/DeprecatedMessage';
 import T from 'i18n-react';
 
 const PREFIX = 'features.PipelineConfigurations.PipelineConfig';
@@ -54,7 +55,10 @@ const mapDispatchToCheckpointingProps = (dispatch) => {
 const Checkpointing = ({ disableCheckpoints, checkpointDir, onToggle, onCheckpointDirChange }) => {
   const checkpointDirComponent = (
     <div className="label-with-toggle row">
-      <span className="toggle-label col-4">{T.translate(`${PREFIX}.checkpointDir`)}</span>
+      <span className="toggle-label col-4">
+        <DeprecatedMessage />
+        {T.translate(`${PREFIX}.checkpointDir`)}
+      </span>
       <div className="col-7">
         <input
           type="text"
@@ -69,7 +73,10 @@ const Checkpointing = ({ disableCheckpoints, checkpointDir, onToggle, onCheckpoi
   return (
     <React.Fragment>
       <div className="label-with-toggle checkpointing row">
-        <span className="toggle-label col-4">{T.translate(`${PREFIX}.checkpointing`)}</span>
+        <span className="toggle-label col-4">
+          <DeprecatedMessage />
+          {T.translate(`${PREFIX}.checkpointing`)}
+        </span>
         <div className="col-7 toggle-container">
           <ToggleSwitch
             isOn={!disableCheckpoints}

--- a/app/cdap/components/shared/DeprecatedMessage/index.tsx
+++ b/app/cdap/components/shared/DeprecatedMessage/index.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React from 'react';
+import WarningIcon from '@material-ui/icons/Warning';
+import styled from 'styled-components';
+import T from 'i18n-react';
+
+const DeprecatedTextContent = styled.span`
+  font-weight: bold;
+  padding: 0 0.25em;
+`;
+
+const DepcrecatedMessage = () => {
+  return (
+    <>
+      <WarningIcon fontSize="inherit" />
+      <DeprecatedTextContent>[{T.translate('commons.deprecated')}]</DeprecatedTextContent>
+    </>
+  );
+};
+
+export default DepcrecatedMessage;

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -10,6 +10,7 @@ commons:
   clickhere: click here
   close: Close
   delete: Delete
+  deprecated: Deprecated
   descriptionLabel: Description
   doneLabel: Done
   duplicate: Duplicate
@@ -194,7 +195,7 @@ features:
         allocation: Allocation
       NewRequests:
         newRequestsHeader: New requests
-        noNewRequests: There are no new requests 
+        noNewRequests: There are no new requests
       CreateRequest:
         createRequestButton: CREATE NEW REQUEST
         headerTitle: Create new tethering request
@@ -209,7 +210,7 @@ features:
           title: Tethered Namespaces
           description: Select the namespaces that will be tethered to the cloud instance
           noNamespaces: There are no available namespaces
-          Name: 
+          Name:
             name: namespace
             label: Name
           CpuLimit:
@@ -220,7 +221,7 @@ features:
             label: Memory (GB)
         CDFInformation:
           title: CDF Information
-          ProjectName: 
+          ProjectName:
             name: projectName
             label: Project Name
             placeholder: Specify the Google Cloud project name
@@ -2295,11 +2296,11 @@ features:
       status: Status
       close: Close
       loading: Loading
-  ApiError:    
+  ApiError:
     CmekError:
       mainTitle: CMEK Key Revoked
       secondaryTitle: Instance is unusable because the CMEK key for this instance has been revoked.
-      suggestionPart1: View the  
+      suggestionPart1: View the
       suggestionPart2: troubleshooting
       suggestionPart3: page
   Pagination:


### PR DESCRIPTION
# CDAP-19559 Add deprecated messaging to Checkpointing for streaming pipelines

## Description
Makrs "Checkpointing" toggle and "Checkpoint directory" as deprecated. Also refactors the deprecated message to be reusable, since the same style message is now used in 3 places.

## PR Type
- [ ] Bug Fix
- [X] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19559](https://cdap.atlassian.net/browse/CDAP-19559)

## Test Plan
Manually verify

## Screenshots
![image](https://user-images.githubusercontent.com/2728821/191863320-abbe35f2-5331-4f4b-8063-431d4447ba6c.png)

I'm not crazy about splitting "Checkpoint directory" onto 2 lines, but don't have a good alternative.

