### PR TITLE
[CDAP-20230] add draft deletion during reconciliation

### DIFF
--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/table.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/table.tsx
@@ -56,7 +56,11 @@ import TransformDelete from './TransformDelete';
 import { SUPPORT } from '../Assessment/TablesAssessment/Mappings/Supported';
 
 // uses the last created rename directive on that column to show the target column name
-const useLastRenameOrRowName = (columnName: string, targetColumnName: string, transforms: IColumnTransformation[]) => {
+const useLastRenameOrRowName = (
+  columnName: string,
+  targetColumnName: string,
+  transforms: IColumnTransformation[]
+) => {
   const renameDir = transforms
     .slice()
     .reverse()

--- a/app/cdap/components/hydrator/components/TopPanel/TopPanel.tsx
+++ b/app/cdap/components/hydrator/components/TopPanel/TopPanel.tsx
@@ -157,6 +157,7 @@ interface ITopPanelProps {
   isEdit: boolean;
   saveChangeSummary: (changeSummary: string) => any;
   getParentVersion: () => any;
+  stateParams: any;
 }
 
 export const TopPanel = ({
@@ -208,12 +209,18 @@ export const TopPanel = ({
   isEdit,
   saveChangeSummary,
   getParentVersion,
+  stateParams,
 }: ITopPanelProps) => {
   const sheculdeInfo = getScheduleInfo();
   const [isChangeSummaryOpen, setIsChangeSummaryOpen] = useState<boolean>(false);
   const [changeSummary, setChangeSummary] = useState('');
   const [parentConfig, setParentConfig] = useState({ ...getConfigForExport().config });
   const [editStatus, setEditStatus] = useState(null);
+
+  const params = {
+    namespace: getCurrentNamespace(),
+    appId: state.metadata.name,
+  };
 
   const initialError = {
     errorMessage: null,
@@ -223,6 +230,18 @@ export const TopPanel = ({
   const exportDraftAndRedirect = () => {
     downloadFile(getConfigForExport());
     window.onbeforeunload = null;
+    // if there is a draft saved, delete it
+    if (stateParams.draftId) {
+      MyPipelineApi.deleteDraft({
+        context: getCurrentNamespace(),
+        draftId: stateParams.draftId,
+      }).subscribe({
+        error(err) {
+          // tslint:disable:no-console
+          console.log('Cannot delete draft');
+        },
+      });
+    }
     editPipeline(state.metadata.name);
   };
 
@@ -235,7 +254,7 @@ export const TopPanel = ({
             exportDraftAndRedirect();
           }}
         >
-          Export
+          {T.translate(`${PREFIX}.errors.outdatedDraftActionButton`)}
         </ErrorExportButton>
       </div>
     );
@@ -275,10 +294,6 @@ export const TopPanel = ({
   const publishPipeline = () => {
     if (isEdit) {
       // check for if parentVersion is still good
-      const params = {
-        namespace: getCurrentNamespace(),
-        appId: state.metadata.name,
-      };
       MyPipelineApi.get(params).subscribe(
         (res) => {
           // check for if edit has new changes
@@ -308,10 +323,6 @@ export const TopPanel = ({
     if (!isEdit) {
       return;
     }
-    const params = {
-      namespace: getCurrentNamespace(),
-      appId: state.metadata.name,
-    };
 
     // first time execute before interval
     MyPipelineApi.get(params).subscribe(

--- a/app/cdap/components/shared/ConfirmationModal/index.js
+++ b/app/cdap/components/shared/ConfirmationModal/index.js
@@ -29,7 +29,7 @@ export default class ConfirmationModal extends Component {
   static propTypes = {
     cancelButtonText: PropTypes.string,
     cancelFn: PropTypes.func,
-    confirmationElem: PropTypes.element,
+    confirmationElem: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     confirmButtonText: PropTypes.string,
     confirmationText: PropTypes.oneOfType([
       PropTypes.string,

--- a/app/cdap/components/shared/DiscardDraftModal/index.tsx
+++ b/app/cdap/components/shared/DiscardDraftModal/index.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import ConfirmationModal from '../ConfirmationModal';
 import T from 'i18n-react';
 
-const PREFIX = 'features.LifeCycleManagement';
+const PREFIX = 'features.LifeCycleManagement.discardModal';
 
 interface IDiscardDraftModalProps {
   isOpen: boolean;
@@ -35,14 +35,14 @@ export const DiscardDraftModal = ({
 }: IDiscardDraftModalProps) => {
   return (
     <ConfirmationModal
-      headerTitle="Edit draft exists"
+      headerTitle={T.translate(`${PREFIX}.title`)}
       isOpen={isOpen}
-      cancelFn={continueFn}
-      cancelButtonText="Continue"
-      confirmButtonText="Discard"
+      cancelFn={discardFn}
+      cancelButtonText={T.translate(`${PREFIX}.discard`)}
+      confirmButtonText={T.translate(`${PREFIX}.continue`)}
       toggleModal={toggleModal}
-      confirmationElem={T.translate(`${PREFIX}.discardModalText`)}
-      confirmFn={discardFn}
+      confirmationElem={T.translate(`${PREFIX}.text`)}
+      confirmFn={continueFn}
       closeable={true}
     />
   );

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -1944,10 +1944,15 @@ features:
   licenseText: Licensed under the Apache License, Version 2.0
 
   LifeCycleManagement:
-    discardModalText: An edit draft exists for this pipeline. Click 'Discard' to discard the changes
-      that were made and start a new draft. Click 'Continue' to continue editing the existing draft.
+    discardModal:
+      continue: Continue
+      discard: Discard
+      text: An edit draft exists for this pipeline. Click 'Discard' to discard the changes 
+        that were made and start a new draft. Click 'Continue' to continue editing the existing draft.
+      title: Edit draft exists
     errors:
       noEditChangeError: You have not made any changes to the pipeline, deployment is not allowed.
+      outdatedDraftActionButton: Export and Rebase
       outdatedDraftError: A new version of pipeline "{pipelineName}" has been deployed. 
         This draft is outdated and please export the draft for manual reconciliation.
 

--- a/app/hydrator/templates/create/reacttoppanel.html
+++ b/app/hydrator/templates/create/reacttoppanel.html
@@ -64,4 +64,5 @@
   is-edit="HydratorPlusPlusTopPanelCtrl.isEdit"
   save-change-summary="HydratorPlusPlusTopPanelCtrl.saveChangeSummary"
   get-parent-version="HydratorPlusPlusTopPanelCtrl.getParentVersion"
+  state-params="HydratorPlusPlusTopPanelCtrl.$stateParams"
 ></top-panel-react>


### PR DESCRIPTION
# [CDAP-20230] add draft deletion during reconciliation

## Description
* For LCM, when the user saves a draft and the draft becomes outdated, they can reconcile by rebasing the pipeline to latest version. However, if they choose to save draft again, they will save it as a second copy instead of overwriting the existing one. The approach in this pr is to delete the existing draft while rebasing. I can see another approach to be making the draftId persistent while redirect the page, so that when the user clicks 'save' it saves to the same draft. I'm open to either
* Switch 'Continue' and 'Discard' positions based on feedbacks

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20230](https://cdap.atlassian.net/browse/CDAP-20230)





[CDAP-20230]: https://cdap.atlassian.net/browse/CDAP-20230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20230]: https://cdap.atlassian.net/browse/CDAP-20230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20230]: https://cdap.atlassian.net/browse/CDAP-20230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ