### PR TITLE
[CDAP-19994] Move Cypress test execution to Node 16 for helmet and to match other build environments

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,24 +13,24 @@
 # the License.
 
 steps:
-- name: node:12
+- name: node:16
   entrypoint: 'yarn'
   args: ['install', '--ignore-optional', '--frozen-lockfile']
-- name: node:12
+- name: node:16
   entrypoint: 'yarn'
   args: ['run', 'bower-root']
-- name: node:12
+- name: node:16
   entrypoint: 'yarn'
   args: ['run', 'cdap-full-build-more-memory']
-- name: node:12
+- name: node:16
   entrypoint: 'yarn'
   dir: 'sandboxjs'
   args: ['install', '--frozen-lockfile']
-- name: node:12
+- name: node:16
   entrypoint: 'yarn'
   dir: 'sandboxjs'
   args: ['run', 'setup-cloudbuild']
-- name: node:12
+- name: node:16
   entrypoint: 'bash'
   args: ['-c', 'echo $$KEY_FILE > ./key_file.json']
   secretEnv: ['KEY_FILE']
@@ -48,5 +48,5 @@ availableSecrets:
     env: 'CYPRESS_KEY'
 options:
   machineType: E2_HIGHCPU_8
-  
+
 timeout: 10800s

--- a/cloudbuild/builder/Dockerfile
+++ b/cloudbuild/builder/Dockerfile
@@ -13,21 +13,28 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-FROM node:12.20.1
+FROM node:16
 # It would be easier to use cypress/base:12.19.0
 # However, this uses a Debian that doesn't support OpenJDK 8
 # So build our own Cypress + OpenJDK 8 builder
 # TODO When CDAP moves to Java 11, update this
 
+RUN apt-get update && \
+   apt install -y software-properties-common
+
+# Add OpenJDK registry
+RUN wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
+RUN add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
+
 # Install OpenJDK-8
 RUN apt-get update && \
-   apt-get install -y openjdk-8-jdk && \
+   apt-get install -y adoptopenjdk-8-hotspot && \
    apt-get install -y ant && \
    apt-get clean;
 
 # Fix certificate issues
 RUN apt-get update && \
-   apt-get install ca-certificates-java && \
+   apt-get install -y ca-certificates-java && \
    apt-get clean && \
    update-ca-certificates -f;
 


### PR DESCRIPTION
# Move Cypress test execution to Node 16 for helmet and to match other build environments

## Description
#848 added `helmet` to the Node server. This library requires node 14 but the Cypress build is on node 12. This PR updates the Cypress build to use node 16 in line with our other builds and environments. Since the node 16 image uses Debian 10 (buster) which doesn't include OpenJDK8 in its package repository, some extra steps had to be taken in the runner image.

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [X] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19994](https://cdap.atlassian.net/browse/CDAP-19994)

## Test Plan
Fix for testing

## Screenshots
N/A




[CDAP-19994]: https://cdap.atlassian.net/browse/CDAP-19994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ