### PR TITLE
Fix source column name displayed in target column in replication assessment

### DIFF
--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/table.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/table.tsx
@@ -56,7 +56,7 @@ import TransformDelete from './TransformDelete';
 import { SUPPORT } from '../Assessment/TablesAssessment/Mappings/Supported';
 
 // uses the last created rename directive on that column to show the target column name
-const useLastRenameOrRowName = (columnName: string, transforms: IColumnTransformation[]) => {
+const useLastRenameOrRowName = (columnName: string, targetColumnName: string, transforms: IColumnTransformation[]) => {
   const renameDir = transforms
     .slice()
     .reverse()
@@ -68,7 +68,7 @@ const useLastRenameOrRowName = (columnName: string, transforms: IColumnTransform
     return renameDir.directive.split(' ')[2];
   }
 
-  return columnName;
+  return targetColumnName;
 };
 
 export const renderTable = ({
@@ -286,7 +286,7 @@ export const renderTable = ({
                 </Grid>
                 <GridCell item xs={4}>
                   <NoPaddingSpanLeft>
-                    {useLastRenameOrRowName(row.name, transforms)}
+                    {useLastRenameOrRowName(row.name, row.targetName, transforms)}
                   </NoPaddingSpanLeft>
                 </GridCell>
               </GridCellContainer>


### PR DESCRIPTION
# Fix source column name displayed in target column in replication assessment

## Description
When creating replication pipelines, on "Mappings, assessments and transformations" step,  source column name is displayed in target column

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20225](https://cdap.atlassian.net/browse/CDAP-20225)

## Test Plan
Tested on sandbox

## Screenshots

### Mappings, assessments and transformations 
<img width="746" alt="Screen Shot 2022-12-30 at 4 34 41 PM" src="https://user-images.githubusercontent.com/108464238/210064334-dd62c27a-efe4-4a78-8b4a-f4218aa4adac.png">


### View mappings (Correct)
<img width="811" alt="Screen Shot 2022-12-30 at 4 41 48 PM" src="https://user-images.githubusercontent.com/108464238/210064325-80a56146-097e-4960-a66d-6ced19f175c9.png">




