### PR TITLE
[cdap-20008] - watch number of plugins 

### DIFF
--- a/app/cdap/components/hydrator/components/SidePanel/ChangeVersionMenu.tsx
+++ b/app/cdap/components/hydrator/components/SidePanel/ChangeVersionMenu.tsx
@@ -67,7 +67,7 @@ export default function ChangeVersionMenu({
     <>
       <Button aria-label={'change version'} component="span" onClick={handleOpen} ref={elementRef}>
         <ToolTipButtonContainer>
-          <EditIcon /> Change
+          <EditIcon /> Change Version
         </ToolTipButtonContainer>
       </Button>
       <Menu

--- a/app/cdap/components/hydrator/components/SidePanel/SidePanel.tsx
+++ b/app/cdap/components/hydrator/components/SidePanel/SidePanel.tsx
@@ -71,7 +71,6 @@ const organizePlugins = (pluginGroups, availablePlugins) => {
     if (!group.plugins?.length) {
       return;
     }
-
     group.plugins.forEach((plugin) => {
       plugin.displayName =
         generateLabel(plugin, availablePlugins.plugins.pluginsMap) || plugin.name;
@@ -131,6 +130,11 @@ export const SidePanel = ({
   const [sidePanelViewType, setSidePanelViewType] = useState<string>('icon');
   const [openPopoverId, setOpenPopoverId] = useState<string | null>(null);
 
+  // keep track of number of plugins so if you create a template we can rerun organizePlugins
+  const numberOfPlugins = groups.reduce((prev, curr) => {
+    return (prev += curr.plugins.length);
+  }, 0);
+
   const handlePopperButtonClick = (popoverId: string) => (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     event.preventDefault();
@@ -158,7 +162,7 @@ export const SidePanel = ({
 
   useEffect(() => {
     setPluginGroups(organizePlugins(pluginGroups, availablePlugins));
-  }, [groups]);
+  }, [numberOfPlugins]);
 
   const handleSetSearch = debounce((text) => {
     // open all accordions when searching (then filtered closes them if no plugins)
@@ -208,7 +212,7 @@ export const SidePanel = ({
       const ToolTipContent = (
         <TooltipContentBox>
           <Box>
-            <Typography variant="h6">{label}</Typography>
+            <Typography variant="h4">{label}</Typography>
             <Button
               aria-label={`show more ${label}`}
               component="span"
@@ -236,7 +240,7 @@ export const SidePanel = ({
             )}
           </Box>
           <Box>
-            <Typography>
+            <Typography variant="h6">
               {plugin.defaultArtifact?.version} {plugin.defaultArtifact?.scope}
             </Typography>
             <ChangeVersionMenu changePluginVersion={handleChangePluginVersion} plugin={plugin} />


### PR DESCRIPTION
# [CDAP-20008] - watch plugin versions and small style fixes

## Description
Count number of plugins and organize plugins based on that (useEffect only does shallow watch)
Fix styling on plugin context

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## screenshots
![Screen Shot 2022-11-03 at 12 44 58 PM](https://user-images.githubusercontent.com/2054644/199821751-fa71d84c-7385-4a84-a944-dc5a29ed6380.png)




[CDAP-20008]: https://cdap.atlassian.net/browse/CDAP-20008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ