### PR TITLE
[CDAP-19801] Show created/deleted templates in studio immediately

### DIFF
--- a/app/cdap/components/hydrator/components/LeftPanel/LeftPanel.tsx
+++ b/app/cdap/components/hydrator/components/LeftPanel/LeftPanel.tsx
@@ -14,7 +14,7 @@
  * the License.
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import ChevronLeft from '@material-ui/icons/ChevronLeft';
 import ChevronRight from '@material-ui/icons/ChevronRight';
 import Select from '@material-ui/core/Select';
@@ -22,6 +22,8 @@ import SidePanel from 'components/hydrator/components/SidePanel/SidePanel';
 import MenuItem from '@material-ui/core/MenuItem';
 import { Button } from '@material-ui/core';
 import styled from 'styled-components';
+import AvailablePluginsStore from 'services/AvailablePluginsStore';
+import { useOnUnmount } from 'services/react/customHooks/useOnUnmount';
 
 interface ILeftPanelProps {
   onArtifactChange: (value: any) => void;
@@ -55,53 +57,66 @@ export const LeftPanel = ({
 }: ILeftPanelProps) => {
   // angular has this saved in local storage - is this necessary?
   const [isExpanded, setIsExpanded] = useState<boolean>(true);
+  const [availablePlugins, setAvailablePlugins] = useState(AvailablePluginsStore.getState());
+  let unsub;
+  useEffect(() => {
+    unsub = AvailablePluginsStore.subscribe(() => {
+      const avp = AvailablePluginsStore.getState();
+      if (avp.plugins) {
+        setAvailablePlugins(avp);
+      }
+    });
+  }, []);
+
+  useOnUnmount(() => {
+    unsub();
+  });
 
   return (
-    <>
-      <div className={`left-panel-wrapper ${isExpanded ? 'expanded' : ''}`}>
-        <div className="left-panel">
-          <div className="left-top-section">
-            <StyledSelect
-              value={selectedArtifact.label}
-              className="form-control"
-              onChange={(event: any) => onArtifactChange(event.currentTarget.dataset.name)}
-              MenuProps={{
-                getContentAnchorEl: null,
-                anchorOrigin: {
-                  vertical: 'bottom',
-                  horizontal: 'left',
-                },
-              }}
-              disabled={isEdit}
-            >
-              {artifacts.map((artifact) => {
-                return (
-                  <MenuItem value={artifact.label} key={artifact.label} data-name={artifact.name}>
-                    {artifact.label}
-                  </MenuItem>
-                );
-              })}
-            </StyledSelect>
-            <Button
-              onClick={() => setIsExpanded(!isExpanded)}
-              color="primary"
-              component="button"
-              className="btn-sm pull-right"
-            >
-              {isExpanded ? <ChevronLeft /> : <ChevronRight />}
-            </Button>
-          </div>
-          <div className="my-side-panel">
-            <SidePanel
-              itemGenericName={itemGenericName}
-              groups={groups}
-              groupGenericName={groupGenericName}
-              onPanelItemClick={(event, plugin) => onPanelItemClick(event, plugin)}
-              createPluginTemplate={createPluginTemplate}
-            />
-          </div>
+    <div className={`left-panel-wrapper ${isExpanded ? 'expanded' : ''}`}>
+      <div className="left-panel">
+        <div className="left-top-section">
+          <StyledSelect
+            value={selectedArtifact.label}
+            className="form-control"
+            onChange={(event: any) => onArtifactChange(event.currentTarget.dataset.name)}
+            MenuProps={{
+              getContentAnchorEl: null,
+              anchorOrigin: {
+                vertical: 'bottom',
+                horizontal: 'left',
+              },
+            }}
+            disabled={isEdit}
+          >
+            {artifacts.map((artifact) => {
+              return (
+                <MenuItem value={artifact.label} key={artifact.label} data-name={artifact.name}>
+                  {artifact.label}
+                </MenuItem>
+              );
+            })}
+          </StyledSelect>
+          <Button
+            onClick={() => setIsExpanded(!isExpanded)}
+            color="primary"
+            component="button"
+            className="btn-sm pull-right"
+          >
+            {isExpanded ? <ChevronLeft /> : <ChevronRight />}
+          </Button>
+        </div>
+        <div className="my-side-panel">
+          <SidePanel
+            availablePlugins={availablePlugins}
+            itemGenericName={itemGenericName}
+            groups={groups}
+            groupGenericName={groupGenericName}
+            onPanelItemClick={(event, plugin) => onPanelItemClick(event, plugin)}
+            createPluginTemplate={createPluginTemplate}
+          />
         </div>
       </div>
-    </>
+    </div>
   );
 };

--- a/app/cdap/components/hydrator/components/SidePanel/SidePanel.tsx
+++ b/app/cdap/components/hydrator/components/SidePanel/SidePanel.tsx
@@ -17,178 +17,39 @@
 import React, { useEffect, useState, MouseEvent } from 'react';
 
 import { myRemoveCamelCase } from 'services/filters/removeCamelCase';
-import AvailablePluginsStore from 'services/AvailablePluginsStore';
-import { useOnUnmount } from 'services/react/customHooks/useOnUnmount';
 import { shouldShowCustomIcon, getCustomIconSrc, filterPlugins, generateLabel } from './helpers';
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Button,
-  Chip,
-  Box,
-  Icon,
-  IconButton,
-  ListItem,
-  Typography,
-} from '@material-ui/core';
+import { Button, Chip, Box, Icon, Typography } from '@material-ui/core';
 import ArrowRightIcon from '@material-ui/icons/ArrowRight';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 import AppsIcon from '@material-ui/icons/Apps';
 import ListIcon from '@material-ui/icons/List';
-import styled, { css, createGlobalStyle } from 'styled-components';
+import { createGlobalStyle } from 'styled-components';
 import debounce from 'lodash/debounce';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import AddCircle from '@material-ui/icons/AddCircle';
 import DeleteIcon from '@material-ui/icons/Delete';
 import RichTooltip from 'components/shared/RichToolTip';
-import { ToolTipButtonContainer } from './sharedStyled';
+import {
+  EllipsisIconButton,
+  FontIconContainer,
+  GroupsContainer,
+  IconImg,
+  IconsMenuContainer,
+  ItemBodyWrapper,
+  ListOrIconsButton,
+  PluginBadge,
+  PluginButton,
+  PluginListItem,
+  PluginNameContainer,
+  PluginNameContainerList,
+  StyledAccordion,
+  StyledAccordionDetails,
+  StyledAccordionSummary,
+  StyledGroupName,
+  ToolTipButtonContainer,
+  TooltipContentBox,
+} from './sharedStyled';
 import ChangeVersionMenu from './ChangeVersionMenu';
-
-/**
- * the old styling was too specific and we can't get rid of the classname
- * otherwise the rest of the styling won't work so the && > && > && is a way
- * to make this styling more specific without using !important
- */
-const GroupsContainer = styled.div`
-  && {
-    && {
-      && {
-        overflow-y: scroll;
-        padding: 0;
-        right: 1px;
-        height: 100%;
-        border: none;
-      }
-    }
-  }
-`;
-
-const ItemBodyWrapper = styled.div`
-  background: white;
-  border: none;
-  display: flex;
-  flex-wrap: wrap;
-  flex-grow: 1;
-`;
-
-const StyledGroupName = styled(Typography)`
-  margin-left: 5px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-`;
-
-const StyledAccordion = styled(Accordion)`
-  background: #eeeeee;
-  :before {
-    border: none;
-  }
-
-  &.Mui-expanded {
-    margin: 0;
-    padding: 0;
-    overflow-y: scroll;
-  }
-`;
-
-const StyledAccordionDetails = styled(AccordionDetails)`
-  background: #ffffff;
-  background-clip: content-box;
-  padding: 0;
-  margin-top: 5px;
-`;
-
-const StyledAccordionSummary = styled(AccordionSummary)`
-  &.Mui-expanded {
-    min-height: 0px;
-  }
-  ${css`
-    .MuiAccordionSummary-content.Mui-expanded {
-      margin: 12px 0;
-    }
-  `}
-`;
-
-const ListOrIconsButton = styled(Button)`
-  min-width: 20px;
-  padding: 5px;
-  margin-left: 5px;
-  box-shadow: 0;
-  background: white;
-`;
-
-const EllipsisIconButton = styled(IconButton)`
-  width: 0;
-  height: 0;
-  z-index: 10000;
-  position: absolute;
-  top: 6px;
-  right: 2px;
-  visibility: hidden;
-`;
-
-// show ellipsisIconButton when you hover PluginButton
-//
-const PluginButton = styled(Button)`
-  color: #666666;
-  text-transform: none;
-  min-height: ${(props) => (props.sidePanelViewType === 'icon' ? '85px' : '0')};
-  &:hover {
-    ${EllipsisIconButton} {
-      visibility: visible;
-    }
-  }
-`;
-
-const IconsMenuContainer = styled.div`
-  flex: 0 1 0;
-  min-width: 33%;
-  display: flex;
-  flex-direction: column;
-  vertical-align: top;
-`;
-
-const FontIconContainer = styled.div`
-  && {
-    && {
-      && {
-        font-size: 32px;
-        display: flex;
-        flex-direction: column;
-      }
-    }
-  }
-`;
-
-// creates a 2 line max wrap text container
-const PluginNameContainer = styled.div`
-  line-height: 14px;
-  padding-top: 8px;
-  overflow: hidden;
-  font-weight: 500;
-  display: -webkit-box;
-  vertical-align: top;
-  text-overflow: ellipsis;
-  -webkit-line-clamp: 2;
-  text-align: center;
-  -webkit-box-orient: vertical;
-`;
-
-const PluginNameContainerList = styled.div`
-  margin-left: 5px;
-  width: 100%;
-  margin-right: 10px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-`;
-
-const IconImg = styled.img`
-  width: 32px;
-  height: 32px;
-  margin: 0 auto;
-`;
 
 /**
  * Mui creates tooltips at the bottom of the dom tree
@@ -196,36 +57,37 @@ const IconImg = styled.img`
  * the style won't apply to that element - this is a way
  * to just insert regular css onto the page using styled-comps
  */
-const GlobalTooltipStyle = createGlobalStyle`
-  .MuiTooltip-popper {
-    .MuiTooltip-tooltip {
-      background-color: black;
+export const GlobalTooltipStyle = createGlobalStyle`
+ .MuiTooltip-popper {
+   .MuiTooltip-tooltip {
+     background-color: black;
+   }
+ }
+`;
+
+const organizePlugins = (pluginGroups, availablePlugins) => {
+  pluginGroups.forEach((group) => {
+    if (!group.plugins?.length) {
+      return;
     }
-  }
-`;
 
-const PluginListItem = styled(ListItem)`
-  padding: 0;
-`;
+    group.plugins.forEach((plugin) => {
+      plugin.displayName =
+        generateLabel(plugin, availablePlugins.plugins.pluginsMap) || plugin.name;
+      plugin.showCustomIcon = shouldShowCustomIcon(plugin, availablePlugins.plugins.pluginsMap);
+      plugin.customIconSrc = getCustomIconSrc(plugin, availablePlugins.plugins.pluginsMap);
+    });
 
-const TooltipContentBox = styled(Box)`
-  max-width: 300px;
-`;
+    group.plugins.sort((pluginA, pluginB) => {
+      return pluginA.displayName < pluginB.displayName ? -1 : 1;
+    });
+  });
 
-const PluginBadge = styled.div`
-  display: block;
-  font-size: 8px;
-  position: absolute;
-  left: 90%;
-  background: #d8d8d8;
-  border-radius: 2px;
-
-  padding: 3px;
-  line-height: 8px;
-  bottom: 3px;
-`;
+  return pluginGroups;
+};
 
 interface ISidePanelProps {
+  availablePlugins: any;
   itemGenericName: string;
   groups: any[];
   groupGenericName: string;
@@ -252,6 +114,7 @@ interface ISidePanelProps {
  *    that altered plugin.defaultArtifact to the canvas and it automatically sends that to be saved...
  */
 export const SidePanel = ({
+  availablePlugins,
   itemGenericName,
   groups,
   groupGenericName,
@@ -275,7 +138,6 @@ export const SidePanel = ({
     setOpenPopoverId(null);
   };
 
-  let AvailablePluginsStoreSubscription;
   useEffect(() => {
     // set first group opened
     if (groups && groups.length) {
@@ -284,35 +146,14 @@ export const SidePanel = ({
   }, [groups, groups.length]);
 
   useEffect(() => {
-    AvailablePluginsStoreSubscription = AvailablePluginsStore.subscribe(() => {
-      const all = AvailablePluginsStore.getState();
-      if (all.plugins) {
-        // treat plugin group plugins as immutable
-        const newPluginGroups = pluginGroups.map((group) => {
-          const newGroup = { ...group, plugins: [] };
-          newGroup.plugins = group.plugins
-            .map((plugin) => {
-              return {
-                ...plugin,
-                displayName: generateLabel(plugin, all.plugins.pluginsMap) || plugin.name,
-                showCustomIcon: shouldShowCustomIcon(plugin, all.plugins.pluginsMap),
-                customIconSrc: getCustomIconSrc(plugin, all.plugins.pluginsMap),
-              };
-            })
-            .sort((pluginA, pluginB) => {
-              return pluginA.displayName < pluginB.displayName ? -1 : 1;
-            });
-          return newGroup;
-        });
+    if (availablePlugins && availablePlugins.plugins) {
+      setPluginGroups(organizePlugins(pluginGroups, availablePlugins));
+    }
+  }, [availablePlugins]);
 
-        setPluginGroups(newPluginGroups);
-      }
-    });
-  }, []);
-
-  useOnUnmount(() => {
-    AvailablePluginsStoreSubscription();
-  });
+  useEffect(() => {
+    setPluginGroups(organizePlugins(pluginGroups, availablePlugins));
+  }, [groups]);
 
   const handleSetSearch = debounce((text) => {
     setSearchText(text);

--- a/app/cdap/components/hydrator/components/SidePanel/sharedStyled.tsx
+++ b/app/cdap/components/hydrator/components/SidePanel/sharedStyled.tsx
@@ -14,7 +14,18 @@
  * the License.
  */
 
-import styled from 'styled-components';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Button,
+  Box,
+  IconButton,
+  ListItem,
+  Typography,
+} from '@material-ui/core';
+
+import styled, { css } from 'styled-components';
 
 export const ToolTipButtonContainer = styled.div`
   color: blue;
@@ -25,4 +36,170 @@ export const ToolTipButtonContainer = styled.div`
     height: 0.8em;
     width: 0.8em;
   }
+`;
+
+/**
+ * the old styling was too specific and we can't get rid of the classname
+ * otherwise the rest of the styling won't work so the && > && > && is a way
+ * to make this styling more specific without using !important
+ */
+export const GroupsContainer = styled.div`
+  && {
+    && {
+      && {
+        overflow-y: scroll;
+        padding: 0;
+        right: 1px;
+        height: 100%;
+        border: none;
+      }
+    }
+  }
+`;
+
+export const ItemBodyWrapper = styled.div`
+  background: white;
+  border: none;
+  display: flex;
+  flex-wrap: wrap;
+  flex-grow: 1;
+`;
+
+export const StyledGroupName = styled(Typography)`
+  margin-left: 5px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+`;
+
+export const StyledAccordion = styled(Accordion)`
+  background: #eeeeee;
+  :before {
+    border: none;
+  }
+
+  &.Mui-expanded {
+    margin: 0;
+    padding: 0;
+    overflow-y: scroll;
+  }
+`;
+
+export const StyledAccordionDetails = styled(AccordionDetails)`
+  background: #ffffff;
+  background-clip: content-box;
+  padding: 0;
+  margin-top: 5px;
+`;
+
+export const StyledAccordionSummary = styled(AccordionSummary)`
+  &.Mui-expanded {
+    min-height: 0px;
+  }
+  ${css`
+    .MuiAccordionSummary-content.Mui-expanded {
+      margin: 12px 0;
+    }
+  `}
+`;
+
+export const ListOrIconsButton = styled(Button)`
+  min-width: 20px;
+  padding: 5px;
+  margin-left: 5px;
+  box-shadow: 0;
+  background: white;
+`;
+
+export const EllipsisIconButton = styled(IconButton)`
+  width: 0;
+  height: 0;
+  z-index: 10000;
+  position: absolute;
+  top: 6px;
+  right: 2px;
+  visibility: hidden;
+`;
+
+// show ellipsisIconButton when you hover PluginButton
+//
+export const PluginButton = styled(Button)`
+  color: #666666;
+  text-transform: none;
+  min-height: ${(props) => (props.sidePanelViewType === 'icon' ? '85px' : '0')};
+  &:hover {
+    ${EllipsisIconButton} {
+      visibility: visible;
+    }
+  }
+`;
+
+export const IconsMenuContainer = styled.div`
+  flex: 0 1 0;
+  min-width: 33%;
+  display: flex;
+  flex-direction: column;
+  vertical-align: top;
+`;
+
+export const FontIconContainer = styled.div`
+  && {
+    && {
+      && {
+        font-size: 32px;
+        display: flex;
+        flex-direction: column;
+      }
+    }
+  }
+`;
+
+// creates a 2 line max wrap text container
+export const PluginNameContainer = styled.div`
+  line-height: 14px;
+  padding-top: 8px;
+  overflow: hidden;
+  font-weight: 500;
+  display: -webkit-box;
+  vertical-align: top;
+  text-overflow: ellipsis;
+  -webkit-line-clamp: 2;
+  text-align: center;
+  -webkit-box-orient: vertical;
+`;
+
+export const PluginNameContainerList = styled.div`
+  margin-left: 5px;
+  width: 100%;
+  margin-right: 10px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+export const IconImg = styled.img`
+  width: 32px;
+  height: 32px;
+  margin: 0 auto;
+`;
+
+export const PluginListItem = styled(ListItem)`
+  padding: 0;
+`;
+
+export const TooltipContentBox = styled(Box)`
+  max-width: 300px;
+`;
+
+export const PluginBadge = styled.div`
+  display: block;
+  font-size: 8px;
+  position: absolute;
+  left: 90%;
+  background: #d8d8d8;
+  border-radius: 2px;
+
+  padding: 3px;
+  line-height: 8px;
+  bottom: 3px;
 `;


### PR DESCRIPTION
# [CDAP-19801]

## Description
Moved styled components to different file from sidePanel.tsx
Moved Available plugins store call to LeftPanel.tsx
Created templates are now shown immediately after created
Deleted templates are now deleted after created
Code Cleanup

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick




[CDAP-19801]: https://cdap.atlassian.net/browse/CDAP-19801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ