### PR TITLE
[CDAP-20253] improve lcm runtimeargs ux

### DIFF
--- a/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ConfigModelessActionButtons/index.tsx
+++ b/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ConfigModelessActionButtons/index.tsx
@@ -89,7 +89,7 @@ export const ConfigModelessActionButtons = ({ ...props }: IConfigModelessActionB
     setSaveLoading(true);
     let observable;
     if (lifecycleManagementEditEnabled) {
-      observable = updatePreferences(lifecycleManagementEditEnabled, true);
+      observable = updatePreferences();
     } else {
       observable = Observable.forkJoin(updatePipeline(), updatePreferences());
     }

--- a/app/cdap/components/PipelineConfigurations/ConfigurationsContent/PipelineConfigTabContent/Instrumentation.js
+++ b/app/cdap/components/PipelineConfigurations/ConfigurationsContent/PipelineConfigTabContent/Instrumentation.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Cask Data, Inc.
+ * Copyright © 2018-2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -25,8 +25,8 @@ import PipelineConfigurationsStore, {
 } from 'components/PipelineConfigurations/Store';
 import T from 'i18n-react';
 import { GENERATED_RUNTIMEARGS } from 'services/global-constants';
-import { convertKeyValuePairsToMap, convertMapToKeyValuePairs } from 'services/helpers';
 import { useFeatureFlagDefaultFalse } from 'services/react/customHooks/useFeatureFlag';
+import { getUpdatedRuntimeArgsPair } from '../helper';
 
 const PREFIX = 'features.PipelineConfigurations.PipelineConfig';
 
@@ -46,16 +46,17 @@ const mapDispatchToInstrumentationProps = (dispatch) => {
   );
   return {
     onToggle: (value) => {
-      const { runtimeArgs } = PipelineConfigurationsStore.getState();
-      const pairs = [...runtimeArgs.pairs];
-      const runtimeObj = convertKeyValuePairsToMap(pairs, true);
-      runtimeObj[GENERATED_RUNTIMEARGS.PIPELINE_INSTRUMENTATION] = value.toString();
-      const newRunTimePairs = convertMapToKeyValuePairs(runtimeObj);
       dispatch({
         type: PipelineConfigurationsActions.SET_INSTRUMENTATION,
         payload: { instrumentation: value },
       });
       if (lifecycleManagementEditEnabled) {
+        const { runtimeArgs } = PipelineConfigurationsStore.getState();
+        const newRunTimePairs = getUpdatedRuntimeArgsPair(
+          runtimeArgs,
+          GENERATED_RUNTIMEARGS.PIPELINE_INSTRUMENTATION,
+          value
+        );
         dispatch({
           type: PipelineConfigurationsActions.SET_RUNTIME_ARGS,
           payload: { runtimeArgs: { pairs: newRunTimePairs } },

--- a/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ResourcesTabContent/DriverResources.js
+++ b/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ResourcesTabContent/DriverResources.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Cask Data, Inc.
+ * Copyright © 2018-2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -25,8 +25,8 @@ import PipelineConfigurationsStore, {
 } from 'components/PipelineConfigurations/Store';
 import T from 'i18n-react';
 import { GENERATED_RUNTIMEARGS } from 'services/global-constants';
-import { convertKeyValuePairsToMap, convertMapToKeyValuePairs } from 'services/helpers';
 import { useFeatureFlagDefaultFalse } from 'services/react/customHooks/useFeatureFlag';
+import { getUpdatedRuntimeArgsPair } from '../helper';
 
 const PREFIX = 'features.PipelineConfigurations.Resources';
 
@@ -50,31 +50,35 @@ const mapDispatchToProps = (dispatch) => {
   );
   return {
     onVirtualCoresChange: (e) => {
-      const { runtimeArgs } = PipelineConfigurationsStore.getState();
-      const pairs = [...runtimeArgs.pairs];
-      const runtimeObj = convertKeyValuePairsToMap(pairs, true);
-      runtimeObj[GENERATED_RUNTIMEARGS.SYSTEM_DRIVER_RESOURCES_CORES] = e.target.value;
-      const newRunTimePairs = convertMapToKeyValuePairs(runtimeObj);
       dispatch({
         type: PipelineConfigurationsActions.SET_DRIVER_VIRTUAL_CORES,
         payload: { virtualCores: e.target.value },
       });
-      dispatch({
-        type: PipelineConfigurationsActions.SET_RUNTIME_ARGS,
-        payload: { runtimeArgs: { pairs: newRunTimePairs } },
-      });
+      if (lifecycleManagementEditEnabled) {
+        const { runtimeArgs } = PipelineConfigurationsStore.getState();
+        const newRunTimePairs = getUpdatedRuntimeArgsPair(
+          runtimeArgs,
+          GENERATED_RUNTIMEARGS.SYSTEM_DRIVER_RESOURCES_CORES,
+          e.target.value
+        );
+        dispatch({
+          type: PipelineConfigurationsActions.SET_RUNTIME_ARGS,
+          payload: { runtimeArgs: { pairs: newRunTimePairs } },
+        });
+      }
     },
     onMemoryMBChange: (e) => {
-      const { runtimeArgs } = PipelineConfigurationsStore.getState();
-      const pairs = [...runtimeArgs.pairs];
-      const runtimeObj = convertKeyValuePairsToMap(pairs, true);
-      runtimeObj[GENERATED_RUNTIMEARGS.SYSTEM_DRIVER_RESOURCES_MEMORY] = e.target.value;
-      const newRunTimePairs = convertMapToKeyValuePairs(runtimeObj);
       dispatch({
         type: PipelineConfigurationsActions.SET_DRIVER_MEMORY_MB,
         payload: { memoryMB: e.target.value },
       });
       if (lifecycleManagementEditEnabled) {
+        const { runtimeArgs } = PipelineConfigurationsStore.getState();
+        const newRunTimePairs = getUpdatedRuntimeArgsPair(
+          runtimeArgs,
+          GENERATED_RUNTIMEARGS.SYSTEM_DRIVER_RESOURCES_MEMORY,
+          e.target.value
+        );
         dispatch({
           type: PipelineConfigurationsActions.SET_RUNTIME_ARGS,
           payload: { runtimeArgs: { pairs: newRunTimePairs } },

--- a/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ResourcesTabContent/ExecutorResources.js
+++ b/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ResourcesTabContent/ExecutorResources.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Cask Data, Inc.
+ * Copyright © 2018-2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -26,8 +26,8 @@ import PipelineConfigurationsStore, {
 } from 'components/PipelineConfigurations/Store';
 import T from 'i18n-react';
 import { GENERATED_RUNTIMEARGS, GLOBALS } from 'services/global-constants';
-import { convertKeyValuePairsToMap, convertMapToKeyValuePairs } from 'services/helpers';
 import { useFeatureFlagDefaultFalse } from 'services/react/customHooks/useFeatureFlag';
+import { getUpdatedRuntimeArgsPair } from '../helper';
 
 const PREFIX = 'features.PipelineConfigurations.Resources';
 
@@ -53,31 +53,35 @@ const mapDispatchToProps = (dispatch) => {
   );
   return {
     onVirtualCoresChange: (e) => {
-      const { runtimeArgs } = PipelineConfigurationsStore.getState();
-      const pairs = [...runtimeArgs.pairs];
-      const runtimeObj = convertKeyValuePairsToMap(pairs, true);
-      runtimeObj[GENERATED_RUNTIMEARGS.SYSTEM_EXECUTOR_RESOURCES_CORES] = e.target.value;
-      const newRunTimePairs = convertMapToKeyValuePairs(runtimeObj);
       dispatch({
         type: PipelineConfigurationsActions.SET_MEMORY_VIRTUAL_CORES,
         payload: { virtualCores: e.target.value },
       });
-      dispatch({
-        type: PipelineConfigurationsActions.SET_RUNTIME_ARGS,
-        payload: { runtimeArgs: { pairs: newRunTimePairs } },
-      });
+      if (lifecycleManagementEditEnabled) {
+        const { runtimeArgs } = PipelineConfigurationsStore.getState();
+        const newRunTimePairs = getUpdatedRuntimeArgsPair(
+          runtimeArgs,
+          GENERATED_RUNTIMEARGS.SYSTEM_EXECUTOR_RESOURCES_CORES,
+          e.target.value
+        );
+        dispatch({
+          type: PipelineConfigurationsActions.SET_RUNTIME_ARGS,
+          payload: { runtimeArgs: { pairs: newRunTimePairs } },
+        });
+      }
     },
     onMemoryMBChange: (e) => {
-      const { runtimeArgs } = PipelineConfigurationsStore.getState();
-      const pairs = [...runtimeArgs.pairs];
-      const runtimeObj = convertKeyValuePairsToMap(pairs, true);
-      runtimeObj[GENERATED_RUNTIMEARGS.SYSTEM_EXECUTOR_RESOURCES_MEMORY] = e.target.value;
-      const newRunTimePairs = convertMapToKeyValuePairs(runtimeObj);
       dispatch({
         type: PipelineConfigurationsActions.SET_MEMORY_MB,
         payload: { memoryMB: e.target.value },
       });
       if (lifecycleManagementEditEnabled) {
+        const { runtimeArgs } = PipelineConfigurationsStore.getState();
+        const newRunTimePairs = getUpdatedRuntimeArgsPair(
+          runtimeArgs,
+          GENERATED_RUNTIMEARGS.SYSTEM_EXECUTOR_RESOURCES_MEMORY,
+          e.target.value
+        );
         dispatch({
           type: PipelineConfigurationsActions.SET_RUNTIME_ARGS,
           payload: { runtimeArgs: { pairs: newRunTimePairs } },

--- a/app/cdap/components/PipelineConfigurations/ConfigurationsContent/helper.ts
+++ b/app/cdap/components/PipelineConfigurations/ConfigurationsContent/helper.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { convertKeyValuePairsToMap, convertMapToKeyValuePairs } from 'services/helpers';
+
+export interface IRuntimeArgs {
+  pairs: any[];
+}
+
+/**
+ *
+ * @param runtimeArgs - the original runtimeArgs
+ * @param key - insert key
+ * @param value - insert value
+ * @returns - updated runtimeArgsPair
+ */
+export const getUpdatedRuntimeArgsPair = (
+  runtimeArgs: IRuntimeArgs,
+  key: string,
+  value: string
+) => {
+  const pairs = runtimeArgs.pairs;
+  const runtimeObj = convertKeyValuePairsToMap(pairs, true);
+  runtimeObj[key] = value.toString();
+  const newRunTimePairs = convertMapToKeyValuePairs(runtimeObj);
+  return newRunTimePairs;
+};

--- a/app/cdap/components/PipelineConfigurations/Store/ActionCreator.js
+++ b/app/cdap/components/PipelineConfigurations/Store/ActionCreator.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Cask Data, Inc.
+ * Copyright © 2018-2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -42,7 +42,7 @@ import { objectQuery } from 'services/helpers';
 import uuidV4 from 'uuid/v4';
 import uniqBy from 'lodash/uniqBy';
 import cloneDeep from 'lodash/cloneDeep';
-import { CLOUD, GENERATED_RUNTIMEARGS } from 'services/global-constants';
+import { CLOUD } from 'services/global-constants';
 import { Observable } from 'rxjs/Observable';
 import { map } from 'rxjs/operators';
 
@@ -132,57 +132,14 @@ const getMacrosResolvedByPrefs = (resolvedPrefs = {}, macrosMap = {}) => {
   return resolvedMacros;
 };
 
-const updatePreferences = (
-  lifecycleManagementEditEnabled = false,
-  overwriteEngineConfig = false
-) => {
-  const {
-    runtimeArgs,
-    properties,
-    pipelineVisualConfiguration,
-  } = PipelineConfigurationsStore.getState();
+const updatePreferences = () => {
+  const { runtimeArgs } = PipelineConfigurationsStore.getState();
   let filteredRuntimeArgs = cloneDeep(runtimeArgs);
   filteredRuntimeArgs.pairs = filteredRuntimeArgs.pairs.filter(
     (runtimeArg) => !runtimeArg.provided
   );
   let appId = PipelineDetailStore.getState().name;
   let prefObj = convertKeyValuePairsObjToMap(runtimeArgs);
-
-  if (lifecycleManagementEditEnabled) {
-    const customSparkConfigKeyValuePairs = runtimeArgs.pairs.filter((pair) =>
-      pair.key.startsWith(GENERATED_RUNTIMEARGS.CUSTOM_SPARK_KEY_PREFIX)
-    );
-    let pairs = cloneDeep(customSparkConfigKeyValuePairs);
-
-    // engine config overwritting
-    if (!overwriteEngineConfig) {
-      // save from runtime args dropdown
-      pairs.forEach((pair) => {
-        const trimmedKey = pair.key.substring(GENERATED_RUNTIMEARGS.CUSTOM_SPARK_KEY_PREFIX.length);
-        pair.key = trimmedKey;
-      });
-      pairs.push({
-        key: '',
-        value: '',
-      });
-      const keyValues = { pairs: pairs };
-      const customConfigObj = convertKeyValuePairsObjToMap(keyValues);
-      PipelineConfigurationsStore.dispatch({
-        type: PipelineConfigurationsActions.SET_CUSTON_CONFIG_AND_KEY_VALUE_PAIRS,
-        payload: {
-          keyValues,
-          customConfig: customConfigObj,
-          pipelineType: pipelineVisualConfiguration.pipelineType,
-        },
-      });
-    } else {
-      // save from config tabs
-      pairs.forEach((pair) => {
-        delete prefObj[pair.key];
-      });
-      prefObj = { ...prefObj, ...properties, 'app.pipeline.overwriteConfig': 'true' };
-    }
-  }
 
   return MyPreferenceApi.setAppPreferences(
     {

--- a/app/cdap/components/PipelineDetails/PipelineRuntimeArgsDropdownBtn/RuntimeArgsModeless/index.tsx
+++ b/app/cdap/components/PipelineDetails/PipelineRuntimeArgsDropdownBtn/RuntimeArgsModeless/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Cask Data, Inc.
+ * Copyright © 2018-2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -95,7 +95,7 @@ class RuntimeArgsModeless extends PureComponent<IRuntimeArgsModelessProps> {
   public saveRuntimeArgs = (e) => {
     preventPropagation(e);
     this.toggleSaving();
-    updatePreferences(true).subscribe(
+    updatePreferences().subscribe(
       () => {
         this.setState(
           {

--- a/app/cdap/components/PipelineDetails/RunLevelInfo/RunLevelInfo.scss
+++ b/app/cdap/components/PipelineDetails/RunLevelInfo/RunLevelInfo.scss
@@ -208,6 +208,7 @@ $border-color: $grey-05;
       text-align: left;
       padding: 10px 0;
       height: calc(100% - 45px);
+      max-height: 700px;
       overflow-y: auto;
       margin-bottom: 10px;
 

--- a/app/cdap/services/helpers.js
+++ b/app/cdap/services/helpers.js
@@ -845,6 +845,34 @@ const flattenObj = (ob) => {
 };
 
 /**
+ * Unflatten a string and put into an object given a separator
+ * key = a.b.c 
+ * value = d
+ * => {a : {b : {c : d}}}
+ * 
+ * @param {object} obj - the object to put back to
+ * @param {string} stringKey - string key to be unflatten
+ * @param {string} value - value of the key
+ * @param {string} separator 
+ */
+const unflatternStringToObj = (obj, stringKey, value, separator = ".") => {
+  const arr = stringKey.split(separator);
+  let temp = obj;
+  arr.forEach((key, index) => {
+    if (key in temp) {
+      temp = temp[key];
+    } else {
+      if (index != arr.length - 1) {
+        temp[key] = {};
+        temp = temp[key];
+      } else {
+        temp[key] = value;
+      }
+    }
+  });
+};
+
+/**
  * 
  * @param {string[]} arr - a string array to search
  * @param {string} target - target string
@@ -926,6 +954,7 @@ export {
   cleanseObject,
   cleanseAndCompareTwoObjects,
   flattenObj,
+  unflatternStringToObj,
   arrayOfStringsMatchTargetPrefix,
   PIPELINE_ARTIFACTS,
 };


### PR DESCRIPTION
# [CDAP-20253] improve lcm runtimeargs ux

## Description
* improve transformation pushdown runtimeargs experience, saving from configs tab will delete outdated settings
* bind pushdown configurations on page load, so that settings will not always be empty when refreshing the page
* some other small bug fixes, added more comments

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [x] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20253](https://cdap.atlassian.net/browse/CDAP-20253)





[CDAP-20253]: https://cdap.atlassian.net/browse/CDAP-20253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20253]: https://cdap.atlassian.net/browse/CDAP-20253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ