### PR TITLE
Remove concurrency from github builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,10 +28,6 @@ jobs:
 
     if: ${{ github.event.workflow_run.conclusion != 'skipped' }}
 
-    # Cancel ongoing runs
-    concurrency: 
-      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-
     steps:
     # Pinned 1.0.0 version
     - uses: haya14busa/action-workflow_run-status@967ed83efa565c257675ed70cfe5231f062ddd94


### PR DESCRIPTION
# Remove concurrency from github builds

## Description
This PR removes concurrency from github builds

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [X] General Improvement
- [ ] Cherry Pick

## Links
N/A

## Test Plan
N/A

## Screenshots
N/A

