### PR TITLE
[CDAP-20138]: hide service account email field

### DIFF
--- a/app/cdap/components/CaskWizards/AddNamespace/ResourcesStep/index.tsx
+++ b/app/cdap/components/CaskWizards/AddNamespace/ResourcesStep/index.tsx
@@ -131,6 +131,10 @@ const InputK8sServiceAccountEmail = connect(
 )(InputWithValidations);
 
 export default function ResourcesStep() {
+  const shouldDisplayServiceAccountEmailField =
+    window.CDAP_CONFIG.cdap.k8sWorkloadIdentityEnabled === 'true' &&
+    window.CDAP_CONFIG.cdap.namespaceCreationHookEnabled === 'true';
+
   return (
     <Provider store={AddNamespaceStore}>
       <Form
@@ -170,18 +174,20 @@ export default function ResourcesStep() {
             <InputK8sMemoryLimit />
           </Col>
         </FormGroup>
-        <FormGroup row>
-          <Col xs="4">
-            <Label className="control-label">
-              {T.translate(
-                'features.Wizard.Add-Namespace.ResourcesStep.service-account-email-label'
-              )}
-            </Label>
-          </Col>
-          <Col xs="7">
-            <InputK8sServiceAccountEmail />
-          </Col>
-        </FormGroup>
+        {shouldDisplayServiceAccountEmailField && (
+          <FormGroup row>
+            <Col xs="4">
+              <Label className="control-label">
+                {T.translate(
+                  'features.Wizard.Add-Namespace.ResourcesStep.service-account-email-label'
+                )}
+              </Label>
+            </Col>
+            <Col xs="7">
+              <InputK8sServiceAccountEmail />
+            </Col>
+          </FormGroup>
+        )}
       </Form>
     </Provider>
   );

--- a/server/express.js
+++ b/server/express.js
@@ -230,6 +230,8 @@ function makeApp(authAddress, cdapConfig, uiSettings) {
         proxyBaseUrl: cdapConfig['dashboard.proxy.base.url'],
         maxRecordsPreview: cdapConfig['preview.max.num.records'],
         ui: uiSettings['ui'],
+        k8sWorkloadIdentityEnabled: cdapConfig['master.environment.k8s.workload.identity.enabled'],
+        namespaceCreationHookEnabled: cdapConfig['namespaces.creation.hook.enabled'],
       },
       hydrator: {
         previewEnabled: cdapConfig['enable.preview'] === 'true',


### PR DESCRIPTION
# Hide service account email field in namespace creation

## Description
This PR hides service account email field when creating namespaces in hdf if k8s namespace creation and workload identity are not enabled

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20138](https://cdap.atlassian.net/browse/CDAP-20138)

## Test Plan
Manual

## Screenshots
**Disabled:**
![Screen Shot 2022-12-05 at 4 40 44 PM](https://user-images.githubusercontent.com/94018249/205748223-7e75443a-915b-45ba-9097-28999a03f9d3.png)

**Enabled:**
![Screen Shot 2022-12-05 at 4 45 36 PM](https://user-images.githubusercontent.com/94018249/205749023-1e4252ad-61f3-4810-b71b-910406a6e0c2.png)


