### PR TITLE
CDAP-19993 Remove whatwg-fetch from explicit dependencies

### DIFF
--- a/app/cdap/components/CaskWizards/OneStepDeploy/OneStepDeployApp.js
+++ b/app/cdap/components/CaskWizards/OneStepDeploy/OneStepDeployApp.js
@@ -21,7 +21,6 @@ import MarketStore from 'components/Market/store/market-store';
 import OneStepDeployStore from 'services/WizardStores/OneStepDeploy/OneStepDeployStore';
 import OneStepDeployActions from 'services/WizardStores/OneStepDeploy/OneStepDeployActions';
 import NamespaceStore from 'services/NamespaceStore';
-import 'whatwg-fetch';
 import { Observable } from 'rxjs/Observable';
 import OneStepDeployWizard from 'components/CaskWizards/OneStepDeploy';
 import Cookies from 'universal-cookie';

--- a/app/cdap/components/CaskWizards/OneStepDeploy/OneStepDeployPlugin.js
+++ b/app/cdap/components/CaskWizards/OneStepDeploy/OneStepDeployPlugin.js
@@ -20,7 +20,6 @@ import React, { Component } from 'react';
 import OneStepDeployStore from 'services/WizardStores/OneStepDeploy/OneStepDeployStore';
 import OneStepDeployActions from 'services/WizardStores/OneStepDeploy/OneStepDeployActions';
 import NamespaceStore from 'services/NamespaceStore';
-import 'whatwg-fetch';
 import { Observable } from 'rxjs/Observable';
 import OneStepDeployWizard from 'components/CaskWizards/OneStepDeploy';
 import Cookies from 'universal-cookie';

--- a/app/cdap/components/FastAction/ExploreAction/ExploreModal.js
+++ b/app/cdap/components/FastAction/ExploreAction/ExploreModal.js
@@ -21,7 +21,6 @@ import { Modal, ModalHeader, ModalBody } from 'reactstrap';
 import myExploreApi from 'api/explore';
 import isObject from 'lodash/isObject';
 import uuidV4 from 'uuid/v4';
-import 'whatwg-fetch';
 import { insertAt, removeAt, humanReadableDate } from 'services/helpers';
 import { UncontrolledTooltip } from 'components/UncontrolledComponents';
 require('./ExploreModal.scss');

--- a/app/cdap/components/shared/AppHeader/AccessTokenModal/index.tsx
+++ b/app/cdap/components/shared/AppHeader/AccessTokenModal/index.tsx
@@ -21,7 +21,6 @@ import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 import CardActionFeedback from 'components/shared/CardActionFeedback';
 import SessionStore from 'services/SessionTokenStore';
 import T from 'i18n-react';
-import 'whatwg-fetch';
 
 import './AccessTokenModal.scss';
 

--- a/app/cdap/services/StatusFactory.js
+++ b/app/cdap/services/StatusFactory.js
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import 'whatwg-fetch';
 import LoadingIndicatorStore, {
   BACKENDSTATUS,
 } from 'components/shared/LoadingIndicator/LoadingIndicatorStore';

--- a/app/cdap/services/WindowManager/index.ts
+++ b/app/cdap/services/WindowManager/index.ts
@@ -15,7 +15,6 @@
  */
 
 import ee from 'event-emitter';
-import 'whatwg-fetch';
 import ifvisible from 'ifvisible.js';
 import { objectQuery } from 'services/helpers';
 const WINDOW_ON_BLUR = 'WINDOW_BLUR_EVENT';

--- a/app/login/login.js
+++ b/app/login/login.js
@@ -16,7 +16,6 @@
 
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
-import 'whatwg-fetch';
 import Cookies from 'universal-cookie';
 
 import Card from 'components/shared/Card';

--- a/package.json
+++ b/package.json
@@ -262,7 +262,6 @@
     "vega-lite": "2.0.0-beta.16",
     "vega-tooltip": "0.4.3",
     "webpack-dev-server": "3.11.0",
-    "whatwg-fetch": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-1.0.0.tgz",
     "yml-loader": "2.1.0"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -22515,10 +22515,6 @@ whatwg-fetch@^0.9.0:
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz#0e3684c6cb9995b43efc9df03e4c365d95fd9cc0"
   integrity sha1-DjaExsuZlbQ+/J3wPkw2XZX9nMA=
 
-"whatwg-fetch@https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-1.0.0.tgz":
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-1.0.0.tgz#01c2ac4df40e236aaa18480e3be74bd5c8eb798e"
-
 whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"


### PR DESCRIPTION
# TITLE

## Description
This removes whatwg-fetch from `package.json` because it's not needed in modern browsers. It's still included because of a transitive dependency.

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [X] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19993](https://cdap.atlassian.net/browse/CDAP-19993)

## Test Plan
General regression. Covered by integration tests.

## Screenshots


