### PR TITLE
[CDAP-20005] fix modal close on drag event

### DIFF
--- a/app/cdap/components/PipelineDetails/PipelineModeless/index.js
+++ b/app/cdap/components/PipelineDetails/PipelineModeless/index.js
@@ -89,7 +89,7 @@ export default function PipelineModeless({
           <div className={className}>
             {arrow ? <div className="pipeline-modeless-arrow" ref={setArrowRef} /> : null}
             {isDeployed ? (
-              <ClickAwayListener onClickAway={onClose}>
+              <ClickAwayListener mouseEvent="onPointerDown" onClickAway={onClose}>
                 <Paper className="pipeline-modeless-container" variant="outlined">
                   <div className="pipeline-modeless-header">
                     <div className="pipeline-modeless-title">{title}</div>

--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/table.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/table.tsx
@@ -56,7 +56,11 @@ import TransformDelete from './TransformDelete';
 import { SUPPORT } from '../Assessment/TablesAssessment/Mappings/Supported';
 
 // uses the last created rename directive on that column to show the target column name
-const useLastRenameOrRowName = (columnName: string, targetColumnName: string, transforms: IColumnTransformation[]) => {
+const useLastRenameOrRowName = (
+  columnName: string,
+  targetColumnName: string,
+  transforms: IColumnTransformation[]
+) => {
   const renameDir = transforms
     .slice()
     .reverse()


### PR DESCRIPTION
# [CDAP-20005] fix modal close on drag event initiated from inside the pipeline details modal

## Description

Fix for the following issue:

```
Steps to reproduce the issue:

  1. In the deployed pipeline click “Schedule”
  2. Start selecting “0” in “Min” input box from the right
  3. Move mouse to the left while holding the LMB until it exits the window
  4. Depress the LMB

  Result: window closes.
  Expected result: “0” is selected nicely
```


## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20005](https://cdap.atlassian.net/browse/CDAP-20005)

## Test Plan

Tested manually.

## Screenshots
<img width="1512" alt="Screen Shot 2023-01-04 at 4 38 20 AM" src="https://user-images.githubusercontent.com/4161531/210456710-aa7acfe2-d0e5-43e3-a80e-0e76dba28d26.png">




[CDAP-20005]: https://cdap.atlassian.net/browse/CDAP-20005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ