### PR TITLE
cancel ongoing runs of the same PR only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
 
     # Cancel ongoing runs
     concurrency: 
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
 
     steps:


### PR DESCRIPTION
# Cancel ongoing runs of the same PR only

## Description
This PR modifies the concurrency part of the build file, so that PRs from diff authors don't cancel each other (not fully tested, might end up remove cancellation overall if the result is not desired)

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [X] General Improvement
- [ ] Cherry Pick

## Links
N/A

## Test Plan
N/A

## Screenshots
N/A

