### PR TITLE
make mvn cmd output less verbose

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
         yarn run cdap-full-build-more-memory # Build UI
         yarn start &
         yarn run test:unit
-        mvn clean verify -P e2e-tests
+        mvn clean verify -P e2e-tests -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
     - name: Archive build artifacts
       uses: actions/upload-artifact@v2.2.2


### PR DESCRIPTION
# Make mvn cmd output less verbose

## Description
This PR removes download progress logs when running the `mvn verify` cmd in the build.

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [X] General Improvement
- [ ] Cherry Pick

## Links
N/A

## Test Plan
N/A

## Screenshots
N/A

