### PR TITLE
[CDAP-20004] Update notags text for viewonly state

### DIFF
--- a/app/cdap/components/shared/Tags/index.js
+++ b/app/cdap/components/shared/Tags/index.js
@@ -299,7 +299,7 @@ export default class Tags extends Component {
 
   getNoTagsText() {
     if (this.props.viewOnly) {
-      return T.translate(`${PREFIX}.notagsViewonly`);
+      return T.translate(`${PREFIX}.noTagsViewonly`);
     }
 
     return T.translate(`${PREFIX}.notags`);

--- a/app/cdap/components/shared/Tags/index.js
+++ b/app/cdap/components/shared/Tags/index.js
@@ -297,6 +297,14 @@ export default class Tags extends Component {
     return this.state.showInputField ? this.renderInputField() : this.renderPlusButton();
   }
 
+  getNoTagsText() {
+    if (this.props.viewOnly) {
+      return T.translate(`${PREFIX}.notagsViewonly`);
+    }
+
+    return T.translate(`${PREFIX}.notags`);
+  }
+
   render() {
     let tagsCount = this.state.userTags.length;
 
@@ -305,7 +313,7 @@ export default class Tags extends Component {
         {this.props.showCountLabel ? (
           <strong>{`${T.translate(`${PREFIX}.labelWithCount`, { count: tagsCount })}:`}</strong>
         ) : null}
-        {!tagsCount && !this.state.loading ? <i>{T.translate(`${PREFIX}.notags`)}</i> : null}
+        {!tagsCount && !this.state.loading ? <i>{this.getNoTagsText()}</i> : null}
         <span className="tags-list">{this.renderUserTags()}</span>
         {this.state.showAllTagsLabel ? this.renderTagsPopover() : null}
         {this.renderAddTag()}

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -3113,7 +3113,7 @@ features:
     allTags: All Tags
     labelWithCount: Tags ({count})
     notags: No tags found. Click to add a new business tag.
-    notagsViewonly: No tags found.
+    noTagsViewonly: No tags found.
 
   TriggeredPipelines:
     collapsedTabLabel: "Outbound triggers ({count})"

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -3113,6 +3113,7 @@ features:
     allTags: All Tags
     labelWithCount: Tags ({count})
     notags: No tags found. Click to add a new business tag.
+    notagsViewonly: No tags found.
 
   TriggeredPipelines:
     collapsedTabLabel: "Outbound triggers ({count})"


### PR DESCRIPTION
# [CDAP-20004] Update notags text for viewonly state

## Description

Fix for the following issue:

```
In pipeline list it says "No tags found. Click to add a business tag". But when I click I get to pipeline details.
```

**Solution** : The PipelineTags column is viewonly. In this state the text should be `No tags found.`  

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20004](https://cdap.atlassian.net/browse/CDAP-20004)

## Test Plan

Manually tested.

## Screenshots

![Screen Shot 2023-01-04 at 3 16 49 PM](https://user-images.githubusercontent.com/4161531/210527736-4d748eb4-6af8-485b-98be-ed2f5b689da8.png)



[CDAP-20004]: https://cdap.atlassian.net/browse/CDAP-20004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20004]: https://cdap.atlassian.net/browse/CDAP-20004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20004]: https://cdap.atlassian.net/browse/CDAP-20004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ