### PR TITLE
Conversion of widget code editor tests from cypress to selenium

### DIFF
--- a/app/hydrator/templates/partial/node-config-modal/popover.html
+++ b/app/hydrator/templates/partial/node-config-modal/popover.html
@@ -52,6 +52,7 @@
     </div>
     <button class="btn btn-primary validate-btn" type="button"
             data-cy="plugin-properties-validate-btn"
+            data-testid="plugin-properties-validate-btn"
             ng-if="!isDisabled"
             ng-class="{'disabled': HydratorPlusPlusNodeConfigCtrl.validating}"
             ng-click="!HydratorPlusPlusNodeConfigCtrl.validating && HydratorPlusPlusNodeConfigCtrl.validatePluginProperties()">

--- a/src/e2e-test/features/widget.codeeditor.feature
+++ b/src/e2e-test/features/widget.codeeditor.feature
@@ -1,0 +1,36 @@
+#
+# Copyright © 2022 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+@Integration_Tests
+Feature: Widget Code editor Tests
+
+  @WIDGET_CODE_EDITOR_TEST
+  Scenario: Should render default value the first time
+    When Open Pipeline Studio Page
+    Then Toggle Transform panel
+    Then Add JS node to canvas
+    Then Open JS node properties
+    Then Get JS editor value and compare with default JS editor value
+    Then Exit Studio Page
+
+  @WIDGET_CODE_EDITOR_TEST
+  Scenario: Should not jump the cursor position on selecting text and replacing them
+    When Open Pipeline Studio Page
+    Then Toggle Transform panel
+    Then Add JS node to canvas
+    Then Open JS node properties
+    Then Replace and verify JS editor value and cursor position
+    Then Exit Studio Page

--- a/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/WidgetCodeEditor.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/WidgetCodeEditor.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.ui.stepsdesign;
+
+import io.cdap.cdap.ui.types.NodeInfo;
+import io.cdap.cdap.ui.utils.Commands;
+import io.cdap.cdap.ui.utils.Helper;
+import io.cdap.e2e.pages.actions.CdfStudioActions;
+import io.cdap.e2e.utils.ElementHelper;
+import io.cdap.e2e.utils.SeleniumDriver;
+import io.cucumber.java.en.Then;
+import org.apache.commons.lang.StringUtils;
+import org.junit.Assert;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebElement;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class WidgetCodeEditor {
+    private NodeInfo jSNode = new NodeInfo("JavaScript", "transform", "0");
+    private static final String defaultJsEditorVal = "/**\n" +
+            " * @summary Transforms the provided input record into zero or more output records or errors.\n" +
+            "\n" +
+            " * Input records are available in JavaScript code as JSON objects. \n" +
+            "\n" +
+            " * @param input an object that contains the input record as a JSON.   " +
+            "e.g. to access a field called 'total' from the input record, use input.total.\n" +
+            " * @param emitter an object that can be used to emit zero or more records " +
+            "(using the emitter.emit() method) or errors (using the emitter.emitError() method) \n" +
+            " * @param context an object that provides access to:\n" +
+            " *            1. CDAP Metrics - context.getMetrics().count('output', 1);\n" +
+            " *            2. CDAP Logs - context.getLogger().debug('Received a record');\n" +
+            " *            3. Lookups - context.getLookup('blacklist').lookup(input.id); or\n" +
+            " *            4. Runtime Arguments - context.getArguments().get('priceThreshold') \n" +
+            " */ \n" +
+            "function transform(input, emitter, context) {\n" +
+            "  emitter.emit(input);\n" +
+            "}";
+
+    @Then("Toggle Transform panel")
+    public void toggleTransformPanel() {
+        Commands.toggleTransformPanel();
+    }
+
+    @Then("Add JS node to canvas")
+    public void addJSNodeToCanvas() {
+        Commands.addNodeToCanvas(jSNode);
+    }
+
+    @Then("Open JS node properties")
+    public void openJSNodeProperties() {
+        CdfStudioActions.navigateToPluginPropertiesPage(jSNode.getNodeName());
+    }
+    @Then("Get JS editor value and compare with default JS editor value")
+    public void verifyDefaultJSEditorValue() {
+        WebElement jsEditorElement = Helper.locateElementByCssSelector("div[class*='ace-editor-ref']");
+        WebElement jsEditorContentElement = jsEditorElement.findElement(
+                By.cssSelector("div[class*='ace_text-layer']"));
+        String editorValue = ElementHelper.getElementText(jsEditorContentElement);
+        Assert.assertEquals(StringUtils.normalizeSpace(editorValue),
+                StringUtils.normalizeSpace(defaultJsEditorVal));
+    }
+
+    @Then("Replace and verify JS editor value and cursor position")
+    public void replaceJSEditorValueAndVerifyCursor() {
+        WebElement jsEditorElement = Helper.locateElementByCssSelector("div[class*='ace-editor-ref']");
+        JavascriptExecutor jsExecutor = (JavascriptExecutor) SeleniumDriver.getDriver();
+        jsExecutor.executeScript("ace.edit(arguments[0]).gotoLine(15)", jsEditorElement);
+        jsExecutor.executeScript("ace.edit(arguments[0]).session.doc" +
+                ".replace({start: {row: 14, column: 0},end: {row: 14, column: 30}}, 'console.log(\"newcode\");')",
+                jsEditorElement);
+
+        WebElement jsEditorContentElement = jsEditorElement.findElement(
+                By.cssSelector("div[class*='ace_text-layer']"));
+        String editorValue = ElementHelper.getElementText(jsEditorContentElement);
+        Assert.assertTrue(editorValue.contains("console.log(\"newcode\");"));
+
+        String rowPosition = jsExecutor.executeScript(
+                "return ace.edit(arguments[0]).getCursorPosition().row;", jsEditorElement).toString();
+        String columnPosition = jsExecutor.executeScript(
+                "return ace.edit(arguments[0]).getCursorPosition().column;", jsEditorElement).toString();
+        Assert.assertEquals("14", rowPosition);
+        Assert.assertEquals("23", columnPosition);
+    }
+}

--- a/src/e2e-test/java/io/cdap/cdap/ui/utils/Commands.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/utils/Commands.java
@@ -24,7 +24,6 @@ import io.cdap.e2e.utils.SeleniumDriver;
 import io.cdap.e2e.utils.WaitHelper;
 import org.apache.commons.io.FileUtils;
 import org.openqa.selenium.By;
-import org.openqa.selenium.Keys;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebElement;


### PR DESCRIPTION
# [CDAP-19253](https://cdap.atlassian.net/browse/CDAP-19253) : Convert widget.codeeditor.spec.ts test from cypress to selenium

## Description
Conversion of widget code editor tests from cypress to selenium.

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [x] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19253](https://cdap.atlassian.net/browse/CDAP-19253)

## Test Plan
Included in cdap UI e2e test

## Screenshots
n/a


