### PR TITLE
[CDAP-19948] add feature flag for get apps queryparam

### DIFF
--- a/app/cdap/components/PipelineList/DeployedPipelineView/index.tsx
+++ b/app/cdap/components/PipelineList/DeployedPipelineView/index.tsx
@@ -44,6 +44,7 @@ const I18N_PREFIX = 'features.PipelineList.DeployedPipelineView';
 import PaginationStepper from 'components/shared/PaginationStepper';
 import styled from 'styled-components';
 import { MyPipelineApi } from 'api/pipeline';
+import { useFeatureFlagDefaultFalse } from 'services/react/customHooks/useFeatureFlag';
 
 const PaginationContainer = styled.div`
   margin-right: 50px;
@@ -146,6 +147,10 @@ const DeployedPipeline: React.FC = () => {
       reset();
     };
   }, []);
+  const lifecycleManagementEditEnabled = useFeatureFlagDefaultFalse(
+    'lifecycle.management.edit.enabled'
+  );
+  const latestOnly = lifecycleManagementEditEnabled ? 'true' : 'false';
   const { ready, search, pageToken, sortOrder, pageLimit } = useSelector(
     ({ deployed }) => deployed
   );
@@ -159,7 +164,7 @@ const DeployedPipeline: React.FC = () => {
       token: pageToken || undefined,
       pageSize: pageLimit,
       namespace: getCurrentNamespace(),
-      latestOnly: 'true',
+      latestOnly,
     },
   });
   const bannerMessage = checkError(error);


### PR DESCRIPTION
# [CDAP-19948] add feature flag for get apps queryparam

## Description
It's causing the ui not being able to show deployed pipelines after upgrading to 6.8.0. need feature flag to hide queryparam

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19948](https://cdap.atlassian.net/browse/CDAP-19948)




[CDAP-19948]: https://cdap.atlassian.net/browse/CDAP-19948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ