### PR TITLE
CDAP-19787 Handle error when opening deleted Wrangler workspace from Studio

### DIFF
--- a/app/cdap/components/DataPrep/DataPrepErrorAlert/index.js
+++ b/app/cdap/components/DataPrep/DataPrepErrorAlert/index.js
@@ -27,6 +27,7 @@ export default class DataPrepErrorAlert extends Component {
 
     this.state = {
       showError: state.showError,
+      workspaceError: state.workspaceError,
     };
 
     this.dismissError = this.dismissError.bind(this);
@@ -38,6 +39,7 @@ export default class DataPrepErrorAlert extends Component {
 
       this.setState({
         showError: state.showError,
+        workspaceError: state.workspaceError,
       });
     });
   }
@@ -54,18 +56,23 @@ export default class DataPrepErrorAlert extends Component {
     });
   }
 
+  getErrorMessage() {
+    if (this.state.showError) {
+      return this.state.showError;
+    } else if (this.state.workspaceError) {
+      return this.state.workspaceError.message;
+    }
+  }
+
   render() {
-    if (!this.state.showError) {
+    const errorMessage = this.getErrorMessage();
+
+    if (!errorMessage) {
       return null;
     }
 
     return (
-      <Alert
-        showAlert={true}
-        type="error"
-        message={this.state.showError}
-        onClose={this.dismissError}
-      />
+      <Alert showAlert={true} type="error" message={errorMessage} onClose={this.dismissError} />
     );
   }
 }

--- a/app/cdap/components/DataPrep/index.js
+++ b/app/cdap/components/DataPrep/index.js
@@ -87,12 +87,14 @@ export default class DataPrep extends Component {
         state.error.workspaceError.message !== this.state.workspaceError.message &&
         state.error.workspaceError.statusCode !== this.state.workspaceError.statusCode
       ) {
-        this.setState({ workspaceError: state.error.workspaceError }, () => {
-          this.eventEmitter.emit(globalEvents.PAGE_LEVEL_ERROR, {
-            data: this.state.workspaceError.message,
-            statusCode: this.state.workspaceError.statusCode,
+        if (!this.props.mode === 'ROUTED_WORKSPACE') {
+          this.setState({ workspaceError: state.error.workspaceError }, () => {
+            this.eventEmitter.emit(globalEvents.PAGE_LEVEL_ERROR, {
+              data: this.state.workspaceError.message,
+              statusCode: this.state.workspaceError.statusCode,
+            });
           });
-        });
+        }
       }
     });
   }


### PR DESCRIPTION
# CDAP-19787 Handle error when opening deleted Wrangler workspace from Studio

## Description
When opening a deleted Wrangler workspace from Studio, the user was shown an empty Wrangler table. Once Wrangler and the plugin properties were closed, the Studio UI was replaced by a full-page error.

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19787](https://cdap.atlassian.net/browse/CDAP-19787)

## Test Plan
Manual testing

## Screenshots
![image](https://user-images.githubusercontent.com/2728821/200422895-2b23ab03-a6e4-405e-8c10-e32a6b0383fc.png)


