### PR TITLE
CDAP 20050 Feature - Create Recipe Form (Recipe Management)

### DIFF
--- a/app/cdap/api/dataprep.js
+++ b/app/cdap/api/dataprep.js
@@ -269,6 +269,15 @@ const MyDataPrepApi = {
 
   // Connection types
   listConnectionTypes: apiCreator(dataSrc, 'GET', 'REQUEST', connectionTypesPath),
+
+  // Recipe Management
+  createRecipe: apiCreator(dataSrc, 'POST', 'REQUEST', `${contextPathV2}/recipes`),
+  getRecipeByName: apiCreator(
+    dataSrc,
+    'GET',
+    'REQUEST',
+    `${contextPathV2}/recipes/name/:recipeName`
+  ),
 };
 
 export default MyDataPrepApi;

--- a/app/cdap/components/RecipeList/types.ts
+++ b/app/cdap/components/RecipeList/types.ts
@@ -43,3 +43,9 @@ export enum SortOrder {
   ASCENDING = 'asc',
   DESCENDING = 'desc',
 }
+
+export enum ActionType {
+  CREATE_RECIPE = 'create recipe',
+  EDIT_RECIPE = 'edit recipe',
+  VIEW_RECIPE = 'view recipe',
+}

--- a/app/cdap/components/RecipeManagement/CreateRecipe/index.tsx
+++ b/app/cdap/components/RecipeManagement/CreateRecipe/index.tsx
@@ -172,17 +172,10 @@ export default function CreateRecipe({ setShowRecipeForm, setSnackbar }: ICreate
       ...recipeFormData,
       recipeName: event.target.value,
     });
-    if (event.target.value && !REGEX.recipeNameRegEx.test(event.target.value)) {
-      updateRecipeNameErrorData({
-        isRecipeNameError: true,
-        recipeNameErrorMessage: T.translate(`${PREFIX}.validationErrorMessage`).toString(),
-      });
-    } else {
-      validateIfRecipeNameExists.current({
-        recipeName: event.target.value,
-        description: recipeFormData.description,
-      });
-    }
+    validateIfRecipeNameExists.current({
+      recipeName: event.target.value,
+      description: recipeFormData.description,
+    });
   };
 
   const onRecipeDescriptionChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
@@ -218,16 +211,23 @@ export default function CreateRecipe({ setShowRecipeForm, setSnackbar }: ICreate
    */
   const validateIfRecipeNameExists = useRef(
     debounce((formData: IRecipeFormData) => {
-      if (formData.recipeName) {
-        setApiParams({
-          ...apiParams,
-          getRecipeByNameParams: {
-            context: getCurrentNamespace(),
-            recipeName: formData.recipeName,
-          },
+      if (formData.recipeName && !REGEX.recipeNameRegEx.test(formData.recipeName)) {
+        updateRecipeNameErrorData({
+          isRecipeNameError: true,
+          recipeNameErrorMessage: T.translate(`${PREFIX}.validationErrorMessage`).toString(),
         });
       } else {
-        updateRecipeNameErrorData(noErrorState);
+        if (formData.recipeName) {
+          setApiParams({
+            ...apiParams,
+            getRecipeByNameParams: {
+              context: getCurrentNamespace(),
+              recipeName: formData.recipeName,
+            },
+          });
+        } else {
+          updateRecipeNameErrorData(noErrorState);
+        }
       }
     }, 500)
   );

--- a/app/cdap/components/RecipeManagement/CreateRecipe/index.tsx
+++ b/app/cdap/components/RecipeManagement/CreateRecipe/index.tsx
@@ -38,6 +38,12 @@ const PREFIX = 'features.WranglerNewUI.RecipeForm.labels';
  * for e.g. recipe1 - will be allowed , recipe@ - will not be allowed
  */
 const recipeNameRegEx = /^[a-z\d\s]+$/i;
+
+/*
+ * TODO: This static data has to be removed when we have actual API data,
+ * then directly we will get that data from store as directives
+ */
+const recipeSteps = ['uppercase: body1', 'titlecase: body2'];
 export const noErrorState: IRecipeNameErrorData = {
   isRecipeNameError: false,
   recipeNameErrorMessage: '',
@@ -49,7 +55,6 @@ export default function CreateRecipe({ setShowRecipeForm, setSnackbar }: ICreate
     description: '',
   });
   const [recipeNameErrorData, setRecipeNameErrorDataState] = useState(noErrorState);
-
   const [isSaveDisabled, setIsSaveDisabled] = useState(true);
   const [apiParams, setApiParams] = useState({
     getRecipeByNameParams: {
@@ -60,12 +65,6 @@ export default function CreateRecipe({ setShowRecipeForm, setSnackbar }: ICreate
       context: '',
     },
   });
-
-  /*
-   * TODO: This static data has to be removed when we have actual API data,
-   * then directly we will get that data from store as directives
-   */
-  const recipeSteps = ['uppercase: body1', 'titlecase: body2'];
 
   const { response: recipeByNameResponse, error: recipeByNameError } = useFetch(
     MyDataPrepApi.getRecipeByName,
@@ -147,8 +146,6 @@ export default function CreateRecipe({ setShowRecipeForm, setSnackbar }: ICreate
     nameErrorData: IRecipeNameErrorData = recipeNameErrorData
   ) => {
     const shouldDisableSaveButton =
-      formData.recipeName === '' ||
-      formData.description === '' ||
       formData.recipeName?.trim().length === 0 ||
       formData.description?.trim().length === 0 ||
       nameErrorData.isRecipeNameError;

--- a/app/cdap/components/RecipeManagement/CreateRecipe/index.tsx
+++ b/app/cdap/components/RecipeManagement/CreateRecipe/index.tsx
@@ -1,0 +1,239 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { ChangeEvent, FormEvent, useEffect, useRef, useState } from 'react';
+
+import T from 'i18n-react';
+import { debounce } from 'lodash';
+
+import MyDataPrepApi from 'api/dataprep';
+import { ActionType } from 'components/RecipeList/types';
+import RecipeForm from 'components/RecipeManagement/RecipeForm';
+import {
+  ICreateRecipeProps,
+  IRecipeFormData,
+  IRecipeNameErrorData,
+} from 'components/RecipeManagement/types';
+import { getCurrentNamespace } from 'services/NamespaceStore';
+import useFetch from 'services/react/customHooks/useFetch';
+
+const PREFIX = 'features.WranglerNewUI.RecipeForm.labels';
+
+/*
+ * This regular expression which validates the recipe name
+ * should only allow alpha numeric and should not allow special characters
+ * for e.g. recipe1 - will be allowed , recipe@ - will not be allowed
+ */
+
+const recipeNameRegEx = /^[a-z\d\s]+$/i;
+export const noErrorState: IRecipeNameErrorData = {
+  isRecipeNameError: false,
+  recipeNameErrorMessage: '',
+};
+
+export default function CreateRecipe({ setShowRecipeForm, setSnackbar }: ICreateRecipeProps) {
+  const [recipeFormData, setRecipeFormData] = useState({
+    recipeName: '',
+    description: '',
+  });
+  const [recipeNameErrorData, setRecipeNameErrorDataState] = useState(noErrorState);
+
+  const [isSaveDisabled, setIsSaveDisabled] = useState(true);
+  const [apiParams, setApiParams] = useState({
+    getRecipeByNameParams: {
+      context: '',
+      recipeName: '',
+    },
+    createRecipeParams: {
+      context: '',
+    },
+  });
+
+  /*
+   * TODO: This static data has to be removed when we have actual API data,
+   * then directly we will get that data from store as directives
+   */
+  const recipeSteps = ['uppercase: body1', 'titlecase: body2'];
+
+  const { response: recipeByNameResponse, error: recipeByNameError } = useFetch(
+    MyDataPrepApi.getRecipeByName,
+    apiParams.getRecipeByNameParams
+  );
+
+  const { response: createRecipeResponse, error: createRecipeError } = useFetch(
+    MyDataPrepApi.createRecipe,
+    apiParams.createRecipeParams,
+    {
+      recipeName: recipeFormData.recipeName,
+      description: recipeFormData.description,
+      directives: recipeSteps,
+    }
+  );
+
+  // This useEffect is for handling getRecipeByName API call response
+  useEffect(() => {
+    if (recipeByNameResponse) {
+      updateRecipeNameErrorData(
+        {
+          isRecipeNameError: true,
+          recipeNameErrorMessage: T.translate(`${PREFIX}.sameNameErrorMessage`).toString(),
+        },
+        recipeFormData
+      );
+    }
+  }, [recipeByNameResponse]);
+
+  // This useEffect is for handling getRecipeByName API call error
+  useEffect(() => {
+    if (recipeByNameError) {
+      if (recipeByNameError.statusCode === 404) {
+        updateRecipeNameErrorData(noErrorState, recipeFormData);
+      } else {
+        setSnackbar({
+          open: true,
+          isSuccess: false,
+          message: (recipeByNameError.response as Record<string, string>).message,
+        });
+      }
+    }
+  }, [recipeByNameError]);
+
+  // This useEffect is for handling createRecipe API call response
+  useEffect(() => {
+    if (createRecipeResponse) {
+      setShowRecipeForm(false);
+      setSnackbar({
+        open: true,
+        isSuccess: true,
+        message: `${recipeSteps.length} ${T.translate(`${PREFIX}.recipeSaveSuccessMessage`)}`,
+      });
+    }
+  }, [createRecipeResponse]);
+
+  // This useEffect is for handling createRecipe API call error
+  useEffect(() => {
+    if (createRecipeError) {
+      setShowRecipeForm(false);
+      setSnackbar({
+        open: true,
+        isSuccess: false,
+        message: (createRecipeError.response as Record<string, string>).message,
+      });
+    }
+  }, [createRecipeError]);
+
+  const updateRecipeNameErrorData = (
+    recipeNameError: IRecipeNameErrorData,
+    formData: IRecipeFormData = recipeFormData
+  ) => {
+    setRecipeNameErrorDataState(recipeNameError);
+    handleSaveButtonMode(formData, recipeNameError);
+  };
+
+  const handleSaveButtonMode = (
+    formData: IRecipeFormData = recipeFormData,
+    nameErrorData: IRecipeNameErrorData = recipeNameErrorData
+  ) => {
+    const shouldDisableSaveButton =
+      formData.recipeName === '' ||
+      formData.description === '' ||
+      formData.recipeName?.trim().length === 0 ||
+      formData.description?.trim().length === 0 ||
+      nameErrorData.isRecipeNameError;
+    setIsSaveDisabled(shouldDisableSaveButton);
+  };
+
+  const handleRecipeFormData = (formData: IRecipeFormData) => {
+    setRecipeFormData(formData);
+    handleSaveButtonMode(formData);
+  };
+
+  const onRecipeNameChange = (event: ChangeEvent<HTMLInputElement>) => {
+    handleRecipeFormData({
+      ...recipeFormData,
+      recipeName: event.target.value,
+    });
+    validateIfRecipeNameExists.current({
+      recipeName: event.target.value,
+      description: recipeFormData.description,
+    });
+  };
+
+  const onRecipeDescriptionChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    handleRecipeFormData({
+      ...recipeFormData,
+      description: event.target.value,
+    });
+  };
+
+  const onFormSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setApiParams({
+      ...apiParams,
+      createRecipeParams: {
+        context: getCurrentNamespace(),
+      },
+    });
+  };
+
+  const onCancel = () => {
+    setShowRecipeForm(false);
+  };
+
+  /*
+   * In this function we are validating recipe name input field by storing
+   * debounce function in a ref so that it can persist across renders
+   * and not get recreated on each render
+   * (whether recipe name already exists or not and recipe name without alphanumeric characters)
+   * and based on the result we are showing the helper text
+   */
+  const validateIfRecipeNameExists = useRef(
+    debounce((formData: IRecipeFormData) => {
+      if (formData.recipeName && !recipeNameRegEx.test(formData.recipeName)) {
+        updateRecipeNameErrorData({
+          isRecipeNameError: true,
+          recipeNameErrorMessage: T.translate(`${PREFIX}.validationErrorMessage`).toString(),
+        });
+      } else {
+        if (formData.recipeName) {
+          setApiParams({
+            ...apiParams,
+            getRecipeByNameParams: {
+              context: getCurrentNamespace(),
+              recipeName: formData.recipeName,
+            },
+          });
+        } else {
+          updateRecipeNameErrorData(noErrorState);
+        }
+      }
+    }, 500)
+  );
+
+  return (
+    <RecipeForm
+      recipeFormData={recipeFormData}
+      isRecipeNameError={recipeNameErrorData.isRecipeNameError}
+      recipeNameErrorMessage={recipeNameErrorData.recipeNameErrorMessage}
+      onRecipeNameChange={onRecipeNameChange}
+      onFormSubmit={onFormSubmit}
+      onCancel={onCancel}
+      isSaveDisabled={isSaveDisabled}
+      recipeFormAction={ActionType.CREATE_RECIPE}
+      onRecipeDescriptionChange={onRecipeDescriptionChange}
+    />
+  );
+}

--- a/app/cdap/components/RecipeManagement/CreateRecipe/index.tsx
+++ b/app/cdap/components/RecipeManagement/CreateRecipe/index.tsx
@@ -37,7 +37,7 @@ const REGEX = {
    * should only allow alpha numeric and should not allow special characters
    * for e.g. recipe1 - will be allowed , recipe@ - will not be allowed
    */
-  recipeNameRegEx: /^(?=\S)[a-z\d\s]+$/i,
+  recipeNameRegEx: /^[a-zA-Z\d]+(\s[a-zA-Z\d]+)*$/i,
 
   /*
    * This regular expression which validates description
@@ -45,7 +45,7 @@ const REGEX = {
    * but can have any characters after that
    * for e.g. (  desc!@) - will not be allowed , (desc!@) - will be allowed
    */
-  descriptionRegEx: /^(?!\s).*$/i,
+  descriptionRegEx: /^\S(.*\S)?$/i,
 };
 /*
  * TODO: This static data has to be removed when we have actual API data,

--- a/app/cdap/components/RecipeManagement/CreateRecipe/index.tsx
+++ b/app/cdap/components/RecipeManagement/CreateRecipe/index.tsx
@@ -37,7 +37,6 @@ const PREFIX = 'features.WranglerNewUI.RecipeForm.labels';
  * should only allow alpha numeric and should not allow special characters
  * for e.g. recipe1 - will be allowed , recipe@ - will not be allowed
  */
-
 const recipeNameRegEx = /^[a-z\d\s]+$/i;
 export const noErrorState: IRecipeNameErrorData = {
   isRecipeNameError: false,

--- a/app/cdap/components/RecipeManagement/RecipeForm/__test__/RecipeForm.test.tsx
+++ b/app/cdap/components/RecipeManagement/RecipeForm/__test__/RecipeForm.test.tsx
@@ -1,0 +1,85 @@
+/*
+ *  Copyright © 2023 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import T from 'i18n-react';
+import RecipeForm from 'components/RecipeManagement/RecipeForm';
+
+describe('Test Recipe Form Component', () => {
+  const mockOnFormSubmit = jest.fn();
+  const mockOnCancel = jest.fn();
+
+  beforeEach(() => {
+    render(
+      <RecipeForm
+        recipeFormData={{
+          recipeName: 'test',
+          description: 'abc desc',
+          directives: ['uppercase: body1', 'titlecase: body2'],
+        }}
+        isRecipeNameError={false}
+        recipeNameErrorMessage={'error message'}
+        onRecipeNameChange={jest.fn()}
+        onFormSubmit={mockOnFormSubmit}
+        onCancel={mockOnCancel}
+        isSaveDisabled={false}
+        recipeFormAction={'create recipe'}
+        onRecipeDescriptionChange={jest.fn()}
+      />
+    );
+  });
+
+  it('should render Recipe Name Label', () => {
+    const RecipeNameLabelElement = screen.getByTestId(/recipe-form-name-label/i);
+    expect(RecipeNameLabelElement).toBeInTheDocument();
+    expect(RecipeNameLabelElement).toHaveTextContent(
+      `${T.translate('features.WranglerNewUI.RecipeForm.labels.createRecipeNameLabel')}`
+    );
+  });
+
+  it('should render Recipe Description Label', () => {
+    const RecipeDescriptionLabelElement = screen.getByTestId(/recipe-form-description-label/i);
+    expect(RecipeDescriptionLabelElement).toBeInTheDocument();
+    expect(RecipeDescriptionLabelElement).toHaveTextContent(
+      `${T.translate('features.WranglerNewUI.RecipeForm.labels.description')}`
+    );
+  });
+
+  it('should render Recipe Name Field and trigger the change event as expected', () => {
+    const RecipeNameElement = screen.getByTestId(/recipe-form-name-field/i);
+    fireEvent.change(RecipeNameElement.firstChild.firstChild, { target: { value: 'test' } });
+    expect(RecipeNameElement.firstChild.firstChild).toHaveValue('test');
+  });
+
+  it('should render Recipe Description Field', () => {
+    const RecipeDescriptionElement = screen.getByTestId(/recipe-form-description-field/i);
+    fireEvent.change(RecipeDescriptionElement, { target: { value: 'abc desc' } });
+    expect(RecipeDescriptionElement).toHaveValue('abc desc');
+  });
+
+  it('should trigger onCancel event in recipe', () => {
+    const cancelButtonElement = screen.getByTestId(/recipe-form-cancel-button/i);
+    fireEvent.click(cancelButtonElement);
+    expect(mockOnCancel).toBeCalled();
+  });
+
+  it('should trigger onSave event in recipe', () => {
+    const saveButtonElement = screen.getByTestId(/recipe-form-save-button/i);
+    fireEvent.click(saveButtonElement);
+    expect(mockOnFormSubmit).toBeCalled();
+  });
+});

--- a/app/cdap/components/RecipeManagement/RecipeForm/index.tsx
+++ b/app/cdap/components/RecipeManagement/RecipeForm/index.tsx
@@ -44,6 +44,7 @@ export default function RecipeForm({
   isSaveDisabled,
   recipeFormAction,
   onRecipeDescriptionChange,
+  regEx,
 }: IRecipeFormProps) {
   const StyledLabel = isRecipeNameError ? ErrorLabel : Label;
   const StyledTextField = isRecipeNameError ? ErrorTextField : NormalTextField;
@@ -78,6 +79,7 @@ export default function RecipeForm({
             required
             value={recipeFormData.recipeName}
             variant="outlined"
+            pattern={regEx.recipeNameRegEx}
           />
         </FormFieldWrapper>
         <FormFieldWrapper>
@@ -99,6 +101,7 @@ export default function RecipeForm({
               placeholder={T.translate(`${PREFIX}.descriptionPlaceholder`)}
               required
               value={recipeFormData.description}
+              pattern={regEx.descriptionRegEx}
             />
           </FormControl>
         </FormFieldWrapper>

--- a/app/cdap/components/RecipeManagement/RecipeForm/index.tsx
+++ b/app/cdap/components/RecipeManagement/RecipeForm/index.tsx
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React from 'react';
+import { FormControl } from '@material-ui/core';
+import T from 'i18n-react';
+import {
+  CancelButton,
+  CreateRecipeFormButtonWrapper,
+  EditRecipeFormButtonWrapper,
+  ErrorLabel,
+  ErrorTextField,
+  FormFieldWrapper,
+  Label,
+  NormalTextField,
+  SaveButton,
+  StyledTextAreaAutosize,
+} from 'components/RecipeManagement/RecipeForm/styles';
+import { IRecipeFormProps } from 'components/RecipeManagement/types';
+import { ActionType } from 'components/RecipeList/types';
+
+const PREFIX = 'features.WranglerNewUI.RecipeForm.labels';
+
+export default function RecipeForm({
+  recipeFormData,
+  isRecipeNameError,
+  recipeNameErrorMessage,
+  onRecipeNameChange,
+  onFormSubmit,
+  onCancel,
+  isSaveDisabled,
+  recipeFormAction,
+  onRecipeDescriptionChange,
+}: IRecipeFormProps) {
+  const StyledLabel = isRecipeNameError ? ErrorLabel : Label;
+  const StyledTextField = isRecipeNameError ? ErrorTextField : NormalTextField;
+  const isCreateRecipeAction = recipeFormAction === ActionType.CREATE_RECIPE;
+  const StyledFormButtonWrapper = isCreateRecipeAction
+    ? CreateRecipeFormButtonWrapper
+    : EditRecipeFormButtonWrapper;
+
+  return (
+    <>
+      <form onSubmit={onFormSubmit} data-testid="recipe-form-parent">
+        <FormFieldWrapper>
+          <StyledLabel
+            data-testid="recipe-form-name-label"
+            component="label"
+            htmlFor="recipe-form-name-field"
+          >
+            {isCreateRecipeAction && T.translate(`${PREFIX}.createRecipeNameLabel`)}
+            {!isCreateRecipeAction && T.translate(`${PREFIX}.editRecipeNameLabel`)}
+          </StyledLabel>
+          <StyledTextField
+            id="recipe-form-name-field"
+            autoFocus={true}
+            aria-label="Recipe Name"
+            data-testid="recipe-form-name-field"
+            defaultValue={recipeFormData.recipeName}
+            error={isRecipeNameError}
+            fullWidth
+            helperText={isRecipeNameError ? recipeNameErrorMessage : ''}
+            onChange={onRecipeNameChange}
+            placeholder={T.translate(`${PREFIX}.namePlaceholder`)}
+            required
+            value={recipeFormData.recipeName}
+            variant="outlined"
+          />
+        </FormFieldWrapper>
+        <FormFieldWrapper>
+          <FormControl variant="outlined">
+            <Label
+              data-testid="recipe-form-description-label"
+              component="label"
+              htmlFor="recipe-form-description-field"
+            >
+              {T.translate(`${PREFIX}.description`)}
+            </Label>
+            <StyledTextAreaAutosize
+              id="recipe-form-description-field"
+              aria-label="Recipe Description"
+              data-testid="recipe-form-description-field"
+              defaultValue={recipeFormData.description}
+              minRows={4}
+              onChange={onRecipeDescriptionChange}
+              placeholder={T.translate(`${PREFIX}.descriptionPlaceholder`)}
+              required
+              value={recipeFormData.description}
+            />
+          </FormControl>
+        </FormFieldWrapper>
+        <StyledFormButtonWrapper>
+          <SaveButton
+            variant="contained"
+            type="submit"
+            data-testid="recipe-form-save-button"
+            disabled={isSaveDisabled}
+          >
+            {T.translate(`${PREFIX}.save`)}
+          </SaveButton>
+          <CancelButton
+            variant="outlined"
+            onClick={onCancel}
+            data-testid="recipe-form-cancel-button"
+          >
+            {T.translate(`${PREFIX}.cancel`)}
+          </CancelButton>
+        </StyledFormButtonWrapper>
+      </form>
+    </>
+  );
+}

--- a/app/cdap/components/RecipeManagement/RecipeForm/styles.ts
+++ b/app/cdap/components/RecipeManagement/RecipeForm/styles.ts
@@ -119,7 +119,7 @@ export const SaveButton = styled(PrimaryContainedButton)`
 
 export const CreateRecipeFormButtonWrapper = styled.div`
   float: left;
-  margin-top: 100px;
+  margin-top: 78px;
   padding-bottom: 20px;
 `;
 

--- a/app/cdap/components/RecipeManagement/RecipeForm/styles.ts
+++ b/app/cdap/components/RecipeManagement/RecipeForm/styles.ts
@@ -42,6 +42,7 @@ export const Label = styled(Typography)`
   font-weight: 400;
   letter-spacing: 0.4px;
   line-height: 20px;
+  margin-bottom: 2px;
 `;
 
 export const ErrorLabel = styled(Label)`
@@ -60,7 +61,7 @@ export const StyledTextField = styled(TextField)`
     margin-right: 0px;
   }
   .MuiOutlinedInput-input {
-    padding: 12px 14px;
+    padding: 12px 18px;
     font-size: 14px;
     line-height: 150%;
     letter-spacing: 0.15px;
@@ -89,7 +90,7 @@ export const StyledTextAreaAutosize = styled(TextareaAutosize)`
   height: 100px;
   letter-spacing: 0.15px;
   line-height: 150%;
-  padding: 10.5px 14px;
+  padding: 10.5px 18px;
   resize: none;
   width: 460px;
   :focus-visible {

--- a/app/cdap/components/RecipeManagement/RecipeForm/styles.ts
+++ b/app/cdap/components/RecipeManagement/RecipeForm/styles.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { Box, TextareaAutosize, TextField, Typography } from '@material-ui/core';
+import { grey, red } from '@material-ui/core/colors';
+import styled, { css } from 'styled-components';
+
+import PrimaryContainedButton from 'components/shared/Buttons/PrimaryContainedButton';
+import PrimaryOutlinedButton from 'components/shared/Buttons/PrimaryOutlinedButton';
+
+export const buttonStyles = css`
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 150%;
+  letter-spacing: 0.15px;
+`;
+
+export const FormFieldWrapper = styled(Box)`
+  margin-bottom: 15px;
+  margin-right: 60px;
+  margin-top: 15px;
+  width: calc(100% - 60px);
+`;
+
+export const Label = styled(Typography)`
+  color: ${grey[700]};
+  font-style: normal;
+  font-size: 12px;
+  font-weight: 400;
+  letter-spacing: 0.4px;
+  line-height: 20px;
+`;
+
+export const ErrorLabel = styled(Label)`
+  color: #e05243;
+`;
+
+export const StyledTextField = styled(TextField)`
+  width: 460px;
+  input::placeholder {
+    color: ${grey[600]};
+    opacity: 1;
+  }
+  .MuiFormHelperText-root.Mui-error {
+    color: #e05243;
+    margin-left: 0px;
+    margin-right: 0px;
+  }
+  .MuiOutlinedInput-input {
+    padding: 12px 14px;
+    font-size: 14px;
+    line-height: 150%;
+    letter-spacing: 0.15px;
+  }
+`;
+
+export const ErrorTextField = styled(StyledTextField)`
+  .MuiOutlinedInput-root .MuiOutlinedInput-notchedOutline {
+    border: 1px solid ${red.A100};
+  }
+  .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline {
+    border: 1px solid ${red.A100};
+  }
+`;
+
+export const NormalTextField = styled(StyledTextField)`
+  .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline {
+    border: 1px solid #000000;
+  }
+`;
+
+export const StyledTextAreaAutosize = styled(TextareaAutosize)`
+  border-color: ${grey[300]};
+  border-radius: 4px;
+  font-size: 14px;
+  height: 100px;
+  letter-spacing: 0.15px;
+  line-height: 150%;
+  padding: 10.5px 14px;
+  resize: none;
+  width: 460px;
+  :focus-visible {
+    outline: unset;
+    border: 1px solid #000000;
+  }
+  :hover {
+    border: 1px solid #000000;
+  }
+  ::placeholder {
+    color: ${grey[600]};
+  }
+`;
+
+export const CancelButton = styled(PrimaryOutlinedButton)`
+  ${buttonStyles}
+  color: #3367D6;
+  width: 92px;
+`;
+
+export const SaveButton = styled(PrimaryContainedButton)`
+  ${buttonStyles}
+  background: #3367d6;
+  margin-right: 20px;
+  width: 70px;
+`;
+
+export const CreateRecipeFormButtonWrapper = styled.div`
+  float: left;
+  margin-top: 100px;
+  padding-bottom: 20px;
+`;
+
+export const EditRecipeFormButtonWrapper = styled(CreateRecipeFormButtonWrapper)`
+  margin-top: 348px;
+`;

--- a/app/cdap/components/RecipeManagement/types.ts
+++ b/app/cdap/components/RecipeManagement/types.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { ChangeEvent, Dispatch, FormEvent, SetStateAction } from 'react';
+import { ISnackbar } from 'components/Snackbar';
+
+export interface IRecipeFormProps {
+  isRecipeNameError: boolean;
+  isSaveDisabled: boolean;
+  onCancel: () => void;
+  onFormSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onRecipeDescriptionChange: (event: ChangeEvent<HTMLTextAreaElement>) => void;
+  onRecipeNameChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  recipeFormAction: string;
+  recipeFormData: IRecipeFormData | IRecipeData;
+  recipeNameErrorMessage: string;
+}
+
+export interface IRecipeFormData {
+  recipeName: string;
+  description: string;
+}
+
+export interface IRecipeData extends IRecipeFormData {
+  directives: string[];
+}
+
+export interface ICreateRecipeProps {
+  setShowRecipeForm: Dispatch<SetStateAction<boolean>>;
+  setSnackbar: Dispatch<SetStateAction<ISnackbar>>;
+}
+
+export interface IRecipeNameErrorData {
+  isRecipeNameError: boolean;
+  recipeNameErrorMessage: string;
+}

--- a/app/cdap/components/RecipeManagement/types.ts
+++ b/app/cdap/components/RecipeManagement/types.ts
@@ -27,6 +27,12 @@ export interface IRecipeFormProps {
   recipeFormAction: string;
   recipeFormData: IRecipeFormData | IRecipeData;
   recipeNameErrorMessage: string;
+  regEx: IRecipeFormFieldsRegEx;
+}
+
+export interface IRecipeFormFieldsRegEx {
+  recipeNameRegEx: RegExp;
+  descriptionRegEx: RegExp;
 }
 
 export interface IRecipeFormData {

--- a/app/cdap/services/react/customHooks/useFetch.ts
+++ b/app/cdap/services/react/customHooks/useFetch.ts
@@ -40,13 +40,8 @@ export default function useFetch<T>(service, params, requestBody?): ApiResponse<
     setResponse(null);
     setError(null);
     service(params, requestBody ?? {}).subscribe(
-      (res) => {
-        const apiResponse = res || true;
-        setResponse(apiResponse);
-      },
-      (err: Record<string, unknown>) => {
-        setError(err);
-      }
+      (res) => setResponse(res || true),
+      (err: Record<string, unknown>) => setError(err)
     );
   }, [params]);
 

--- a/app/cdap/services/react/customHooks/useFetch.ts
+++ b/app/cdap/services/react/customHooks/useFetch.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { useState, useEffect, useRef } from 'react';
+
+interface ApiResponse<T> {
+  response: T;
+  error: Record<string, unknown>;
+}
+
+export default function useFetch<T>(service, params, requestBody?): ApiResponse<T> {
+  const [response, setResponse] = useState<T>(null);
+  const [error, setError] = useState<Record<string, unknown>>(null);
+  const isFirstRender = useRef(true);
+
+  useEffect(() => {
+    /*
+     * here to avoid the API calling for the first time when useEffect is called
+     * we are using a ref with default value true
+     * and when this useEffect is called for the first time we are making this value false
+     * and returning without calling an API so that unnecessary API call will not happen for the first time
+     */
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    setResponse(null);
+    setError(null);
+    service(params, requestBody ?? {}).subscribe(
+      (res) => {
+        const apiResponse = res || true;
+        setResponse(apiResponse);
+      },
+      (err: Record<string, unknown>) => {
+        setError(err);
+      }
+    );
+  }, [params]);
+
+  return { response, error };
+}

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -3579,7 +3579,7 @@ features:
         sameNameErrorMessage: Another recipe with same name exists. Please input another name
         save: Save
         saveRecipe: Save as recipe
-        validationErrorMessage: Recipe name should contain only alphanumeric characters or spaces      
+        validationErrorMessage: Recipe name should contain only alphanumeric characters or spaces in between      
     Snackbar:
       labels:
         failure: Failure

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -3564,10 +3564,26 @@ features:
         steps: Steps
         updated: Last updated
         view: View
-        viewAll: View All      
+        viewAll: View All
+    RecipeForm:
+      labels:
+        cancel: Cancel
+        createRecipeNameLabel: Name of new recipe
+        description: Description of recipe
+        descriptionPlaceholder: Input a description to identify it later
+        editRecipeNameLabel: Name of recipe
+        errorMessage: Something went wrong!
+        namePlaceholder: Input a name to identify it later
+        recipeFormInfo: steps will be saved as a recpe. You can access this saved recipe from the recipes section on Wrangler Home page.
+        recipeSaveSuccessMessage: Steps successfully saved as a recipe!
+        sameNameErrorMessage: Another recipe with same name exists. Please input another name
+        save: Save
+        saveRecipe: Save as recipe
+        validationErrorMessage: Recipe name should contain only alphanumeric characters or spaces      
     Snackbar:
       labels:
         failure: Failure
         success: Success
         undo: Undo
 ...
+

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
       Only update this when releasing a new UI pack.
     -->
     <ui.pack.version>4.3.4_p7</ui.pack.version>
-    <guava.version>27.0.1-jre</guava.version>
+    <guava.version>31.1-jre</guava.version>
     <testSourceLocation>${project.basedir}/src/test/java/</testSourceLocation>
   </properties>
 


### PR DESCRIPTION
# TITLE
Feature - Create Recipe

## Description
Summary of changes
This PR contains changes related to Create Recipe Form

## Following are the files to be reviewed as part of this PR
1. app/cdap/components/CreateEditRecipeForm/*
2. app/cdap/components/CreateRecipe/*
3. app/cdap/text/text-en.yaml

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira:[ [Jira issue #](fill-in.org)](https://divami21.atlassian.net/browse/GW2-127)

## Test Plan
1. TC_Create_14 - Verify if the Name field is enabled or not
2. TC_Create_15 - Verify the user is able to enter the string in the Name field
3. TC_Create_16 - Verify if the Description field is enabled or not
4. TC_Create_17 - Verify if the user is able to enter the string in the Description field
5. TC_Create_18 - Verify the user is able to Save the recipe with a non-existing name and valid Description
6. TC_Create_19 - Verify the user is able to Save the recipe with the existing name and valid Description
7. TC_Create_20 - Verify if the user is not able to Save the recipe by entering data in the Description field only
8. TC_Create_21 - Verify if the user is not able to Save the recipe by entering data in the Name field only
9. TC_Create_22 -  Verify if the user is not able to Save the recipe by entering spaces in the Name field only
10. TC_Create_23 - Verify if the user is not able to Save the recipe by entering spaces in the Description field only
11. TC_Create_24 - Verify if the user is not able to Save the recipe by entering spaces in both fields
12. TC_Create_25 - Verify clicking on the 'Cancel' button after entering valid data in both fields
13. TC_Create_26 - Verify clicking on the 'Cancel' button when the Create Form displayed
14. TC_Create_27 - Verify snack bar is displayed after saving the recipe

## Screenshots
<img width="1440" alt="Screenshot 2022-12-14 at 12 26 33 AM" src="https://user-images.githubusercontent.com/114049829/207422673-4d321e97-a6be-4558-8aac-7722b9b88e35.png">
<img width="1436" alt="Screenshot 2022-12-14 at 12 31 39 AM" src="https://user-images.githubusercontent.com/114049829/207422701-b4364b1c-d0da-44cf-bfba-1e250cd29df8.png">
<img width="1431" alt="Screenshot 2022-12-14 at 12 32 31 AM" src="https://user-images.githubusercontent.com/114049829/207422704-2c6c47db-c6bb-4e79-a63d-f17e57976638.png">
<img width="1434" alt="Screenshot 2022-12-14 at 12 33 06 AM" src="https://user-images.githubusercontent.com/114049829/207422715-fb1d6841-1ce4-4c9e-b16e-9560ccfca54e.png">
<img width="1440" alt="Screenshot 2022-12-14 at 12 33 46 AM" src="https://user-images.githubusercontent.com/114049829/207422719-f650ef4d-8389-4e14-ab92-f9dc3542f734.png">