### PR TITLE
Add ability to add external links from the site.xml

### DIFF
--- a/app/cdap/components/shared/AppHeader/AppToolBar/AppToolbarMenu.tsx
+++ b/app/cdap/components/shared/AppHeader/AppToolBar/AppToolbarMenu.tsx
@@ -137,12 +137,8 @@ class AppToolbarMenu extends React.Component<IAppToolbarMenuProps, IAppToolbarSt
     const { classes } = this.props;
     const cdapVersion = VersionStore.getState().version;
     let builtSettingsUrls;
-    const settingsUrls = objectQuery(
-      window.CDAP_CONFIG.cdap.ui,
-      'settings',
-      'cogMenu',
-      'externalLinks'
-    );
+    const settingsUrls = objectQuery(window.CDAP_CONFIG.cdap.ui, 'externalLinks');
+
     if (settingsUrls && typeof settingsUrls === 'object') {
       builtSettingsUrls = Object.entries<string>(settingsUrls).map(([displayName, url]) => {
         return (

--- a/app/hydrator/main.js
+++ b/app/hydrator/main.js
@@ -364,5 +364,5 @@ angular
         <auth-refresher></auth-refresher>
         <api-error-dialog ng-if="BodyCtrl.apiError"></api-error-dialog>
       `
-    }
+    };
   });

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "dev": "concurrently \"yarn start\" \"gulp watch\" \"yarn cdap-dev-build-w\" \"yarn build-dev-common-w\"",
-    "prestart": "yarn run build-server",
-    "start": "NODE_ENV=development node ./packaged/server_dist/index.js",
+    "start": "yarn run build-server && NODE_ENV=development node ./packaged/server_dist/index.js",
     "cdap-prod-build": "NODE_ENV=production parallel-webpack",
     "cdap-dev-build": "NODE_ENV=development parallel-webpack --config=webpack.config.js -d",
     "cdap-dev-build-w": "NODE_ENV=development parallel-webpack --watch -d ",

--- a/server.js
+++ b/server.js
@@ -69,6 +69,7 @@ async function setAllowedOrigin() {
 
   // take exact domain as-is from config
   const whitelistedOrigin = cdapConfig['dashboard.origin'];
+
   allowedOrigin = [getFullURL(nodejsserver)];
   try {
     hostname = await getHostName();
@@ -96,20 +97,43 @@ async function setAllowedOrigin() {
 log.info('Starting CDAP UI ...');
 getCDAPConfig()
   .then(function(c) {
-    // extract feature flags from the config with shorter keys to make it easier
-    // to consume
+    /**
+     * In order for the sandbox to refresh the conf/cdap-config.json you need
+     * to run 'cdap config-tool --cdap' in the sandbox folder.
+     *
+     * In order to simulate what is created there, you need to edit
+     * server/config/development and add whatever config piece you want there.
+     *
+     * You also need to edit the get /config route inside of express.js if you
+     * want your new config to be returned to the ui.
+     */
+
+    // extract feature flags from the config with shorter keys to make it
+    // easier to consume
     const featureFlags = {};
+    // extract external links to be placed in cog menu of the app toolbar
+    const externalLinks = {};
     for (const [key, value] of Object.entries(c)) {
       if (key.match(/^feature/)) {
-        // feature. is 8 characters and we only want to include
-        // feature flags
+        // feature. is 8 characters and we only want to include feature flags
         featureFlags[key.substring(8)] = value;
+        delete c[key];
+      }
+
+      if (key.match(/uiExternalLinks/)) {
+        /**
+         * uiExternalLinks is 15 characters so remove uiExternalLinks.
+         * the format for external links inside of the config is uiExternalLinks.link
+         * and the value is the url it should link to
+         */
+        externalLinks[key.substring(16)] = value;
         delete c[key];
       }
     }
 
     cdapConfig = c;
     cdapConfig.featureFlags = featureFlags;
+    cdapConfig.externalLinks = externalLinks;
     if (cdapConfig['security.enabled'] === 'true') {
       log.debug('CDAP Security has been enabled');
       return extractConfig('security');
@@ -231,7 +255,7 @@ getCDAPConfig()
     function gracefulShutdown() {
       log.info('Caught SIGTERM. Closing http & ws server');
       server.close();
-      if(typeof wsConnections === 'object' && Object.keys(wsConnections).length) {
+      if (typeof wsConnections === 'object' && Object.keys(wsConnections).length) {
         log.debug(`Closing ${Object.keys(wsConnections).length} open websocket connections`)
         Object.values(wsConnections).forEach((connection) => {
           log.debug('Ending and destroying all graceful shutdown: ' + connection.readyState);

--- a/server/config/ui-settings.json
+++ b/server/config/ui-settings.json
@@ -1,12 +1,6 @@
 {
   "standalone.website.sdk.download": "true",
   "ui": {
-    "debug.enabled": "false",
-    "settings": {
-      "cogMenu": {
-        "externalLinks": {
-        }
-      }
-    }
+    "debug.enabled": "false"
   }
 }


### PR DESCRIPTION
# Add external Links to the cog menu on the main app bar

## Description
Changed server to allow for external links for the app menu bar as long as you use the correct property in the site.xml:
```
    <property>
    <name>uiExternalLinks.neato</name>
    <value>burrito.com</value>
    <description>
      Cool external link!
    </description>
  </property>
  ```

The script `prestart` is deprecated in newer versions of yarn so changed yarn start to reflect that.
Fixed eslint errors inside express.js

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick



