### PR TITLE
CDAP-19389: Use sourceType from assess table consistently across select tables and review assessment

### DIFF
--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/table.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/table.tsx
@@ -292,7 +292,7 @@ export const renderTable = ({
               </GridCellContainer>
               <GridCellContainer item xs={2} container direction="row">
                 <GridCell item xs={3}>
-                  <NoPaddingSpanLeft> {row.type.toLowerCase()}</NoPaddingSpanLeft>
+                  <NoPaddingSpanLeft> {row.sourceType.toLowerCase()}</NoPaddingSpanLeft>
                 </GridCell>
                 <Grid item xs={5}>
                   <span></span>


### PR DESCRIPTION
# Use sourceType from assess table consistently across select tables and review assessment

## Description
Today we use different fields from API responses on "select tables and transformation" and "review assessment" steps when creating replication pipelines. With the fix to correct source type in https://github.com/data-integrations/database-delta-plugins/pull/218, mapping on [review assessment](https://github.com/cdapio/cdap-ui/blob/develop/app/cdap/components/Replicator/Create/Content/Assessment/TablesAssessment/Mappings/index.tsx#L375) step is fixed, but in [select tables and transformation](https://github.com/cdapio/cdap-ui/blob/develop/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/table.tsx#L295) we use `type` instead of `sourceType`, this PR fixes the inconsistency. 

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19389](https://cdap.atlassian.net/browse/CDAP-19389)

## Test Plan
Tested on sandbox

## Screenshots

### Review assessment
<img width="1675" alt="Screen Shot 2022-11-30 at 6 43 34 PM" src="https://user-images.githubusercontent.com/108464238/204805431-868e0b45-195b-4892-b64b-acea4b04fb1c.png">

### Select tables and transformation
<img width="1433" alt="Screen Shot 2022-11-30 at 6 42 59 PM" src="https://user-images.githubusercontent.com/108464238/204805343-d305750d-b87d-45f3-879c-8eb2441beec0.png">

