### PR TITLE
Review: CDAP 19685 Feature - Breadcrumb with UT and Cucumber

### DIFF
--- a/app/cdap/components/Breadcrumb/__test__/Breadcrumb.test.tsx
+++ b/app/cdap/components/Breadcrumb/__test__/Breadcrumb.test.tsx
@@ -1,0 +1,37 @@
+/*
+ *  Copyright © 2022 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { Route, Router, Switch } from 'react-router';
+import history from 'services/history';
+import BreadCrumb from 'components/Breadcrumb';
+
+describe('Test Breadcrumb Component', () => {
+  render(
+    <Router history={history}>
+      <Switch>
+        <Route>
+          <BreadCrumb breadcrumbsList={[{ label: 'display name', link: 'path to redirect' }]} />
+        </Route>
+      </Switch>
+    </Router>
+  );
+
+  it('Should have the Home text in the Breadcrumb', () => {
+    expect(screen.getByTestId('breadcrumb-home-display-name')).toHaveTextContent('display name');
+  });
+});

--- a/app/cdap/components/Breadcrumb/index.tsx
+++ b/app/cdap/components/Breadcrumb/index.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { Typography } from '@material-ui/core';
+import Breadcrumbs from '@material-ui/core/Breadcrumbs';
+import { grey } from '@material-ui/core/colors';
+import NavigateNextIcon from '@material-ui/icons/NavigateNext';
+import React from 'react';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+export interface IBreadcrumbItemProps {
+  link?: string;
+  label: string;
+}
+
+export interface IBreadcrumbProps {
+  breadcrumbsList: IBreadcrumbItemProps[];
+}
+
+const StyledBreadcrumb = styled(Breadcrumbs)`
+  display: flex;
+  justify-content: space-between;
+  height: 48px;
+  align-items: center;
+  margin-right: 30px;
+  margin-left: 34px;
+`;
+
+const StyledLink = styled(Link)`
+    color: blue[500];
+    font-size: 14px;
+    font-weight: 400;
+    width: 41px,
+    height: 21px,
+`;
+
+const StyledTypography = styled(Typography)`
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 21px;
+  letter-spacing: 0.15px;
+  color: ${grey[900]};
+`;
+
+const getBreadcrumbLabel = (breadcrumbData:IBreadcrumbItemProps) => {
+  if (breadcrumbData.link) {
+    return (
+      <StyledLink
+        to={breadcrumbData.link}
+        data-testid={`breadcrumb-home-${breadcrumbData.label
+          .toLowerCase()
+          .split(' ')
+          .join('-')}`}
+      >
+        {breadcrumbData.label}
+      </StyledLink>
+    );
+  }
+  return (
+    <StyledTypography color="textPrimary" data-testid="breadcrumb-workspace-name">
+      {breadcrumbData.label}
+    </StyledTypography>
+  );
+};
+
+export default function({ breadcrumbsList }: IBreadcrumbProps) {
+  return (
+    <StyledBreadcrumb separator={<NavigateNextIcon fontSize="small" />} aria-label="breadcrumb">
+      {breadcrumbsList?.map((eachBreadcrumb) => getBreadcrumbLabel(eachBreadcrumb))}
+    </StyledBreadcrumb>
+  );
+}

--- a/app/cdap/components/ConnectionList/Components/ConnectionTabs/__test__/ConnectionTabs.test.tsx
+++ b/app/cdap/components/ConnectionList/Components/ConnectionTabs/__test__/ConnectionTabs.test.tsx
@@ -20,20 +20,24 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { mockTabsDataWithBrowse } from '../mock/mockTabsDataWithBrowse';
 import { mockTabsDataWithBrowseIndex } from '../mock/mockTabsDataWithBrowseIndex';
 import { mockTabsTestData } from '../mock/mockTabsTestData';
-
-const tabsTestData = [{ showTabs: true }];
+import { Router, Route } from 'react-router-dom';
+import history from 'services/history';
 
 describe('Test ConnectionsTabs', () => {
   it('Should render Connections Tabs Parent Component', () => {
     render(
-      <ConnectionsTabs
-        tabsData={mockTabsTestData}
-        handleChange={() => null}
-        value="apple"
-        index="0"
-        connectionId={undefined}
-        setIsErrorOnNoWorkSpace={jest.fn()}
-      />
+      <Router history={history}>
+        <Route>
+          <ConnectionsTabs
+            tabsData={mockTabsTestData}
+            handleChange={() => null}
+            value="apple"
+            index="0"
+            connectionId={undefined}
+            setIsErrorOnNoWorkSpace={jest.fn()}
+          />
+        </Route>
+      </Router>
     );
     const ele = screen.getByTestId(/connections-tabs-parent/i);
     expect(ele).toBeInTheDocument();
@@ -41,14 +45,18 @@ describe('Test ConnectionsTabs', () => {
 
   it('Should render Connections Tabs Component', () => {
     render(
-      <ConnectionsTabs
-        tabsData={mockTabsTestData}
-        handleChange={() => null}
-        value="apple"
-        index="1"
-        connectionId={undefined}
-        setIsErrorOnNoWorkSpace={jest.fn()}
-      />
+      <Router history={history}>
+        <Route>
+          <ConnectionsTabs
+            tabsData={mockTabsTestData}
+            handleChange={() => null}
+            value="apple"
+            index="1"
+            connectionId={undefined}
+            setIsErrorOnNoWorkSpace={jest.fn()}
+          />
+        </Route>
+      </Router>
     );
     const ele = screen.getByTestId(/connection-tabs/i);
     expect(ele).toBeInTheDocument();
@@ -56,14 +64,18 @@ describe('Test ConnectionsTabs', () => {
 
   it('Should render TabLabelCanBrowse with connectorTypes and count', () => {
     render(
-      <ConnectionsTabs
-        tabsData={mockTabsDataWithBrowseIndex}
-        handleChange={() => null}
-        value="apple"
-        index={0}
-        connectionId={undefined}
-        setIsErrorOnNoWorkSpace={jest.fn()}
-      />
+      <Router history={history}>
+        <Route>
+          <ConnectionsTabs
+            tabsData={mockTabsDataWithBrowseIndex}
+            handleChange={() => null}
+            value="apple"
+            index={0}
+            connectionId={undefined}
+            setIsErrorOnNoWorkSpace={jest.fn()}
+          />
+        </Route>
+      </Router>
     );
     const ele = screen.getByTestId(/connections-tab-label-browse/i);
     expect(ele).toBeInTheDocument();
@@ -74,14 +86,18 @@ describe('Should test whether handleChange function is triggered or not', () => 
   it('Should trigger handlechange function for the first column i.e. Connector Types', () => {
     const handleChange = jest.fn();
     render(
-      <ConnectionsTabs
-        tabsData={mockTabsTestData}
-        handleChange={handleChange}
-        value="apple"
-        index="1"
-        connectionId={undefined}
-        setIsErrorOnNoWorkSpace={jest.fn()}
-      />
+      <Router history={history}>
+        <Route>
+          <ConnectionsTabs
+            tabsData={mockTabsTestData}
+            handleChange={handleChange}
+            value="apple"
+            index="1"
+            connectionId={undefined}
+            setIsErrorOnNoWorkSpace={jest.fn()}
+          />
+        </Route>
+      </Router>
     );
     const ele = screen.getAllByTestId(/connections-tab-button/i);
     fireEvent.click(ele[0]);
@@ -91,14 +107,18 @@ describe('Should test whether handleChange function is triggered or not', () => 
   it('Should not trigger handlechange function when clicked on columns other than first one, and canBrowse is false', () => {
     const handleChange = jest.fn();
     render(
-      <ConnectionsTabs
-        tabsData={mockTabsTestData}
-        handleChange={handleChange}
-        value="apple"
-        index="2"
-        connectionId={undefined}
-        setIsErrorOnNoWorkSpace={jest.fn()}
-      />
+      <Router history={history}>
+        <Route>
+          <ConnectionsTabs
+            tabsData={mockTabsTestData}
+            handleChange={handleChange}
+            value="apple"
+            index="2"
+            connectionId={undefined}
+            setIsErrorOnNoWorkSpace={jest.fn()}
+          />
+        </Route>
+      </Router>
     );
     const ele = screen.getAllByTestId(/connections-tab-button/i);
     fireEvent.click(ele[0]);
@@ -108,14 +128,18 @@ describe('Should test whether handleChange function is triggered or not', () => 
   it('Should not trigger handlechange function when clicked on columns other than first one, and canBrowse is true', () => {
     const handleChange = jest.fn();
     render(
-      <ConnectionsTabs
-        tabsData={mockTabsDataWithBrowse}
-        handleChange={handleChange}
-        value="apple"
-        index="2"
-        connectionId={undefined}
-        setIsErrorOnNoWorkSpace={jest.fn()}
-      />
+      <Router history={history}>
+        <Route>
+          <ConnectionsTabs
+            tabsData={mockTabsDataWithBrowse}
+            handleChange={handleChange}
+            value="apple"
+            index="2"
+            connectionId={undefined}
+            setIsErrorOnNoWorkSpace={jest.fn()}
+          />
+        </Route>
+      </Router>
     );
     const ele = screen.getAllByTestId(/connections-tab-button/i);
     fireEvent.click(ele[0]);

--- a/app/cdap/components/ConnectionList/Components/ConnectionTabs/index.tsx
+++ b/app/cdap/components/ConnectionList/Components/ConnectionTabs/index.tsx
@@ -116,6 +116,7 @@ export default function ConnectionsTabs({
                         initialConnectionId={connectionIdProp}
                         toggleLoader={props.toggleLoader}
                         setIsErrorOnNoWorkSpace={setIsErrorOnNoWorkSpace}
+                        dataTestId={`connectionlist-connectiontabs-label-loop-${index}-${connectorTypeIndex}`}
                       />
                     )
                   ) : (
@@ -129,8 +130,7 @@ export default function ConnectionsTabs({
                 }
                 value={connectorType.name}
                 disableTouchRipple
-                key={`${connectorType.name}=${connectorTypeIndex}`}
-                id={connectorType.name}
+                key={`${connectorType.name}-${connectorTypeIndex}`}
                 className={index > 1 && !connectorType.canBrowse ? classes.wrangleTab : null}
               />
             ))}

--- a/app/cdap/components/ConnectionList/Components/SubHeader/__test__/Breadcrumb.test.tsx
+++ b/app/cdap/components/ConnectionList/Components/SubHeader/__test__/Breadcrumb.test.tsx
@@ -16,20 +16,21 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import BreadCumb from '../index';
+import Breadcrumb from 'components/ConnectionList/Components/SubHeader';
 import history from 'services/history';
 import { Router, Route } from 'react-router';
 
-describe('renders BreadCumb Component', () => {
+describe('renders Breadcrumb Component', () => {
   render(
     <Router history={history}>
       <Route>
-        <BreadCumb />
+        <Breadcrumb />
       </Route>
     </Router>
   );
+
   it('should render the Breadcrumb component', () => {
-    const ele = screen.getByTestId(/bread-comb-container-parent/i);
+    const ele = screen.getByTestId('breadcrumb-container-parent');
     expect(ele).toBeInTheDocument();
   });
 });

--- a/app/cdap/components/ConnectionList/Components/SubHeader/index.tsx
+++ b/app/cdap/components/ConnectionList/Components/SubHeader/index.tsx
@@ -14,47 +14,89 @@
  * the License.
  */
 
-import { Breadcrumbs, Typography } from '@material-ui/core';
 import Box from '@material-ui/core/Box';
-import { useStyles } from 'components/ConnectionList/Components/SubHeader/styles';
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { getCurrentNamespace } from 'services/NamespaceStore';
-import NavigateNextIcon from '@material-ui/icons/NavigateNext';
 import AddCircleOutlineOutlinedIcon from '@material-ui/icons/AddCircleOutlineOutlined';
 import SaveAltRoundedIcon from '@material-ui/icons/SaveAltRounded';
+import Breadcrumb from 'components/Breadcrumb';
+import styled from 'styled-components';
+import { grey } from '@material-ui/core/colors';
+import { Typography } from '@material-ui/core';
+import { getCurrentNamespace } from 'services/NamespaceStore';
 import T from 'i18n-react';
 
-export default function SubHeader() {
-  const classes = useStyles();
-  return (
-    <Box className={classes.breadCombContainer} data-testid="bread-comb-container-parent">
-      <Box>
-        <Breadcrumbs separator={<NavigateNextIcon fontSize="small" />} aria-label="breadcrumb">
-          <Link
-            color="inherit"
-            to={`/ns/${getCurrentNamespace()}/home`}
-            data-testid="breadcrumb-home-link"
-          >
-            {T.translate('features.WranglerNewUI.Breadcrumb.labels.wranglerHome')}
-          </Link>
-          <Typography>
-            {' '}
-            {T.translate('features.WranglerNewUI.Breadcrumb.labels.connectionsList')}
-          </Typography>
-        </Breadcrumbs>
-      </Box>
+export const CONNECTION_LIST_BREADCRUMB_OPTIONS = [
+  {
+    link: `/ns/${getCurrentNamespace()}/wrangle`,
+    label: T.translate('features.WranglerNewUI.Breadcrumb.labels.wrangleHome').toString(),
+  },
+  {
+    label: T.translate('features.WranglerNewUI.Breadcrumb.labels.connectionsList').toString(),
+  },
+];
 
-      <Box className={classes.importDataContainer}>
-        <Box className={classes.importData}>
-          <AddCircleOutlineOutlinedIcon className={classes.subHeaderIcon} />
-          <Box className={classes.breadCrumbTyporgraphy}>Add connection</Box>
-        </Box>
-        <Box className={classes.importData}>
-          <SaveAltRoundedIcon className={classes.subHeaderIcon} />
-          <Box className={classes.breadCrumbTyporgraphy}>Import data</Box>
-        </Box>
+const AddConnectionIcon = styled(AddCircleOutlineOutlinedIcon)`
+  font-size: x-large;
+  color: ${grey[700]};
+`;
+
+const BreadcrumbContainer = styled(Box)`
+  border-bottom: 1px solid ${grey[300]};
+  display: flex;
+  justify-content: space-between;
+  height: 48px;
+  align-items: center;
+  padding-right: 30px;
+`;
+
+const FlexContainer = styled(Box)`
+  display: flex;
+  align-items: flex-end;
+`;
+
+const FeaturesContainer = styled(FlexContainer)`
+  gap: 30px;
+  font-size: 14px;
+`;
+
+const ImportDataContainer = styled(FlexContainer)`
+  gap: 12px;
+  &:hover {
+    cursor: pointer;
+  }
+`;
+
+const SaveIcon = styled(SaveAltRoundedIcon)`
+  font-size: x-large;
+  color: ${grey[700]};
+`;
+
+const TypographyLabel = styled(Typography)`
+  color: ${grey[900]};
+  font-size: 14px;
+  line-height: 21px;
+`;
+
+export default function SubHeader() {
+  return (
+    <BreadcrumbContainer data-testid="breadcrumb-container-parent">
+      <Box>
+        <Breadcrumb breadcrumbsList={CONNECTION_LIST_BREADCRUMB_OPTIONS} />
       </Box>
-    </Box>
+      <FeaturesContainer>
+        <ImportDataContainer>
+          <AddConnectionIcon />
+          <TypographyLabel component="span">
+            {T.translate('features.WranglerNewUI.AddConnections.referenceLabel')}
+          </TypographyLabel>
+        </ImportDataContainer>
+        <ImportDataContainer>
+          <SaveIcon />
+          <TypographyLabel component="span">
+            {T.translate('features.WranglerNewUI.ImportData.referenceLabel')}
+          </TypographyLabel>
+        </ImportDataContainer>
+      </FeaturesContainer>
+    </BreadcrumbContainer>
   );
 }

--- a/app/cdap/components/ConnectionList/Components/TabLabelCanSample/__test__/TabLabelCanSample.test.tsx
+++ b/app/cdap/components/ConnectionList/Components/TabLabelCanSample/__test__/TabLabelCanSample.test.tsx
@@ -20,37 +20,43 @@ import TabLabelCanSample from '../index';
 import { mockConnectorTypeData, mockEntityDataForNoWorkspace } from '../mock/mockConnectorTypeData';
 import { Route, Router, Switch } from 'react-router';
 import * as apiHelpers from 'components/Connections/Browser/GenericBrowser/apiHelpers';
-import { createBrowserHistory } from 'history';
-
-const history = createBrowserHistory({
-  basename: '/',
-});
+import history from 'services/history';
 
 describe('Test TabLabelCanSample Component', () => {
   it('Should render TabLabelCanSample Component', () => {
     render(
-      <TabLabelCanSample
-        label={mockConnectorTypeData.name}
-        entity={mockConnectorTypeData}
-        initialConnectionId={undefined}
-        toggleLoader={() => null}
-        setIsErrorOnNoWorkSpace={jest.fn()}
-      />
+      <Router history={history}>
+        <Route>
+          <TabLabelCanSample
+            label={mockConnectorTypeData.name}
+            entity={mockConnectorTypeData}
+            initialConnectionId={undefined}
+            toggleLoader={() => null}
+            setIsErrorOnNoWorkSpace={jest.fn()}
+            dataTestId={'connections-tab-ref-label-simple'}
+          />
+        </Route>
+      </Router>
     );
-    const ele = screen.getByTestId(/connections-tab-label-simple/i);
+    const ele = screen.getByTestId(/connections-tab-ref-label-simple/i);
     expect(ele).toBeInTheDocument();
   });
 
   it('Should trigger setIsErrorOnNoWorkSpace function ', () => {
     const setIsErrorOnNoWorkSpace = jest.fn();
     render(
-      <TabLabelCanSample
-        label={mockConnectorTypeData.name}
-        entity={mockConnectorTypeData}
-        initialConnectionId={undefined}
-        toggleLoader={() => null}
-        setIsErrorOnNoWorkSpace={setIsErrorOnNoWorkSpace}
-      />
+      <Router history={history}>
+        <Route>
+          <TabLabelCanSample
+            label={mockConnectorTypeData.name}
+            entity={mockConnectorTypeData}
+            initialConnectionId={undefined}
+            toggleLoader={() => null}
+            setIsErrorOnNoWorkSpace={setIsErrorOnNoWorkSpace}
+            dataTestId={'tab-label-can-sample'}
+          />
+        </Route>
+      </Router>
     );
     const ele = screen.getByTestId(/connections-tab-explore/i);
     fireEvent.click(ele);
@@ -85,6 +91,7 @@ describe('Test TabLabelCanSample Component', () => {
               initialConnectionId="exl"
               toggleLoader={() => null}
               setIsErrorOnNoWorkSpace={setIsErrorOnNoWorkSpace}
+              dataTestId={'test'}
             />
           </Route>
         </Switch>

--- a/app/cdap/components/ConnectionList/Components/TabLabelCanSample/index.tsx
+++ b/app/cdap/components/ConnectionList/Components/TabLabelCanSample/index.tsx
@@ -26,6 +26,8 @@ import { createRef, Ref, useContext, useEffect, useState } from 'react';
 import { Redirect } from 'react-router';
 import { getCurrentNamespace } from 'services/NamespaceStore';
 import useStyles from './styles';
+import { useLocation } from 'react-router';
+import T from 'i18n-react';
 
 export default function TabLabelCanSample({
   label,
@@ -33,14 +35,18 @@ export default function TabLabelCanSample({
   initialConnectionId,
   toggleLoader,
   setIsErrorOnNoWorkSpace,
+  dataTestId,
 }: {
   label: string;
   entity: IRecords;
   initialConnectionId: string;
   toggleLoader: (value: boolean, isError?: boolean) => void;
   setIsErrorOnNoWorkSpace: React.Dispatch<React.SetStateAction<boolean>>;
+  dataTestId: string;
 }) {
   const classes = useStyles();
+
+  const location = useLocation();
 
   const myLabelRef: Ref<HTMLSpanElement> = createRef();
   const [refValue, setRefValue] = useState(false);
@@ -92,28 +98,42 @@ export default function TabLabelCanSample({
       });
   };
 
+  const indexOfSelectedDataset = location?.pathname?.lastIndexOf('/');
+  const requiredPath =
+    indexOfSelectedDataset && location.pathname.slice(indexOfSelectedDataset + 1);
+
   return workspaceId ? (
-    <Redirect to={`/ns/${getCurrentNamespace()}/wrangler-grid/${workspaceId}`} />
+    <Redirect
+      to={{
+        pathname: `/ns/${getCurrentNamespace()}/wrangler-grid/${workspaceId}`,
+        state: {
+          from: T.translate('features.WranglerNewUI.Breadcrumb.labels.connectionsList'),
+          path: requiredPath,
+        },
+      }}
+    />
   ) : refValue ? (
     <CustomTooltip title={label} arrow data-testid="connections-tab-ref-label-simple">
-      <Box className={classes.labelsContainerCanSample}>
+      <Box className={classes.labelsContainerCanSample} data-testid={dataTestId}>
         <Typography variant="body2" className={classes.labelStylesCanSample} ref={myLabelRef}>
           {label}
         </Typography>
-        <button
-          className="wranglingHover"
-          onClick={() => onExplore(entity)}
-          data-testid="connections-tab-ref-explore"
-        >
-          <WrangleIcon />
-          <Typography variant="body2" className={classes.wrangleButton}>
-            Wrangle
-          </Typography>
+        <button className="wranglingHover" onClick={() => onExplore(entity)}>
+          <Box className="wranglingHover">
+            <WrangleIcon />
+            <Typography
+              variant="body2"
+              className={classes.wrangleButton}
+              data-testid="dataset-name-with-tooltip"
+            >
+              {T.translate('features.WranglerNewUI.Breadcrumb.labels.loadToGrid')}
+            </Typography>
+          </Box>
         </button>
       </Box>
     </CustomTooltip>
   ) : (
-    <Box className={classes.labelsContainerCanSample} data-testid="connections-tab-label-simple">
+    <Box className={classes.labelsContainerCanSample} data-testid={dataTestId}>
       <Typography variant="body2" className={classes.labelStylesCanSample} ref={myLabelRef}>
         {label}
       </Typography>
@@ -123,8 +143,12 @@ export default function TabLabelCanSample({
         data-testid="connections-tab-explore"
       >
         <WrangleIcon />
-        <Typography variant="body2" className={classes.wrangleButton}>
-          Wrangle
+        <Typography
+          variant="body2"
+          className={classes.wrangleButton}
+          data-testid="dataset-name-without-tooltip"
+        >
+          {T.translate('features.WranglerNewUI.Breadcrumb.labels.loadToGrid')}
         </Typography>
       </button>
     </Box>

--- a/app/cdap/components/Connections/Create/index.tsx
+++ b/app/cdap/components/Connections/Create/index.tsx
@@ -193,7 +193,7 @@ export function CreateConnection({
         const value: string | boolean = featRequestingFrom ? featRequestingFrom : false;
         if (value) {
           value === 'home'
-            ? setRedirectUrl(`/ns/${getCurrentNamespace()}/home`)
+            ? setRedirectUrl(`/ns/${getCurrentNamespace()}/wrangle`)
             : setRedirectUrl(`/ns/${getCurrentNamespace()}/datasources/${value}`);
         } else {
           setRedirectUrl(`${getConnectionPath(name)}`);
@@ -260,7 +260,7 @@ export function CreateConnection({
       const value: string | boolean = featRequestingFrom ? featRequestingFrom : false;
       if (value) {
         return value === 'home'
-          ? setRedirectUrl(`/ns/${getCurrentNamespace()}/home`)
+          ? setRedirectUrl(`/ns/${getCurrentNamespace()}/wrangle`)
           : setRedirectUrl(`/ns/${getCurrentNamespace()}/datasources/${value}`);
       } else {
         navigateToConnectionList(dispatch);

--- a/app/cdap/components/GridTable/__test__/GridTable.test.tsx
+++ b/app/cdap/components/GridTable/__test__/GridTable.test.tsx
@@ -14,15 +14,15 @@
  *  the License.
  */
 
-import React from 'react';
-import GridTable from 'components/GridTable/index';
 import { render } from '@testing-library/react';
-import { Route, Router, Switch } from 'react-router';
-import { createBrowserHistory as createHistory } from 'history';
 import MyDataPrepApi from 'api/dataprep';
+import GridTable from 'components/GridTable/index';
+import React from 'react';
+import { Route, Router, Switch } from 'react-router';
 import rxjs from 'rxjs/operators';
-import { mockForFlatMap, mockForGetWorkspace } from '../mock/mockDataForGrid';
 import history from 'services/history';
+import { mockForFlatMap, mockForGetWorkspace } from '../mock/mockDataForGrid';
+import * as BreadcrumbOptions from 'components/GridTable/utils';
 
 describe('Testing Grid Table Component', () => {
   jest.spyOn(rxjs, 'flatMap' as any).mockImplementation((callback: any) => {
@@ -40,6 +40,10 @@ describe('Testing Grid Table Component', () => {
         },
       };
     });
+
+    jest
+      .spyOn(BreadcrumbOptions, 'getWrangleGridBreadcrumbOptions')
+      .mockReturnValue([{ label: 'yolo', link: 'abcd' }]);
 
     const container = render(
       <Router history={history}>

--- a/app/cdap/components/GridTable/constants.ts
+++ b/app/cdap/components/GridTable/constants.ts
@@ -1,1 +1,17 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 export const MISSING_NULL = 'Missing/Null';

--- a/app/cdap/components/GridTable/utils.ts
+++ b/app/cdap/components/GridTable/utils.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { getCurrentNamespace } from 'services/NamespaceStore';
+import T from 'i18n-react';
+import { IBreadcrumbItemProps } from 'components/Breadcrumb';
+const PREFIX = 'features.WranglerNewUI.Breadcrumb';
+
+export const getWrangleGridBreadcrumbOptions = (workspaceName, location) => {
+  const finalBreadcrumbList: IBreadcrumbItemProps[] = [
+    {
+      link: `/ns/${getCurrentNamespace()}/wrangle`,
+      label: T.translate(`${PREFIX}.labels.wrangleHome`).toString(),
+    },
+  ];
+
+  const requestFromAddress = location?.state?.from;
+  const sourcePath =
+    requestFromAddress === T.translate(`${PREFIX}.labels.wrangleHome`)
+      ? 'wrangle'
+      : `datasources/${location?.state?.path}`;
+
+  const intermediateBreadcrumb = {
+    link: `/ns/${getCurrentNamespace()}/${sourcePath}`,
+    label: requestFromAddress,
+  };
+
+  requestFromAddress !== T.translate(`${PREFIX}.labels.wrangleHome`) &&
+    finalBreadcrumbList.push(intermediateBreadcrumb);
+
+  finalBreadcrumbList.push({
+    label: workspaceName?.toString(),
+  });
+
+  return finalBreadcrumbList;
+};

--- a/app/cdap/components/Home/index.js
+++ b/app/cdap/components/Home/index.js
@@ -152,7 +152,7 @@ export default class Home extends Component {
       <div>
         <Switch>
           <Route exact path="/ns/:namespace" component={HomeActions} />
-          <Route exact path="/ns/:namespace/home" component={WrangleHome} />
+          <Route exact path="/ns/:namespace/wrangle" component={WrangleHome} />
           <Route
             exact
             path="/ns/:namespace/datasources/:connectorType"

--- a/app/cdap/components/WrangleHome/Components/OngoingDataExploration/index.tsx
+++ b/app/cdap/components/WrangleHome/Components/OngoingDataExploration/index.tsx
@@ -111,8 +111,8 @@ export default function OngoingDataExploration() {
             to={{
               pathname: `/ns/${getCurrentNamespace()}/wrangler-grid/${`${item[4].workspaceId}`}`,
               state: {
-                from: T.translate('features.WranglerNewUI.Breadcrumb.labels.wranglerHome'),
-                path: T.translate('features.WranglerNewUI.Breadcrumb.params.wranglerHome'),
+                from: T.translate('features.WranglerNewUI.Breadcrumb.labels.wrangleHome'),
+                path: T.translate('features.WranglerNewUI.Breadcrumb.params.wrangleHome'),
               },
             }}
             style={{ textDecoration: 'none' }}

--- a/app/cdap/components/WrangleHome/Components/WrangleCard/index.tsx
+++ b/app/cdap/components/WrangleHome/Components/WrangleCard/index.tsx
@@ -17,11 +17,11 @@
 import { Box, Card, Typography } from '@material-ui/core';
 import DataPrepStore from 'components/DataPrep/store';
 import { useStyles } from 'components/WrangleHome/Components/WrangleCard/styles';
-import { IConnector, IWrangleCard } from 'components/WrangleHome/Components/WrangleCard/types';
 import { getUpdatedConnectorCards } from 'components/WrangleHome/services/getUpdatedConnectorCards';
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { getCurrentNamespace } from 'services/NamespaceStore';
+import { IConnector, IWrangleCard } from 'components/WrangleHome/Components/WrangleCard/types';
 
 export default function({ toggleViewAllLink }: IWrangleCard) {
   const [connectorsData, setConnectorsData] = useState<{ connectorTypes: IConnector[] }>({

--- a/app/cdap/components/WrangleHome/index.tsx
+++ b/app/cdap/components/WrangleHome/index.tsx
@@ -16,18 +16,16 @@
 
 import { Typography } from '@material-ui/core';
 import Box from '@material-ui/core/Box';
-import DataPrepStore from 'components/DataPrep/store';
-import LoadingSVG from 'components/shared/LoadingSVG';
 import { getWidgetData } from 'components/WidgetSVG/utils';
-import OngoingDataExploration from 'components/WrangleHome/Components/OngoingDataExploration/index';
 import WrangleCard from 'components/WrangleHome/Components/WrangleCard/index';
 import WrangleHomeTitle from 'components/WrangleHome/Components/WrangleHomeTitle/index';
 import { GradientLine, HeaderImage } from 'components/WrangleHome/icons';
 import { useStyles } from 'components/WrangleHome/styles';
 import T from 'i18n-react';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { getCurrentNamespace } from 'services/NamespaceStore';
+import OngoingDataExploration from 'components/WrangleHome/Components/OngoingDataExploration';
 
 export default function() {
   const classes = useStyles();

--- a/app/cdap/components/common/DrawerWidget/__test__/DrawerWidget.test.tsx
+++ b/app/cdap/components/common/DrawerWidget/__test__/DrawerWidget.test.tsx
@@ -75,8 +75,5 @@ describe('Test DrawerWidget Component', () => {
 
     fireEvent.click(closeIcon);
     expect(closeClickHandler).toBeCalled();
-
-    const underlineIcon = container.getByTestId('underline-icon');
-    expect(underlineIcon).toBeInTheDocument();
   });
 });

--- a/app/cdap/components/common/DrawerWidget/index.tsx
+++ b/app/cdap/components/common/DrawerWidget/index.tsx
@@ -18,7 +18,6 @@ import { Box, Container, Drawer, DrawerProps, IconButton, Typography } from '@ma
 import grey from '@material-ui/core/colors/grey';
 import ChevronLeftRoundedIcon from '@material-ui/icons/ChevronLeftRounded';
 import CloseRoundedIcon from '@material-ui/icons/CloseRounded';
-import { Underline } from 'components/common/DrawerWidget/IconStore/Underline';
 import React, { ReactNode } from 'react';
 import styled from 'styled-components';
 
@@ -119,7 +118,7 @@ export default function({
             <Label data-testid="widget-heading-text" component="span">
               {headingText}
             </Label>
-            <Underline />
+            <img src="/cdap_assets/img/underline" />
           </LabelContainer>
         </HeaderActions>
         <HeaderActions>

--- a/app/cdap/styles/img/underline.svg
+++ b/app/cdap/styles/img/underline.svg
@@ -1,0 +1,11 @@
+    <svg
+      width="67"
+      height="3"
+      viewBox="0 0 67 3"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      data-testid="underline-icon"
+    >
+      <path d="M0 0.530273H50L53 2.5318H3L0 0.530273Z" fill="#2196F3" />
+      <path d="M54 0.530273H63.5L66.5 2.5318H57L54 0.530273Z" fill="#2196F3" />
+    </svg>

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -2803,7 +2803,6 @@ features:
       triggerNameExists: "Trigger Name already exists"
       triggerNameRequired: "Trigger Name is required"
       triggerNameLengthLimit: "Trigger Name should not be longer than 50 characters"
-      emptyCompositeTriggerError: "Please select upstream pipelines for this trigger"
       selectPipelineInstruction: "Select the pipelines you want to add to the trigger: "
       triggerAndType: "Wait for all events (AND)"
       triggerOrType: "Trigger on any selected event (OR)"
@@ -3438,10 +3437,14 @@ features:
     Breadcrumb:
       labels:
         connectionsList: Data Sources
-        wranglerHome: Home
+        loadToGrid: Wrangle
+        wrangleHome: Home
+        createPipeline: Create a Pipeline
       params:
         connectionsList: datasources
-        wranglerHome: home
+        wrangleHome: home
+      ariaLabels:
+        breadcrumb: breadcrumb
     common:
       and: and
     ConnectionsList:

--- a/src/e2e-test/features/breadcrumb.feature
+++ b/src/e2e-test/features/breadcrumb.feature
@@ -1,0 +1,65 @@
+#
+# Copyright © 2022 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+@Integration_Tests
+Feature: Wrangler BigQuery Connection Tests
+
+  @WRANGLER_BIGQUERY_CONNECTION_TEST
+  Scenario: Should successfully test BIGQUERY connection
+    When Open Connections page for BigQuery connection test
+    Then Test BigQuery connection with name "bigquery_randomtest1"
+    Then Verify for successful BigQuery test connection and message
+
+  @WRANGLER_BIGQUERY_CONNECTION_TEST
+  Scenario: Should show appropriate message when BigQuery connection fails
+    When Open Connections page
+    Then Test BigQuery connection with "unknown_bigquery_connection_name", "unknown_project", "unknown_path"
+    Then Verify BigQuery test connection failure and message
+
+  @WRANGLER_BIGQUERY_CONNECTION_TEST
+  Scenario: Should create BIGQUERY connection
+    When Open Connections page
+    Then Create BigQuery connection with name "bigquery_randomtest1"
+    Then Verify navigation to created BigQuery connection "bigquery_randomtest1"
+
+  @WRANGLER_BIGQUERY_CONNECTION_TEST
+  Scenario: Should show proper error message when trying to create existing BigQuery connection
+    When Open Connections page
+    Then Create BigQuery connection with name "bigquery_randomtest1"
+    Then Check for the BigQuery connection already exists error for "bigquery_randomtest1"
+
+  @WRANGLER_BIGQUERY_CONNECTION_TEST
+  Scenario: Should show appropriate error when navigating to incorrect BIGQUERY connection
+    When Open BigQuery connection 'bigquery_unknown_connection' page
+    Then Check for BigQuery connection 'bigquery_unknown_connection' not found message
+
+  @WRANGLER_BIGQUERY_CONNECTION_TEST
+  Scenario: Should be able navigate inside BIGQUERY connection & create workspace
+    When Open Connections page
+    Then Select BigQuery connection "bigquery_randomtest1"
+    Then Check BigQuery connection "bigquery_randomtest1" details: Instance, Database, Table
+    Then Verify URL navigation for BigQuery connection
+
+  @Breadcrumb
+  Scenario Outline: Go through the Breadcrumb functionality
+    Given Navigate to the home page to test breadcrumb
+    Then  Click on the Connector type with "<connectionLabel>" and "<connectionTestId>"
+    Then Click on the Home link button
+    Then Click on the Exploration card with "<testId>"
+    Then Click on the Home link of wrangle page
+    Examples:
+         | connectionLabel | connectionTestId |testId|
+         | BigQuery | bigquery | 0 |

--- a/src/e2e-test/features/connectortypes.feature
+++ b/src/e2e-test/features/connectortypes.feature
@@ -24,7 +24,6 @@ Feature: Navigating through the connector types
 
   Examples:
     | connectionLabel | connectionTestId |
-    | Add Connections | add-connection |
     | PostgreSQL | postgresql |
     | File | file |
     | Import Data | import-data |

--- a/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/Breadcrumb.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/Breadcrumb.java
@@ -49,7 +49,7 @@ public class Breadcrumb {
           WaitHelper.waitForPageToLoad();
           String actualText = SeleniumDriver.getDriver().getCurrentUrl();
           Assert.assertEquals(actualText,
-                  "http://localhost:11011/cdap/ns/default/datasources/" + connectionLabel);
+                "http://localhost:11011/cdap/ns/default/datasources/" + connectionLabel);
         }
     } catch (Exception e) {
       System.err.println("error:" + e);
@@ -75,7 +75,7 @@ public class Breadcrumb {
       WaitHelper.waitForPageToLoad();
       Helper.waitSeconds(30);
       ElementHelper.clickOnElement(Helper.locateElementByTestId
-              ("wrangler-home-ongoing-data-exploration-card-" + testId));
+            ("wrangler-home-ongoing-data-exploration-card-" + testId));
     } catch (Exception e) {
       System.err.println("error:" + e);
     }

--- a/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/Breadcrumb.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/Breadcrumb.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.ui.stepsdesign;
+
+import io.cdap.cdap.ui.utils.Constants;
+import io.cdap.cdap.ui.utils.Helper;
+import io.cdap.e2e.utils.ElementHelper;
+import io.cdap.e2e.utils.SeleniumDriver;
+import io.cdap.e2e.utils.WaitHelper;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import org.junit.Assert;
+import org.openqa.selenium.WebElement;
+
+public class Breadcrumb {
+  @Given("Navigate to the home page to test breadcrumb")
+  public void navigateToTheHomePageBreadcrumb() throws Exception {
+    SeleniumDriver.openPage(Constants.WRANGLE_HOME_URL);
+    WaitHelper.waitForPageToLoad();
+  }
+
+  @Then("Click on the Connector type with \\\"(.*)\\\" and \\\"(.*)\\\"")
+  public void clickOnTheConnectorType(String connectionLabel, String connectionTestId) {
+    try {
+      WaitHelper.waitForElementToBeEnabled(
+      Helper.locateElementByTestId("wrangle-card-" + connectionTestId));
+      ElementHelper.clickOnElement(Helper.locateElementByTestId("wrangle-card-" + connectionTestId));
+      WaitHelper.waitForPageToLoad();
+        if (connectionLabel.equals("Add Connections")) {
+          ElementHelper.clickOnElement(Helper.locateElementByTestId("wrangle-card-" + connectionTestId));
+          WaitHelper.waitForPageToLoad();
+          String actualText = SeleniumDriver.getDriver().getCurrentUrl();
+          Assert.assertEquals(actualText, "http://localhost:11011/cdap/ns/default/connections/create");
+        } else {
+          WaitHelper.waitForPageToLoad();
+          String actualText = SeleniumDriver.getDriver().getCurrentUrl();
+          Assert.assertEquals(actualText,
+                  "http://localhost:11011/cdap/ns/default/datasources/" + connectionLabel);
+        }
+    } catch (Exception e) {
+      System.err.println("error:" + e);
+    }
+  }
+
+  @Then("Click on the Home link button")
+  public void clickOnTheHomeLinkButton() {
+    try {
+      WaitHelper.waitForPageToLoad();
+      Helper.waitSeconds(30);
+      WaitHelper.waitForElementToBeDisplayed(Helper.locateElementByTestId("breadcrumb-home-home"));
+      WaitHelper.waitForElementToBeClickable(Helper.locateElementByTestId("breadcrumb-home-home"));
+      ElementHelper.clickOnElement(Helper.locateElementByTestId("breadcrumb-home-home"));
+    } catch (Exception e) {
+      System.err.println("error:" + e);
+    }
+  }
+
+  @Then("Click on the Exploration card with \\\"(.*)\\\"")
+  public void clickOnTheExplorationCard(int testId) {
+    try {
+      WaitHelper.waitForPageToLoad();
+      Helper.waitSeconds(30);
+      ElementHelper.clickOnElement(Helper.locateElementByTestId
+              ("wrangler-home-ongoing-data-exploration-card-" + testId));
+    } catch (Exception e) {
+      System.err.println("error:" + e);
+    }
+  }
+
+  @Then("Click on the Home link of wrangle page")
+  public void clickOnTheHomeLink() {
+  try {
+    SeleniumDriver.getDriver().manage().window().maximize();
+    Helper.waitSeconds(50);
+    String url = SeleniumDriver.getDriver().getCurrentUrl();
+    Assert.assertTrue(url.contains("cdap/ns/default/wrangler-grid"));
+    WaitHelper.waitForElementToBeDisplayed(Helper.locateElementByTestId("breadcrumb-home-home"));
+    WaitHelper.waitForElementToBeClickable(Helper.locateElementByTestId("breadcrumb-home-home"));
+    WebElement ele = Helper.locateElementByTestId("breadcrumb-home-home");
+    ElementHelper.clickOnElement(ele);
+    } catch (Exception e) {
+      System.err.println("error:" + e);
+    }
+  }
+}

--- a/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/ConnectorTypes.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/ConnectorTypes.java
@@ -26,34 +26,30 @@ import io.cucumber.java.en.Then;
 import org.junit.Assert;
 
 public class ConnectorTypes {
-    @Given("Navigate to the Home Page")
-    public void navigateToTheHomePage() {
-        SeleniumDriver.openPage(Constants.WRANGLE_HOME_URL);
-        WaitHelper.waitForPageToLoad();
-    }
+  @Given("Navigate to the Home Page")
+  public void navigateToTheHomePage() {
+    SeleniumDriver.openPage(Constants.WRANGLE_HOME_URL);
+    WaitHelper.waitForPageToLoad();
+  }
 
-    @Then("Click on the \\\"(.*)\\\" connection with test id \\\"(.*)\\\"")
-    public void clickOnConnections(String connectionLabel, String connectionTestId) {
-        try {
-            ElementHelper.clickOnElement(Helper.locateElementByTestId("wrangle-card-" + connectionTestId));
-            System.out.println(connectionLabel + " Element is found successfully");
-            System.out.println("Clicked on " + connectionLabel + " Element");
-            WaitHelper.waitForPageToLoad();
-            if (connectionLabel.equals("Add Connections")) {
-                String actualText = SeleniumDriver.getDriver().getCurrentUrl();
-                Assert.assertEquals(actualText, "http://localhost:11011/cdap/ns/default/connections/create");
-                System.out.println("Navigated to " + connectionLabel + " Page - Old UI");
-            } else if (connectionLabel.equals("Import Data")) {
-                String actualText = SeleniumDriver.getDriver().getCurrentUrl();
-                Assert.assertEquals(actualText, "http://localhost:11011/cdap/ns/default/home");
-            } else {
-                String actualText = SeleniumDriver.getDriver().getCurrentUrl();
-                Assert.assertEquals(actualText, "http://localhost:11011/cdap/ns/default/datasources/"
-                        + connectionLabel);
-                System.out.println("Navigated to Data Source page with connection " + connectionLabel + " selected");
-            }
-        } catch (Exception e) {
-            System.err.println("error: " + e);
-        }
+  @Then("Click on the \\\"(.*)\\\" connection with test id \\\"(.*)\\\"")
+  public void clickOnConnections(String connectionLabel, String connectionTestId) {
+    try {
+      ElementHelper.clickOnElement(Helper.locateElementByTestId("wrangle-card-" + connectionTestId));
+      WaitHelper.waitForPageToLoad();
+      if (connectionLabel.equals("Add Connections")) {
+        String actualText = SeleniumDriver.getDriver().getCurrentUrl();
+        Assert.assertEquals(actualText, "http://localhost:11011/cdap/ns/default/connections/create");
+      } else if (connectionLabel.equals("Import Data")) {
+        String actualText = SeleniumDriver.getDriver().getCurrentUrl();
+        Assert.assertEquals(actualText, "http://localhost:11011/cdap/ns/default/home");
+      } else {
+        String actualText = SeleniumDriver.getDriver().getCurrentUrl();
+        Assert.assertEquals(actualText, "http://localhost:11011/cdap/ns/default/datasources/"
+                + connectionLabel);
+      }
+    } catch (Exception e) {
+      System.err.println("error: " + e);
     }
+  }
 }

--- a/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/SnackBar.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/SnackBar.java
@@ -25,60 +25,48 @@ import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import org.junit.Assert;
 import org.openqa.selenium.By;
-import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
 
 import java.util.ArrayList;
 import java.util.List;
 
-
-
-
 public class SnackBar {
-    @Given("Navigate to Home Page")
-    public void navigateToHomePage() {
-        try {
-            SeleniumDriver.openPage(Constants.WRANGLE_HOME_URL);
-            WaitHelper.waitForPageToLoad();
-        } catch (Exception e) {
-            System.err.println("error:" + e);
-        }
+  @Given("Navigate to Home Page")
+  public void navigateToHomePage() {
+    try {
+      SeleniumDriver.openPage(Constants.WRANGLE_HOME_URL);
+      WaitHelper.waitForPageToLoad();
+    } catch (Exception e) {
+      System.err.println("error:" + e);
     }
+  }
 
-    @Then("Click on the data exploration card")
-    public void clickOnTheDataExplorationCard() {
-        try {
-            WaitHelper.waitForPageToLoad();
-
-            List<String> productName = new ArrayList<String>();
-            List<WebElement> allProductsName = SeleniumDriver.getDriver().findElements(
-                    By.xpath(".//*[@data-testid='wrangler-home-ongoing-data-exploration-card']"));
-            ElementHelper.clickOnElement(allProductsName.get(0));
-            String url = SeleniumDriver.getDriver().getCurrentUrl();
-            Assert.assertTrue(url.contains("http://localhost:11011/cdap/ns/default/wrangler-grid"));
-        } catch (Exception e) {
-            System.err.println("error:" + e);
-        }
+  @Then("Click on the data exploration card")
+  public void clickOnTheDataExplorationCard() {
+    try {
+      WaitHelper.waitForPageToLoad();
+      List<String> productName = new ArrayList<String>();
+      List<WebElement> allProductsName = SeleniumDriver.getDriver().findElements(
+              By.xpath(".//*[@data-testid='wrangler-home-ongoing-data-exploration-card']"));
+      ElementHelper.clickOnElement(allProductsName.get(0));
+      String url = SeleniumDriver.getDriver().getCurrentUrl();
+      Assert.assertTrue(url.contains("http://localhost:11011/cdap/ns/default/wrangler-grid"));
+    } catch (Exception e) {
+      System.err.println("error:" + e);
     }
+  }
 
-    @Then("Click on the Snackbar close icon")
-    public void verifyTheSnackbarPopUpIsComingOrNot() {
-        try {
-            WaitHelper.waitForPageToLoad();
-            boolean flag = true;
-            while (flag == true) {
-                if (Helper.isElementExists(Helper.getCssSelectorByDataTestId("loading-indicator"))) {
-                    flag = true;
-                } else {
-                    flag = false;
-                }
-            }
-            WebElement ele = SeleniumDriver.getDriver().findElement
-                    (By.xpath("//*[@data-testid = 'snackbar-close-icon']"));
-            JavascriptExecutor executor = (JavascriptExecutor) SeleniumDriver.getDriver();
-            executor.executeScript("arguments[0].click();", ele);
-        } catch (Exception e) {
-            System.err.println("error:" + e);
-        }
+  @Then("Click on the Snackbar close icon")
+  public void verifyTheSnackbarPopUpIsComingOrNot() {
+    try {
+      WaitHelper.waitForPageToLoad();
+      WaitHelper.waitForElementToBeDisplayed(Helper.locateElementByTestId("snackbar-close-icon"));
+      WaitHelper.waitForElementToBeClickable(Helper.locateElementByTestId("snackbar-close-icon"));
+      WebElement ele = SeleniumDriver.getDriver().findElement
+              (By.xpath("//*[@data-testid = 'snackbar-close-icon']"));
+      ElementHelper.clickOnElement(ele);
+    } catch (Exception e) {
+      System.err.println("error:" + e);
     }
+  }
 }

--- a/src/e2e-test/java/io/cdap/cdap/ui/utils/Constants.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/utils/Constants.java
@@ -27,7 +27,7 @@ public class Constants {
     String.valueOf(TEST_TIMEOUT_TIME / 1000) +
     "seconds";
 
-  public static final String WRANGLE_HOME_URL = "http://localhost:11011/cdap/ns/default/home";
+  public static final String WRANGLE_HOME_URL = "http://localhost:11011/cdap/ns/default/wrangle";
   public static final String BASE_URL = "http://localhost:11011";
   public static final String BASE_SERVER_URL = "http://localhost:11015";
   public static final String BASE_PIPELINES_URL = BASE_URL + "/pipelines/ns/default";


### PR DESCRIPTION
# [CDAP-19685] : Modifications to the breadcrumb component of Grid Page to adjust dynamic paths(hyperlinks) to navigate based on the path that the dataset got wrangled.

## Description
Changed breadcrumb paths to display proper navigation path

## Files to be Reviewed
1. app/cdap/components/Breadcrumb/*
2. app/cdap/components/ConnectionList/Components/SubHeader/*
3. app/cdap/components/ConnectionList/Components/TabLabelCanSample/index.tsx
4. app/cdap/components/GridTable/index.tsx
5. app/cdap/components/GridTable/utils.ts
6. app/cdap/text/text-en.yaml
7. src/e2e-test/*

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [x] Testing
- [x] General Improvement
- [ ] Cherry Pick

## Links
Jira: [Jira issue #](fill-in.org)
https://cdap.atlassian.net/browse/CDAP-19685

## Test Plan
https://docs.google.com/spreadsheets/d/1UCc9Dv1Vi204_sYMGHOlqZ_DujiRYlm01c88CIKmkMk/edit#gid=506288192

## Screenshots
<img width="296" alt="route1" src="https://user-images.githubusercontent.com/106389490/190393313-eebd7bd9-2f91-417b-bde0-3f2c43b7e92f.png">
<img width="489" alt="routing2" src="https://user-images.githubusercontent.com/106389490/190393325-137856c2-f75b-4ab7-925c-aaabed94cb7e.png">

[CDAP-19685]: https://cdap.atlassian.net/browse/CDAP-19685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ