### PR TITLE
disable canceling ongoing runs in the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,6 @@ jobs:
     # Cancel ongoing runs
     concurrency: 
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-      cancel-in-progress: true
 
     steps:
     # Pinned 1.0.0 version


### PR DESCRIPTION
# Disables cancellation of ongoing runs in the build
## Description
This PR disables cancellation of ongoing runs in the build

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [X] General Improvement
- [ ] Cherry Pick

## Links
N/A

## Test Plan
N/A

## Screenshots
N/A

