### PR TITLE
Cherry pick - Merge pull request #658 from cdapio/podesta/enable-optional-ga-tracking

### DIFF
--- a/app/cdap/cdap.html
+++ b/app/cdap/cdap.html
@@ -28,6 +28,7 @@
 </head>
 <body class="cdap-body-container">
   <div id="app-container"></div>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/analytics.js"></script>
   <script type="text/javascript" nonce="<_= nonceVal _>" src="/config.js"></script>
   <script type="text/javascript" nonce="<_= nonceVal _>" src="/ui-config.js"></script>
   <script type="text/javascript" nonce="<_= nonceVal _>" src="/ui-theme.js"></script>

--- a/app/hydrator/hydrator.html
+++ b/app/hydrator/hydrator.html
@@ -38,6 +38,7 @@
     
   </div>
 
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/analytics.js"></script>
   <script type="text/javascript" nonce="<_= nonceVal _>" src="/config.js"></script>
   <script type="text/javascript" nonce="<_= nonceVal _>" src="/ui-config.js"></script>
   <script type="text/javascript" nonce="<_= nonceVal _>" src="/ui-theme.js"></script>

--- a/server.js
+++ b/server.js
@@ -106,6 +106,16 @@ getCDAPConfig()
         featureFlags[key.substring(8)] = value;
         delete c[key];
       }
+
+      if (key.match(/ui.externalLinks/)) {
+        /**
+         * ui.externalLinks is 15 characters so remove ui.ui.ExternalLinks.
+         * the format for external links inside of the config is ui.externalLinks.link
+         * and the value is the url it should link to
+         */
+        externalLinks[key.substring(17)] = value;
+        delete c[key];
+      }
     }
 
     cdapConfig = c;

--- a/server/express.js
+++ b/server/express.js
@@ -186,6 +186,34 @@ function makeApp(authAddress, cdapConfig, uiSettings) {
     next(err);
   });
 
+  app.get('/analytics.js', (req, res) => {
+    /**
+     * Add Google analytics tag if ui.analyticsTag is present in the config
+     */
+    const aTag = cdapConfig['ui.analyticsTag'];
+    if (aTag) {
+      res.header({
+        'Content-Type': 'text/html',
+        'Cache-Control': 'no-store, must-revalidate',
+      });
+      res.send(
+        `
+        let gaScript1 = document.createElement('script');
+        gaScript1.setAttribute('async', 'true');
+        gaScript1.setAttribute('src', 'https://www.googletagmanager.com/gtag/js?id=${aTag}')
+        document.body.appendChild(gaScript1);
+        
+        let gaScript2 = document.createElement('script');
+        gaScript2.setAttribute('type', 'text/javascript');
+        gaScript2.innerHTML = "window.dataLayer = window.dataLayer || [];function gtag(){window.dataLayer.push(arguments);}gtag('js', new Date());gtag('config', '${aTag}');"
+        document.body.appendChild(gaScript2);
+        `
+      );
+    } else {
+      res.sendStatus(404);
+    }
+  });
+
   // serve the config file
   app.get('/config.js', function(req, res) {
     var data = JSON.stringify({
@@ -217,6 +245,7 @@ function makeApp(authAddress, cdapConfig, uiSettings) {
       instanceMetadataId: cdapConfig['instance.metadata.id'],
       sslEnabled: isSecure,
       featureFlags: cdapConfig.featureFlags,
+      analyticsTag: cdapConfig.analyticsTag,
     });
 
     res.header({

--- a/webpack.config.cdap.js
+++ b/webpack.config.cdap.js
@@ -206,7 +206,7 @@ if (isModeProduction(mode)) {
 if (mode === 'development') {
   plugins.push(
     new LiveReloadPlugin({
-      port: 35728,
+      port: 35799,
       appendScriptTag: true,
       delay: 500,
       ignore:


### PR DESCRIPTION
# Cherry pick #658 into release 6.8

## Description
Analytics - enables optional google analytics tracking in the ui

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [x] Cherry Pick



