### PR TITLE
Analytics - enables optional google analytics tracking in the ui

### DIFF
--- a/app/cdap/cdap.html
+++ b/app/cdap/cdap.html
@@ -28,6 +28,7 @@
 </head>
 <body class="cdap-body-container">
   <div id="app-container"></div>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/analytics.js"></script>
   <script type="text/javascript" nonce="<_= nonceVal _>" src="/config.js"></script>
   <script type="text/javascript" nonce="<_= nonceVal _>" src="/ui-config.js"></script>
   <script type="text/javascript" nonce="<_= nonceVal _>" src="/ui-theme.js"></script>

--- a/app/hydrator/hydrator.html
+++ b/app/hydrator/hydrator.html
@@ -38,6 +38,7 @@
     
   </div>
 
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/analytics.js"></script>
   <script type="text/javascript" nonce="<_= nonceVal _>" src="/config.js"></script>
   <script type="text/javascript" nonce="<_= nonceVal _>" src="/ui-config.js"></script>
   <script type="text/javascript" nonce="<_= nonceVal _>" src="/ui-theme.js"></script>

--- a/server.js
+++ b/server.js
@@ -120,13 +120,13 @@ getCDAPConfig()
         delete c[key];
       }
 
-      if (key.match(/uiExternalLinks/)) {
+      if (key.match(/ui.externalLinks/)) {
         /**
-         * uiExternalLinks is 15 characters so remove uiExternalLinks.
-         * the format for external links inside of the config is uiExternalLinks.link
+         * ui.externalLinks is 15 characters so remove ui.ui.ExternalLinks.
+         * the format for external links inside of the config is ui.externalLinks.link
          * and the value is the url it should link to
          */
-        externalLinks[key.substring(16)] = value;
+        externalLinks[key.substring(17)] = value;
         delete c[key];
       }
     }

--- a/server/express.js
+++ b/server/express.js
@@ -194,7 +194,7 @@ function makeApp(authAddress, cdapConfig, uiSettings) {
     const aTag = cdapConfig['ui.analyticsTag'];
     if (aTag) {
       res.header({
-        'Content-Type': 'text/javascript',
+        'Content-Type': 'text/html',
         'Cache-Control': 'no-store, must-revalidate',
       });
       res.send(

--- a/webpack.config.cdap.js
+++ b/webpack.config.cdap.js
@@ -206,7 +206,7 @@ if (isModeProduction(mode)) {
 if (mode === 'development') {
   plugins.push(
     new LiveReloadPlugin({
-      port: 35728,
+      port: 35799,
       appendScriptTag: true,
       delay: 500,
       ignore:


### PR DESCRIPTION
# Enables optional analytics tracking

## Description
Adds express get response that adds the google analytics tracking script tags - if ui.analyticsTag is present in the config it will add the tag.
Changes the live reload port so it actually live reloads.

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick



