### PR TITLE
[CDAP-19825] change z index so popup doesn't stay over hub

### DIFF
--- a/app/cdap/components/shared/RichToolTip/index.tsx
+++ b/app/cdap/components/shared/RichToolTip/index.tsx
@@ -45,7 +45,7 @@ const useStyles = makeStyles((theme) => {
       padding: theme.spacing(2),
     },
     popper: {
-      zIndex: 2000,
+      zIndex: 1060,
       '&[x-placement*="bottom"] $arrow': {
         top: 0,
         left: 0,


### PR DESCRIPTION
# [CDAP-19825] change z index so popup doesn't stay over hub

## Description
z index change

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick




[CDAP-19825]: https://cdap.atlassian.net/browse/CDAP-19825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ