### PR TITLE
CDAP 20150 Feature - Open Workspaces List

### DIFF
--- a/app/cdap/components/GridTable/index.tsx
+++ b/app/cdap/components/GridTable/index.tsx
@@ -32,6 +32,7 @@ import {
   IRecords,
 } from 'components/GridTable/types';
 import NoRecordScreen from 'components/NoRecordScreen';
+import OpenWorkspacesList from 'components/OpenWorkspacesList';
 import LoadingSVG from 'components/shared/LoadingSVG';
 import { IValues } from 'components/WrangleHome/Components/OngoingDataExploration/types';
 import T from 'i18n-react';
@@ -39,6 +40,11 @@ import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
 import { flatMap } from 'rxjs/operators';
 import { objectQuery } from 'services/helpers';
+import styled from 'styled-components';
+
+const CustomizedBox = styled(Box)`
+  display: flex;
+`;
 
 export default function GridTable() {
   const { wid } = useParams() as IRecords;
@@ -239,7 +245,10 @@ export default function GridTable() {
 
   return (
     <Box data-testid="grid-table-container">
-      <BreadCrumb datasetName={wid} />
+      <CustomizedBox>
+        <BreadCrumb datasetName={wid} />
+        <OpenWorkspacesList />
+      </CustomizedBox>
       {Array.isArray(gridData?.headers) && gridData?.headers.length === 0 ? (
         <NoRecordScreen
           title={T.translate('features.WranglerNewUI.NoRecordScreen.gridTable.title')}

--- a/app/cdap/components/OpenWorkspacesList/StyledComponents.ts
+++ b/app/cdap/components/OpenWorkspacesList/StyledComponents.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { Box, MenuItem, MenuList, Paper, Typography } from '@material-ui/core';
+import styled from 'styled-components';
+
+const CustomizedTypography = styled(Typography)`
+  font-style: normal;
+
+  font-size: 14px;
+  line-height: 21px;
+  letter-spacing: 0.15px;
+`;
+
+export const ViewAllTypography = styled(CustomizedTypography)`
+  color: #2196f3;
+  font-weight: 400;
+`;
+
+export const WorkspaceListTypography = styled(CustomizedTypography)`
+  color: #616161;
+  font-weight: 400;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  max-width: 201px;
+`;
+
+export const WorkspaceOpenTypography = styled(CustomizedTypography)`
+  font-weight: 500;
+  color: #2196f3;
+  cursor: pointer;
+`;
+
+export const OpenWorkspaceContainer = styled(Box)`
+  display: flex;
+  margin: auto 0px;
+`;
+
+export const StyledMenuItem = styled(MenuItem)`
+  margin-top: 8px;
+  margin-bottom: 8px;
+  padding-left: 20px;
+  padding-right: 20px;
+`;
+
+export const StyledMenuList = styled(MenuList)`
+  padding: 0px;
+  font-weight: 400;
+  padding-top: 6px;
+  padding-bottom: 6px;
+  color: #5f6368;
+`;
+
+export const DividerContainer = styled(Box)`
+  margin-right: 20px;
+`;
+
+export const StyledPaper = styled(Paper)`
+  box-shadow: none;
+  border: 1px solid #dadce0;
+  border-radius: 0px;
+  left: -66px;
+  width: 246px;
+  top: 4px;
+  position: absolute;
+`;

--- a/app/cdap/components/OpenWorkspacesList/__test__/OpenWorkspaceList.test.tsx
+++ b/app/cdap/components/OpenWorkspacesList/__test__/OpenWorkspaceList.test.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+import OpenWorkspacesList from "components/OpenWorkspacesList/index";
+import { Route, Router, Switch } from "react-router";
+import history from "services/history";
+import MyDataPrepApi from "api/dataprep";
+import {mockRes} from 'components/OpenWorkspacesList/mock/mock'
+
+describe("It should test OpenWorkspacesList Component", () => {
+
+  beforeEach(() => {
+    jest.spyOn(MyDataPrepApi, "getWorkspaceList").mockImplementation(() => {
+        return {
+          subscribe: (callback) => {
+            callback(mockRes);
+          },
+        };
+      });
+      render(
+        <Router history={history}>
+          <Switch>
+            <Route>
+              <OpenWorkspacesList />
+            </Route>
+          </Switch>
+        </Router>
+      );
+  })
+
+  it("Should click worspaceList button and trigger expected event then trigger workspace-list-item click event", () => {
+
+    const buttonElement = screen.getByTestId(/open-workspaces-list-label/i);
+    fireEvent.click(buttonElement);
+    expect(buttonElement).toBeInTheDocument();
+    const listItemComponent = screen.getByTestId(/open-workspace-list-item-0/i)
+    fireEvent.click(listItemComponent)
+    expect(listItemComponent).toBeInTheDocument()
+    expect(MyDataPrepApi.getWorkspaceList).toBeCalledTimes(1)
+  });
+
+  it("should trigger handleCloseAway function with click event", () => {
+    const closeAwayElement = screen.getAllByTestId(/open-workspaces-list/i);
+    fireEvent.click(closeAwayElement[0].firstChild);
+    expect(closeAwayElement[0]).toBeInTheDocument()
+    expect(MyDataPrepApi.getWorkspaceList).toBeCalledTimes(2)
+  });
+
+});

--- a/app/cdap/components/OpenWorkspacesList/components/OngoingWorkspaceListMenu/OngoingWorkspaceListMenu.tsx
+++ b/app/cdap/components/OpenWorkspacesList/components/OngoingWorkspaceListMenu/OngoingWorkspaceListMenu.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React from 'react';
+import T from 'i18n-react';
+import CustomTooltip from 'components/ConnectionList/Components/CustomTooltip';
+import {
+  StyledMenuItem,
+  WorkspaceListTypography,
+} from 'components/OpenWorkspacesList/StyledComponents';
+import { createRef, Ref, useEffect, useState } from 'react';
+import { IWorkspaceList } from 'components/OpenWorkspacesList';
+
+interface IOngoingWorkspaceListMenuProps {
+  workspace: IWorkspaceList;
+  index: number;
+  handleMenuClick: (
+    event: React.MouseEvent<HTMLLIElement, MouseEvent>,
+    currentWorkspaceId: string
+  ) => void;
+}
+
+export default function({ workspace, index, handleMenuClick }: IOngoingWorkspaceListMenuProps) {
+  const myLabelRef: Ref<HTMLSpanElement> = createRef();
+  const [refValue, setRefValue] = useState(false);
+
+  useEffect(() => {
+    /**
+     * In case, the size of the lable or file name exceeds the maximum width
+     * of it's wrapping container we are showing ellipses using styles and
+     * we are also showing the custom tooltip using the following logic.
+     * So the following statement checks whether the size of the text is greater than the maximum
+     * width of the wrapping element or not. if the size is greater then it sets true for custom tooltip
+     * otherwise it sets false.
+     */
+    setRefValue(myLabelRef?.current?.offsetWidth < myLabelRef?.current?.scrollWidth);
+  }, []);
+
+  return (
+    <>
+      {refValue ? (
+        <CustomTooltip title={`${workspace.workspaceName}`}>
+          <StyledMenuItem
+            role="button"
+            onClick={(e) => handleMenuClick(e, workspace.workspaceId)}
+            key={index}
+            data-testid={`open-workspace-list-item-${index}`}
+          >
+            <WorkspaceListTypography ref={myLabelRef}>
+              {T.translate(workspace.workspaceName)}
+            </WorkspaceListTypography>
+          </StyledMenuItem>
+        </CustomTooltip>
+      ) : (
+        <StyledMenuItem
+          role="button"
+          onClick={(e) => handleMenuClick(e, workspace.workspaceId)}
+          key={index}
+          data-testid={`open-workspace-list-item-${index}`}
+        >
+          <WorkspaceListTypography ref={myLabelRef} data-testid="workspace-name">
+            {T.translate(workspace.workspaceName)}
+          </WorkspaceListTypography>
+        </StyledMenuItem>
+      )}
+    </>
+  );
+}

--- a/app/cdap/components/OpenWorkspacesList/components/OngoingWorkspaceListMenu/__test__/OngoingWorkspaceListMenu.test.tsx
+++ b/app/cdap/components/OpenWorkspacesList/components/OngoingWorkspaceListMenu/__test__/OngoingWorkspaceListMenu.test.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import OngoingWorkspaceListMenu from 'components/OpenWorkspacesList/components/OngoingWorkspaceListMenu/OngoingWorkspaceListMenu';
+
+describe('It should test OngoingWorkspaceListMenu Component', () => {
+  beforeEach(() => {
+    render(
+      <OngoingWorkspaceListMenu
+        workspace={{
+          workspaceId: '96d6923c-3b21-4dc8-9d66-9befa00bb91c',
+          workspaceName: 'information_schema_catalog_name_information_testing',
+        }}
+        index={0}
+        handleMenuClick={jest.fn()}
+      />
+    );
+  });
+
+  it('should trigger onChange event in list item', () => {
+    const listItemElement = screen.getByTestId(/open-workspace-list-item-0/i);
+    fireEvent.click(listItemElement);
+    expect(listItemElement).toBeInTheDocument();
+  });
+
+  it('should test the workspace Name', () => {
+    const workspaceName = screen.getByTestId(/workspace-name/i);
+    expect(workspaceName).toHaveTextContent('information_schema_catalog_name_information_testing');
+  });
+});

--- a/app/cdap/components/OpenWorkspacesList/index.tsx
+++ b/app/cdap/components/OpenWorkspacesList/index.tsx
@@ -1,0 +1,169 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { Box, ClickAwayListener, Grow, Popper } from '@material-ui/core';
+import MyDataPrepApi from 'api/dataprep';
+import OngoingWorkSpaceListMenu from 'components/OpenWorkspacesList/components/OngoingWorkspaceListMenu/OngoingWorkspaceListMenu';
+import {
+  DividerContainer,
+  OpenWorkspaceContainer,
+  StyledMenuItem,
+  StyledMenuList,
+  StyledPaper,
+  ViewAllTypography,
+  WorkspaceOpenTypography,
+} from 'components/OpenWorkspacesList/StyledComponents';
+import T from 'i18n-react';
+import React, { useEffect, useRef, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import { getCurrentNamespace } from 'services/NamespaceStore';
+
+const PREFIX = 'features.WranglerNewUI.OpenWorkspacesList';
+
+const Divider = (
+  <svg width="2" height="21" viewBox="0 0 2 21" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0.511963 0.501953V20.502" stroke="#DADCE0" strokeLinecap="round" />
+  </svg>
+);
+
+export interface IWorkspaceList {
+  workspaceId: string;
+  workspaceName: string;
+}
+
+export default function() {
+  const [open, setOpen] = useState(false);
+  const anchorRef = useRef(null);
+  const [workspaceList, setWorkspaceList] = useState<IWorkspaceList[]>([]);
+  const [workspaceCount, setWorkspaceCount] = useState<number>();
+  const maxWorkspaceListCount = 4;
+  const history = useHistory();
+
+  const handleToggle = () => {
+    setOpen((prevOpen) => !prevOpen);
+  };
+
+  const getWorkspaceList = () => {
+    MyDataPrepApi.getWorkspaceList({
+      context: 'default',
+    }).subscribe((response) => {
+      setWorkspaceCount(response.count);
+      let updatedValues = [];
+      updatedValues = response?.values ?? [];
+      updatedValues.sort((a, b) => b.createdTimeMillis - a.createdTimeMillis);
+      updatedValues.forEach((workspace) => {
+        setWorkspaceList((prev) => [
+          ...prev,
+          {
+            workspaceName: workspace.workspaceName,
+            workspaceId: workspace.workspaceId,
+          },
+        ]);
+      });
+    });
+  };
+
+  const handleMenuClick = (
+    event: React.MouseEvent<HTMLLIElement, MouseEvent>,
+    currentWorkspaceId: string
+  ) => {
+    if (anchorRef.current && anchorRef.current.contains(event.target)) {
+      return;
+    }
+    history.push(`/ns/${getCurrentNamespace()}/wrangler-grid/${currentWorkspaceId}`);
+    setOpen(false);
+  };
+
+  const onViewAllClick = () => {
+    // TODO: Navigate to View All Ongoing Workspace List Page
+  };
+
+  const handleCloseOnAway = (event: React.MouseEvent<Document, MouseEvent>) => {
+    if (anchorRef.current && anchorRef.current.contains(event.target)) {
+      return;
+    }
+    setOpen(false);
+  };
+
+  const prevOpen = useRef(open);
+
+  useEffect(() => {
+    if (prevOpen.current === true && open === false) {
+      anchorRef.current.focus();
+    }
+    prevOpen.current = open;
+  }, [open]);
+
+  useEffect(() => {
+    getWorkspaceList();
+  }, []);
+
+  return (
+    <OpenWorkspaceContainer>
+      <DividerContainer>{Divider}</DividerContainer>
+      <Box>
+        <WorkspaceOpenTypography
+          ref={anchorRef}
+          aria-controls={open ? 'menu-list-grow' : undefined}
+          aria-haspopup="true"
+          onClick={handleToggle}
+          role="button"
+          data-testid="open-workspaces-list-label"
+        >
+          {T.translate(`${PREFIX}.workspacesOpen`, { workspaceCount })}
+        </WorkspaceOpenTypography>
+
+        <Popper open={open} anchorEl={anchorRef.current} role={undefined} transition disablePortal>
+          {({ TransitionProps, placement }) => (
+            <Grow
+              {...TransitionProps}
+              style={{
+                transformOrigin: placement === 'bottom' ? 'center top' : 'center bottom',
+              }}
+            >
+              <StyledPaper data-testid="open-workspaces-list">
+                <ClickAwayListener onClickAway={handleCloseOnAway}>
+                  <StyledMenuList autoFocusItem={open} id="menu-list-grow">
+                    {workspaceList.map((workspace, index) => {
+                      if (index < maxWorkspaceListCount) {
+                        return (
+                          <OngoingWorkSpaceListMenu
+                            workspace={workspace}
+                            index={index}
+                            handleMenuClick={handleMenuClick}
+                          />
+                        );
+                      }
+                    })}
+                    <StyledMenuItem
+                      onClick={onViewAllClick}
+                      role="button"
+                      data-testid="view-all-ongoing-workspaces"
+                    >
+                      <ViewAllTypography>
+                        {T.translate(`${PREFIX}.viewAllOngoingWorkspaces`)}
+                      </ViewAllTypography>
+                    </StyledMenuItem>
+                  </StyledMenuList>
+                </ClickAwayListener>
+              </StyledPaper>
+            </Grow>
+          )}
+        </Popper>
+      </Box>
+    </OpenWorkspaceContainer>
+  );
+}

--- a/app/cdap/components/OpenWorkspacesList/mock/mock.ts
+++ b/app/cdap/components/OpenWorkspacesList/mock/mock.ts
@@ -1,0 +1,246 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+export const mockRes = {
+  message: 'Success',
+  count: 8,
+  values: [
+    {
+      workspaceName: 'sql_sizing_profiles',
+      workspaceId: '46384b61-0ceb-45ae-b74d-bb88a0626cfd',
+      directives: [],
+      createdTimeMillis: 1669744449603,
+      updatedTimeMillis: 1669748151617,
+      sampleSpec: {
+        connectionName: 'exl',
+        path: '/information_schema/sql_sizing_profiles',
+        relatedPlugins: [
+          {
+            schema: {
+              type: 'record',
+              name: 'outputSchema',
+              fields: [
+                {
+                  name: 'sizing_id',
+                  type: ['int', 'null'],
+                },
+                {
+                  name: 'sizing_name',
+                  type: ['string', 'null'],
+                },
+                {
+                  name: 'profile_id',
+                  type: ['string', 'null'],
+                },
+                {
+                  name: 'required_value',
+                  type: ['int', 'null'],
+                },
+                {
+                  name: 'comments',
+                  type: ['string', 'null'],
+                },
+              ],
+            },
+            plugin: {
+              name: 'Postgres',
+              type: 'batchsource',
+              properties: {
+                useConnection: 'true',
+                fetchSize: '1000',
+                numSplits: '1',
+                importQuery: 'SELECT * FROM "information_schema"."sql_sizing_profiles"',
+                connection: '${conn(exl)}',
+                connectionTimeout: '100',
+                referenceName: 'sql_sizing_profiles',
+              },
+              artifact: {
+                name: 'postgresql-plugin',
+                version: '1.9.0-SNAPSHOT',
+                scope: 'SYSTEM',
+              },
+            },
+          },
+          {
+            schema: {
+              type: 'record',
+              name: 'outputSchema',
+              fields: [
+                {
+                  name: 'sizing_id',
+                  type: ['int', 'null'],
+                },
+                {
+                  name: 'sizing_name',
+                  type: ['string', 'null'],
+                },
+                {
+                  name: 'profile_id',
+                  type: ['string', 'null'],
+                },
+                {
+                  name: 'required_value',
+                  type: ['int', 'null'],
+                },
+                {
+                  name: 'comments',
+                  type: ['string', 'null'],
+                },
+              ],
+            },
+            plugin: {
+              name: 'Postgres',
+              type: 'batchsink',
+              properties: {
+                useConnection: 'true',
+                dbSchemaName: 'information_schema',
+                connection: '${conn(exl)}',
+                tableName: 'sql_sizing_profiles',
+                referenceName: 'sql_sizing_profiles',
+              },
+              artifact: {
+                name: 'postgresql-plugin',
+                version: '1.9.0-SNAPSHOT',
+                scope: 'SYSTEM',
+              },
+            },
+          },
+        ],
+      },
+      insights: {},
+    },
+    {
+      workspaceName: 'sql_features',
+      workspaceId: '7ffca9e9-786a-4297-ad00-78e2d3dc8417',
+      directives: [],
+      createdTimeMillis: 1669744327469,
+      updatedTimeMillis: 1669748151760,
+      sampleSpec: {
+        connectionName: 'exl',
+        path: '/information_schema/sql_features',
+        relatedPlugins: [
+          {
+            schema: {
+              type: 'record',
+              name: 'outputSchema',
+              fields: [
+                {
+                  name: 'feature_id',
+                  type: ['string', 'null'],
+                },
+                {
+                  name: 'feature_name',
+                  type: ['string', 'null'],
+                },
+                {
+                  name: 'sub_feature_id',
+                  type: ['string', 'null'],
+                },
+                {
+                  name: 'sub_feature_name',
+                  type: ['string', 'null'],
+                },
+                {
+                  name: 'is_supported',
+                  type: ['string', 'null'],
+                },
+                {
+                  name: 'is_verified_by',
+                  type: ['string', 'null'],
+                },
+                {
+                  name: 'comments',
+                  type: ['string', 'null'],
+                },
+              ],
+            },
+            plugin: {
+              name: 'Postgres',
+              type: 'batchsource',
+              properties: {
+                useConnection: 'true',
+                fetchSize: '1000',
+                numSplits: '1',
+                importQuery: 'SELECT * FROM "information_schema"."sql_features"',
+                connection: '${conn(exl)}',
+                connectionTimeout: '100',
+                referenceName: 'sql_features',
+              },
+              artifact: {
+                name: 'postgresql-plugin',
+                version: '1.9.0-SNAPSHOT',
+                scope: 'SYSTEM',
+              },
+            },
+          },
+          {
+            schema: {
+              type: 'record',
+              name: 'outputSchema',
+              fields: [
+                {
+                  name: 'feature_id',
+                  type: ['string', 'null'],
+                },
+                {
+                  name: 'feature_name',
+                  type: ['string', 'null'],
+                },
+                {
+                  name: 'sub_feature_id',
+                  type: ['string', 'null'],
+                },
+                {
+                  name: 'sub_feature_name',
+                  type: ['string', 'null'],
+                },
+                {
+                  name: 'is_supported',
+                  type: ['string', 'null'],
+                },
+                {
+                  name: 'is_verified_by',
+                  type: ['string', 'null'],
+                },
+                {
+                  name: 'comments',
+                  type: ['string', 'null'],
+                },
+              ],
+            },
+            plugin: {
+              name: 'Postgres',
+              type: 'batchsink',
+              properties: {
+                useConnection: 'true',
+                dbSchemaName: 'information_schema',
+                connection: '${conn(exl)}',
+                tableName: 'sql_features',
+                referenceName: 'sql_features',
+              },
+              artifact: {
+                name: 'postgresql-plugin',
+                version: '1.9.0-SNAPSHOT',
+                scope: 'SYSTEM',
+              },
+            },
+          },
+        ],
+      },
+      insights: {},
+    },
+  ],
+};

--- a/app/cdap/components/WrangleHome/Components/OngoingDataExploration/index.tsx
+++ b/app/cdap/components/WrangleHome/Components/OngoingDataExploration/index.tsx
@@ -116,6 +116,7 @@ export default function OngoingDataExploration() {
               },
             }}
             style={{ textDecoration: 'none' }}
+            data-testid={`ongoing-data-exploration-card-${index}`}
           >
             {index <= 1 && <OngoingDataExplorationCard item={item} key={index} />}
           </Link>

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -3462,4 +3462,7 @@ features:
       labels:
         loadToGrid: Wrangle
         noConnections: No Connections to show
-...
+    OpenWorkspacesList: 
+      viewAllOngoingWorkspaces: View all ongoing workspaces
+      workspacesOpen: "{workspaceCount} workspaces open"
+... 

--- a/src/e2e-test/features/open.workspaces.list.feature
+++ b/src/e2e-test/features/open.workspaces.list.feature
@@ -1,0 +1,25 @@
+#
+# Copyright © 2022 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+@Integration_Tests
+Feature: OpenWorkspacesList
+
+  @OpenWorkspacesList
+  Scenario: Go through the Open Workspace List functionality
+    Given Navigate to Home Page of Wrangle for Open Workspaces List
+    Then Click on the Data Explorations card
+    Then Click on the open workspaces list
+    Then Select the workspace from the list

--- a/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/OpenWorkspacesList.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/OpenWorkspacesList.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.ui.stepsdesign;
+
+import io.cdap.cdap.ui.utils.Constants;
+import io.cdap.cdap.ui.utils.Helper;
+import io.cdap.e2e.utils.ElementHelper;
+import io.cdap.e2e.utils.SeleniumDriver;
+import io.cdap.e2e.utils.WaitHelper;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import org.junit.Assert;
+
+public class OpenWorkspacesList {
+    @Given("Navigate to Home Page of Wrangle for Open Workspaces List")
+    public void navigateToTheHomePageDefine() {
+        SeleniumDriver.openPage(Constants.WRANGLE_HOME_URL);
+        WaitHelper.waitForPageToLoad();
+    }
+
+    @Then("Click on the Data Explorations card")
+    public void clickOnTheDataExplorationCard() {
+        try {
+            WaitHelper.waitForPageToLoad();
+            ElementHelper.clickOnElement(Helper.locateElementByTestId("ongoing-data-exploration-card-0"));
+            String url = SeleniumDriver.getDriver().getCurrentUrl();
+            Assert.assertTrue(url.contains("http://localhost:11011/cdap/ns/default/wrangler-grid"));
+        } catch (Exception e) {
+            System.err.println("error:" + e);
+        }
+    }
+
+    @Then("Click on the open workspaces list")
+    public void ClickOnTheOpenWorkspacesList() {
+        try {
+            WaitHelper.waitForPageToLoad();
+            ElementHelper.clickOnElement(Helper.locateElementByTestId("open-workspaces-list-label"));
+        } catch (Exception e) {
+            System.err.println("error:" + e);
+        }
+    }
+
+    @Then("Select the workspace from the list")
+    public void SelectTheWorkspaceFromTheList() {
+        try {
+            WaitHelper.waitForPageToLoad();
+            Assert.assertTrue(Helper.isElementExists(Helper.getCssSelectorByDataTestId("open-workspaces-list")));
+            ElementHelper.clickOnElement(Helper.locateElementByTestId("open-workspace-list-item-1"));
+        } catch (Exception e) {
+            System.err.println("error:" + e);
+        }
+    }
+}


### PR DESCRIPTION
# TITLE
Feature - Open Workspaces List

## Description
Summary of changes
This PR contains the changes related to the Open Workspaces List

## Following are the files to be reviewed
1. app/cdap/components/OpenWorkspacesList/
2. app/cdap/text/text-en.yaml
3. src/e2e-test/features/open.workspaces.list.feature
4. src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/OpenWorkspacesList.java
5. app/cdap/components/GridTable/index.tsx

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [Jira issue #](fill-in.org)
https://cdap.atlassian.net/browse/CDAP-20150

## Test Plan
1. FE_01_287 - Verify the No. of workspaces is displayed at the breadcrumb section or not - Pass
2. FE_01_288 - Verify by mouse hovering on the open workspace breadcrumb. - Pass
3. FE_01_289 - Verify whether the open workspace list dropdown is displayed as per design or not. - Pass
4. FE_01_289 - Verify the redirection of the selected workspace list is redirected to the particular list or not. - Pass
5. FE_01_292 - Verify the redirection of the selected workspace list is redirected to the particular list or not. - Pass
6. FE_01_293 - Verify the Recently loaded data file on the grid page is displayed below the suggestion list or not. - Pass
7. FE_01_293 - Verify the No. the count is updated as per the loading and deleting of the files. - Pass
8. FE_01_294 - Verify the "View all ongoing workspaces" text on the suggestion popup by mouse hovering. - Pass
9. FE_01_295 - Verify by clicking the "View all ongoing workspaces" text. - Pass
10. FE_01_296 - Verify by clicking on the "View all ongoing workspaces" text by clicking.. - Pass

## Screenshots
<img width="1433" alt="Screenshot 2022-11-30 at 11 31 18 AM" src="https://user-images.githubusercontent.com/107859633/204720744-8fb26d63-00b7-405a-9ac9-bd8e79728292.png">
<img width="1432" alt="Screenshot 2022-11-30 at 11 38 28 AM" src="https://user-images.githubusercontent.com/107859633/204720784-19c2afa5-ca50-4605-b905-02bd9b6d1f82.png">
<img width="1435" alt="Screenshot 2022-11-30 at 11 31 26 AM" src="https://user-images.githubusercontent.com/107859633/204720811-729e779e-cb46-490d-a161-e7ea92d2ac58.png">