### PR TITLE
[CDAP-19967]: fix view metadata button for plugins with no reference name

### DIFF
--- a/app/cdap/api/pipeline.js
+++ b/app/cdap/api/pipeline.js
@@ -23,6 +23,7 @@ const artifactBasePath = `/namespaces/:namespace/artifacts/:artifactName/version
 const statsPath = `${basepath}/workflows/:workflowId/statistics?start=0`;
 const schedulePath = `${basepath}/schedules/:scheduleId`;
 const programPath = `${basepath}/:programType/:programName`;
+const metadataPath = `${basepath}/workflows/:workflowType/runs/:runId/endpoints`;
 const runsCountPath = '/namespaces/:namespace/runcount';
 const batchRunsPath = '/namespaces/:namespace/runs';
 const batchNextRuntimePath = '/namespaces/:namespace/nextruntime';
@@ -46,6 +47,7 @@ export const MyPipelineApi = {
   getScheduleStatus: apiCreator(dataSrc, 'GET', 'REQUEST', `${schedulePath}/status`),
 
   getStatistics: apiCreator(dataSrc, 'GET', 'REQUEST', statsPath),
+  getMetadataEndpoints: apiCreator(dataSrc, 'GET', 'REQUEST', metadataPath),
   getRunDetails: apiCreator(dataSrc, 'GET', 'REQUEST', `${programPath}/runs/:runid`),
   getRuns: apiCreator(dataSrc, 'GET', 'REQUEST', `${programPath}/runs`),
   pollRuns: apiCreator(dataSrc, 'GET', 'POLL', `${programPath}/runs`),

--- a/app/cdap/components/CaskWizards/MicroserviceUpload/index.js
+++ b/app/cdap/components/CaskWizards/MicroserviceUpload/index.js
@@ -16,7 +16,7 @@
 import PropTypes from 'prop-types';
 
 import React, { Component } from 'react';
-import {Observable} from 'rxjs/Observable';
+import { Observable } from 'rxjs/Observable';
 import WizardModal from 'components/shared/WizardModal';
 import Wizard from 'components/shared/Wizard';
 import MicroserviceUploadStore from 'services/WizardStores/MicroserviceUpload/MicroserviceUploadStore';
@@ -26,7 +26,7 @@ import MicroserviceUploadActionCreator from 'services/WizardStores/MicroserviceU
 import MicroserviceQueueStore from 'services/WizardStores/MicroserviceUpload/MicroserviceQueueStore';
 import MicroserviceQueueActions from 'services/WizardStores/MicroserviceUpload/MicroserviceQueueActions';
 import NamespaceStore from 'services/NamespaceStore';
-import {MyProgramApi} from 'api/program';
+import { MyProgramApi } from 'api/program';
 import T from 'i18n-react';
 import ee from 'event-emitter';
 import globalEvents from 'services/global-events';
@@ -39,17 +39,16 @@ export default class MicroserviceUploadWizard extends Component {
     super(props);
     this.state = {
       showWizard: false,
-      successInfo: {}
+      successInfo: {},
     };
     this.eventEmitter = ee(ee);
   }
   componentWillMount() {
-    return MicroserviceUploadActionCreator
-      .findMicroserviceArtifact()
+    return MicroserviceUploadActionCreator.findMicroserviceArtifact()
       .mergeMap((artifact) => {
         MicroserviceUploadStore.dispatch({
           type: MicroserviceUploadActions.setMicroserviceArtifact,
-          payload: { artifact }
+          payload: { artifact },
         });
         if (isEmpty(artifact)) {
           return Observable.of([]);
@@ -59,38 +58,42 @@ export default class MicroserviceUploadWizard extends Component {
       .mergeMap((plugins) => {
         MicroserviceUploadStore.dispatch({
           type: MicroserviceUploadActions.setDefaultMicroservicePlugins,
-          payload: { plugins }
+          payload: { plugins },
         });
         this.setState({
-          showWizard: true
+          showWizard: true,
         });
-        return MicroserviceUploadActionCreator.getMicroservicePluginProperties(plugins[0].name || '');
+        return MicroserviceUploadActionCreator.getMicroservicePluginProperties(
+          plugins[0].name || ''
+        );
       })
-      .subscribe((propertiesArr) => {
-        if (propertiesArr.length > 0 && propertiesArr[0].properties) {
+      .subscribe(
+        (propertiesArr) => {
+          if (propertiesArr.length > 0 && propertiesArr[0].properties) {
+            MicroserviceUploadStore.dispatch({
+              type: MicroserviceUploadActions.setMicroservicePluginProperties,
+              payload: { pluginProperties: Object.keys(propertiesArr[0].properties) },
+            });
+          }
+        },
+        () => {
           MicroserviceUploadStore.dispatch({
             type: MicroserviceUploadActions.setMicroservicePluginProperties,
-            payload: {pluginProperties: Object.keys(propertiesArr[0].properties)}
+            payload: { pluginProperties: [] },
           });
         }
-      }, () => {
-        MicroserviceUploadStore.dispatch({
-          type: MicroserviceUploadActions.setMicroservicePluginProperties,
-          payload: {pluginProperties: []}
-        });
-      });
+      );
   }
   componentWillUnmount() {
     MicroserviceUploadStore.dispatch({
-      type: MicroserviceUploadActions.onReset
+      type: MicroserviceUploadActions.onReset,
     });
     MicroserviceQueueStore.dispatch({
-      type: MicroserviceQueueActions.onReset
+      type: MicroserviceQueueActions.onReset,
     });
   }
   onSubmit() {
-    return MicroserviceUploadActionCreator
-      .uploadArtifact()
+    return MicroserviceUploadActionCreator.uploadArtifact()
       .mergeMap(() => {
         return MicroserviceUploadActionCreator.uploadConfigurationJson();
       })
@@ -108,7 +111,7 @@ export default class MicroserviceUploadWizard extends Component {
       this.props.onClose(returnResult);
     }
     this.setState({
-      showWizard: !this.state.showWizard
+      showWizard: !this.state.showWizard,
     });
   }
   startMicroservice() {
@@ -120,7 +123,7 @@ export default class MicroserviceUploadWizard extends Component {
       appId,
       programType: 'workers',
       programId: 'microservice',
-      action: 'start'
+      action: 'start',
     };
 
     return MyProgramApi.action(params).map((res) => {
@@ -131,22 +134,22 @@ export default class MicroserviceUploadWizard extends Component {
   buildSuccessInfo() {
     let appName = MicroserviceUploadStore.getState().general.instanceName;
     let namespace = NamespaceStore.getState().selectedNamespace;
-    let message = T.translate('features.Wizard.MicroserviceUpload.success', {appName});
+    let message = T.translate('features.Wizard.MicroserviceUpload.success', { appName });
     let buttonLabel = T.translate('features.Wizard.MicroserviceUpload.callToAction');
     let links = [
       {
         linkLabel: T.translate('features.Wizard.MicroserviceUpload.secondaryCallToAction'),
         linkUrl: window.getAbsUIUrl({
           namespaceId: namespace,
-          appId: appName
-        })
+          appId: appName,
+        }),
       },
       {
         linkLabel: T.translate('features.Wizard.GoToHomePage'),
         linkUrl: window.getAbsUIUrl({
-          namespaceId: namespace
-        })
-      }
+          namespaceId: namespace,
+        }),
+      },
     ];
     this.setState({
       successInfo: {
@@ -154,14 +157,16 @@ export default class MicroserviceUploadWizard extends Component {
         buttonLabel,
         buttonUrl: 'javascript:;', // don't go anywhere, all behavior will be handled by buttonOnClick
         buttonOnClick: this.startMicroservice.bind(this),
-        links
-      }
+        links,
+      },
     });
   }
   render() {
     let input = this.props.input;
     let headerLabel = input.headerLabel;
-    let wizardModalTitle = (headerLabel ? headerLabel : T.translate('features.Resource-Center.Application.modalheadertitle'));
+    let wizardModalTitle = headerLabel
+      ? headerLabel
+      : T.translate('features.Resource-Center.Application.modalheadertitle');
     return (
       <WizardModal
         title={wizardModalTitle}
@@ -185,15 +190,15 @@ export default class MicroserviceUploadWizard extends Component {
 MicroserviceUploadWizard.defaultProps = {
   input: {
     action: {
-      arguments: {}
+      arguments: {},
     },
-    package: {}
-  }
+    package: {},
+  },
 };
 
 MicroserviceUploadWizard.propTypes = {
   isOpen: PropTypes.bool,
   input: PropTypes.any,
   onClose: PropTypes.func,
-  buildSuccessInfo: PropTypes.func
+  buildSuccessInfo: PropTypes.func,
 };

--- a/app/cdap/components/PipelineDetails/store/ActionCreator.js
+++ b/app/cdap/components/PipelineDetails/store/ActionCreator.js
@@ -296,6 +296,25 @@ const getStatistics = (params) => {
   );
 };
 
+const getMetadataEndpoints = ({ namespace, appId, workflowType, runId }) => {
+  return MyPipelineApi.getMetadataEndpoints({
+    namespace,
+    runId,
+    appId,
+    workflowType,
+  }).subscribe(
+    (res) => {
+      PipelineDetailStore.dispatch({
+        type: ACTIONS.SET_METADATA_ENDPOINTS,
+        payload: { metadataEndpoints: res.endpoints },
+      });
+    },
+    (err) => {
+      console.log(err);
+    }
+  );
+};
+
 const setMacros = (macrosMap) => {
   PipelineDetailStore.dispatch({
     type: ACTIONS.SET_MACROS,
@@ -411,6 +430,7 @@ export {
   pollRunsCount,
   getNextRunTime,
   getStatistics,
+  getMetadataEndpoints,
   setMacros,
   setUserRuntimeArguments,
   setMacrosAndUserRuntimeArguments,

--- a/app/cdap/components/PipelineDetails/store/index.js
+++ b/app/cdap/components/PipelineDetails/store/index.js
@@ -48,6 +48,9 @@ const ACTIONS = {
   // lifecycle management draftid
   SET_EDIT_DRAFT_ID: 'SET_EDIT_DRAFT_ID',
 
+  // Metadata Endpoints Actions
+  SET_METADATA_ENDPOINTS: 'SET_METADATA_ENDPOINTS',
+
   RESET: 'RESET',
 };
 
@@ -85,6 +88,9 @@ const DEFAULT_PIPELINE_DETAILS = {
   stopError: '',
   change: {},
   editDraftId: null,
+
+  // endpoints for plugin metadata
+  metadataEndpoints: [],
 };
 
 const pipelineDetails = (state = DEFAULT_PIPELINE_DETAILS, action = defaultAction) => {
@@ -181,6 +187,11 @@ const pipelineDetails = (state = DEFAULT_PIPELINE_DETAILS, action = defaultActio
       return {
         ...state,
         runsCount: action.payload.runsCount,
+      };
+    case ACTIONS.SET_METADATA_ENDPOINTS:
+      return {
+        ...state,
+        metadataEndpoints: action.payload.metadataEndpoints,
       };
     case ACTIONS.SET_STATISTICS:
       return {

--- a/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
+++ b/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
@@ -418,7 +418,17 @@ class HydratorPlusPlusNodeConfigCtrl {
             const generateJumpConfig = (jumpConfig, properties) => {
               let datasets = [];
               let jumpConfigDatasets = jumpConfig.datasets || [];
-              datasets = jumpConfigDatasets.map(dataset => ({ datasetId: properties[dataset['ref-property-name']], entityType: 'datasets' }));
+              datasets = jumpConfigDatasets.map(dataset => {
+                let datasetId = properties[dataset['ref-property-name']];
+                const { metadataEndpoints } = window.CaskCommon.PipelineDetailStore.getState();
+                if (!datasetId && metadataEndpoints) {
+                  const endpoint = metadataEndpoints.find(endpoint => {
+                    return endpoint.properties.stageName === this.state.node.id;
+                  });
+                  datasetId = endpoint && endpoint.name;
+                }
+                return { datasetId, entityType: 'datasets' };
+              });
               return {datasets};
             };
             if (res.errorDataset || this.state.node.errorDatasetName) {

--- a/app/hydrator/controllers/detail-ctrl.js
+++ b/app/hydrator/controllers/detail-ctrl.js
@@ -23,16 +23,16 @@ angular.module(PKG.name + '.feature.hydrator')
 
     this.pipelineType = rPipelineDetail.artifact.name;
     this.appInfo = {namespace: $stateParams.namespace, pipelineId: $stateParams.pipelineId};
-    let programType = GLOBALS.programType[this.pipelineType];
-    let programTypeForRunsCount = GLOBALS.programTypeForRunsCount[this.pipelineType];
-    let programName = GLOBALS.programId[this.pipelineType];
-    let scheduleId = GLOBALS.defaultScheduleId;
+    const programType = GLOBALS.programType[this.pipelineType];
+    const programTypeForRunsCount = GLOBALS.programTypeForRunsCount[this.pipelineType];
+    const programName = GLOBALS.programId[this.pipelineType];
+    const scheduleId = GLOBALS.defaultScheduleId;
 
     let currentRun, metricsObservable, runsPoll, runsCountPoll;
     let pluginsFetched = false;
 
     pipelineDetailsActionCreator.init(rPipelineDetail);
-    let runid = $stateParams.runid;
+    const runid = $stateParams.runid;
 
     this.eventEmitter = window.CaskCommon.ee(window.CaskCommon.ee);
     this.pageLevelError = null;
@@ -47,7 +47,7 @@ angular.module(PKG.name + '.feature.hydrator')
       }
     });
 
-    let runsFetch = pipelineDetailsActionCreator.getRuns({
+    const runsFetch = pipelineDetailsActionCreator.getRuns({
       namespace: $stateParams.namespace,
       appId: rPipelineDetail.name,
       programType,
@@ -55,8 +55,8 @@ angular.module(PKG.name + '.feature.hydrator')
     });
 
     runsFetch.subscribe(() => {
-      let {runs} = window.CaskCommon.PipelineDetailStore.getState();
-      let doesCurrentRunExists = _.find(runs, (run) => run.runid === runid);
+      const { runs } = window.CaskCommon.PipelineDetailStore.getState();
+      const doesCurrentRunExists = _.find(runs, (run) => run.runid === runid);
       /**
        * We do this here because of this usecase,
        *
@@ -118,21 +118,20 @@ angular.module(PKG.name + '.feature.hydrator')
       scheduleId
     });
 
-    let pipelineDetailStoreSubscription = window.CaskCommon.PipelineDetailStore.subscribe(() => {
-      let pipelineDetailStoreState = window.CaskCommon.PipelineDetailStore.getState();
+    const pipelineDetailStoreSubscription = window.CaskCommon.PipelineDetailStore.subscribe(() => {
+      const pipelineDetailStoreState = window.CaskCommon.PipelineDetailStore.getState();
 
       if (!pluginsFetched) {
-        let pluginsToFetchDetailsFor = pipelineDetailStoreState.config.stages.concat(pipelineDetailStoreState.config.postActions || []);
+        const pluginsToFetchDetailsFor = pipelineDetailStoreState.config.stages.concat(pipelineDetailStoreState.config.postActions || []);
         PipelineAvailablePluginsActions.fetchPluginsForDetails($stateParams.namespace, pluginsToFetchDetailsFor);
         pluginsFetched = true;
       }
 
-      let latestRun = pipelineDetailStoreState.currentRun;
+      const latestRun = pipelineDetailStoreState.currentRun;
       if (!latestRun || !latestRun.runid) {
         return;
       }
 
-      // let latestRunId = latestRun.runid;
       if (
         currentRun &&
         currentRun.runid === latestRun.runid &&
@@ -149,9 +148,9 @@ angular.module(PKG.name + '.feature.hydrator')
 
       currentRun = latestRun;
 
-      let metricProgramType = programType === 'workflows' ? 'workflow' : programType;
+      const metricProgramType = programType === 'workflows' ? 'workflow' : programType;
 
-      let metricParams = {
+      const metricParams = {
         namespace: $stateParams.namespace,
         app: rPipelineDetail.name,
         run: latestRun.runid,
@@ -167,6 +166,13 @@ angular.module(PKG.name + '.feature.hydrator')
       } else {
         metricsObservable = pipelineMetricsActionCreator.pollForMetrics(metricParams);
       }
+
+      pipelineDetailsActionCreator.getMetadataEndpoints({
+        namespace: $stateParams.namespace,
+        appId: rPipelineDetail.name,
+        runId: currentRun && currentRun.runid,
+        workflowType: GLOBALS.programId['cdap-data-pipeline'],
+      });
     });
 
     this.eventEmitter.on(window.CaskCommon.WINDOW_ON_FOCUS, () => {


### PR DESCRIPTION
# Fix view metadata button for plugins with no reference name

## Description
This PR cherry-picks the updatesto  the node properties page to fetch the `normalized fqn` in the absence of `reference name` so that navigation to the metadata page is not broken.

## PR Type
- [ ] Bug Fix
- [] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [X] Cherry Pick

## Links
Jira: [CDAP-19967](https://cdap.atlassian.net/browse/CDAP-19967)

## Test Plan
Manual

## Screenshots


