### PR TITLE
[CDAP-20279] (SCM) change namespace admin looks

### DIFF
--- a/app/cdap/components/NamespaceAdmin/Description.tsx
+++ b/app/cdap/components/NamespaceAdmin/Description.tsx
@@ -15,30 +15,83 @@
  */
 
 import React from 'react';
-import makeStyles from '@material-ui/core/styles/makeStyles';
 import { connect } from 'react-redux';
+import { INamespaceAdmin } from './store';
+import styled from 'styled-components';
+import T from 'i18n-react';
+import { FormControl, MenuItem, Select } from '@material-ui/core';
 
-const useStyle = makeStyles((theme) => {
-  return {
-    root: {
-      marginTop: '15px',
-      marginBottom: '15px',
-    },
-  };
-});
+const PREFIX = 'features.NamespaceAdmin.description';
+
+const StyledDescription = styled.div`
+  margin-top: 10px;
+  margin-bottom: 15px;
+`;
+
+const StyledNamespaceDropdown = styled.div`
+  margin-top: 15px;
+  display: flex;
+
+  span {
+    font-size: 18px;
+    font-weight: 700;
+    width: 250px;
+  }
+`;
+
+const StyledSelect = styled(Select)`
+  min-width: 150px;
+  font-size: 16px;
+`;
 
 interface IDescriptionProps {
+  namespace: string;
+  namespaces: string[];
   description: string;
 }
 
-const DescriptionView: React.FC<IDescriptionProps> = ({ description }) => {
-  const classes = useStyle();
+const DescriptionView: React.FC<IDescriptionProps> = ({ namespace, namespaces, description }) => {
+  const onNamespaceChange = (event) => {
+    window.location.href = `/cdap/ns/${event.target.value}/details`;
+  };
 
-  return <div className={classes.root}>{description}</div>;
+  return (
+    <>
+      <StyledNamespaceDropdown>
+        <span>{T.translate(`${PREFIX}.title`, { name: namespace })}</span>
+        <span>
+          <FormControl variant="standard">
+            <StyledSelect
+              value={namespace}
+              onChange={onNamespaceChange}
+              MenuProps={{
+                anchorOrigin: {
+                  vertical: 'bottom',
+                  horizontal: 'left',
+                },
+                transformOrigin: {
+                  vertical: 'top',
+                  horizontal: 'left',
+                },
+                getContentAnchorEl: null,
+              }}
+            >
+              {namespaces.map((ns) => (
+                <MenuItem value={ns}>{ns}</MenuItem>
+              ))}
+            </StyledSelect>
+          </FormControl>
+        </span>
+      </StyledNamespaceDropdown>
+      <StyledDescription>{description}</StyledDescription>
+    </>
+  );
 };
 
-const mapStateToProps = (state) => {
+const mapStateToProps = (state: INamespaceAdmin) => {
   return {
+    namespace: state.namespace,
+    namespaces: state.namespaces,
     description: state.description,
   };
 };

--- a/app/cdap/components/NamespaceAdmin/Description.tsx
+++ b/app/cdap/components/NamespaceAdmin/Description.tsx
@@ -18,80 +18,22 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { INamespaceAdmin } from './store';
 import styled from 'styled-components';
-import T from 'i18n-react';
-import { FormControl, MenuItem, Select } from '@material-ui/core';
-
-const PREFIX = 'features.NamespaceAdmin.description';
 
 const StyledDescription = styled.div`
-  margin-top: 10px;
+  margin-top: 15px;
   margin-bottom: 15px;
 `;
 
-const StyledNamespaceDropdown = styled.div`
-  margin-top: 15px;
-  display: flex;
-
-  span {
-    font-size: 18px;
-    font-weight: 700;
-    width: 250px;
-  }
-`;
-
-const StyledSelect = styled(Select)`
-  min-width: 150px;
-  font-size: 16px;
-`;
-
 interface IDescriptionProps {
-  namespace: string;
-  namespaces: string[];
   description: string;
 }
 
-const DescriptionView: React.FC<IDescriptionProps> = ({ namespace, namespaces, description }) => {
-  const onNamespaceChange = (event) => {
-    window.location.href = `/cdap/ns/${event.target.value}/details`;
-  };
-
-  return (
-    <>
-      <StyledNamespaceDropdown>
-        <span>{T.translate(`${PREFIX}.title`, { name: namespace })}</span>
-        <span>
-          <FormControl variant="standard">
-            <StyledSelect
-              value={namespace}
-              onChange={onNamespaceChange}
-              MenuProps={{
-                anchorOrigin: {
-                  vertical: 'bottom',
-                  horizontal: 'left',
-                },
-                transformOrigin: {
-                  vertical: 'top',
-                  horizontal: 'left',
-                },
-                getContentAnchorEl: null,
-              }}
-            >
-              {namespaces.map((ns) => (
-                <MenuItem value={ns}>{ns}</MenuItem>
-              ))}
-            </StyledSelect>
-          </FormControl>
-        </span>
-      </StyledNamespaceDropdown>
-      <StyledDescription>{description}</StyledDescription>
-    </>
-  );
+const DescriptionView: React.FC<IDescriptionProps> = ({ description }) => {
+  return <StyledDescription>{description}</StyledDescription>;
 };
 
 const mapStateToProps = (state: INamespaceAdmin) => {
   return {
-    namespace: state.namespace,
-    namespaces: state.namespaces,
     description: state.description,
   };
 };

--- a/app/cdap/components/NamespaceAdmin/Metrics/MetricCard.tsx
+++ b/app/cdap/components/NamespaceAdmin/Metrics/MetricCard.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { ReactNode } from 'react';
+import styled from 'styled-components';
+
+const StyledMetricCard = styled.div`
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  border-radius: 4px;
+  height: 100px;
+  margin: 10px;
+`;
+
+const StyledMetricNum = styled.div`
+  margin-top: 16px;
+  margin-left: 16px;
+  font-weight: 500;
+  font-size: 20px;
+  color: rgba(0, 0, 0, 0.87);
+`;
+
+const StyledMetricTitle = styled.div`
+  margin-top: 16px;
+  margin-left: 16px;
+  font-weight: 400;
+  font-size: 14px;
+  text-transform: uppercase;
+  color: rgba(0, 0, 0, 0.6);
+`;
+
+interface IMetricCardProps {
+  title: string | ReactNode;
+  metric: number;
+}
+
+export const MetricCard = ({ title, metric }: IMetricCardProps) => {
+  return (
+    <StyledMetricCard>
+      <StyledMetricNum>{metric}</StyledMetricNum>
+      <StyledMetricTitle>{title}</StyledMetricTitle>
+    </StyledMetricCard>
+  );
+};

--- a/app/cdap/components/NamespaceAdmin/Metrics/ProfileMetric.tsx
+++ b/app/cdap/components/NamespaceAdmin/Metrics/ProfileMetric.tsx
@@ -15,18 +15,18 @@
  */
 
 import React from 'react';
-import MetricColumn from 'components/NamespaceAdmin/Metrics/MetricColumn';
 import { connect, Provider } from 'react-redux';
 import ProfilesStore from 'components/Cloud/Profiles/Store';
+import { MetricCard } from './MetricCard';
 
-const mapStateToProps = (state) => {
+const mapStateToProps = (state, ownProps) => {
   return {
-    title: 'profiles',
+    title: ownProps.title,
     metric: state.profiles.length,
   };
 };
 
-const ConnectedProfileMetric = connect(mapStateToProps)(MetricColumn);
+const ConnectedProfileMetric = connect(mapStateToProps)(MetricCard);
 
 export default function ProfileMetrics(props) {
   return (

--- a/app/cdap/components/NamespaceAdmin/Metrics/index.tsx
+++ b/app/cdap/components/NamespaceAdmin/Metrics/index.tsx
@@ -16,9 +16,12 @@
 
 import React from 'react';
 import makeStyles from '@material-ui/core/styles/makeStyles';
-import MetricColumn from 'components/NamespaceAdmin/Metrics/MetricColumn';
 import { connect } from 'react-redux';
 import ProfileMetric from 'components/NamespaceAdmin/Metrics/ProfileMetric';
+import { MetricCard } from './MetricCard';
+import T from 'i18n-react';
+
+const PREFIX = 'features.NamespaceAdmin.metrics';
 
 const useStyle = makeStyles((theme) => {
   const border = `1px solid ${theme.palette.grey[100]}`;
@@ -32,7 +35,7 @@ const useStyle = makeStyles((theme) => {
     },
     content: {
       display: 'grid',
-      gridTemplateColumns: '3fr 2fr 2fr 2fr 2fr',
+      gridTemplateColumns: '2fr 2fr 2fr 2fr 2fr 2fr',
 
       '& > div:not(:last-child)': {
         borderRight: `1px solid ${theme.palette.grey[300]}`,
@@ -61,18 +64,15 @@ const MetricsView: React.FC<IMetricsProps> = ({
   connectionsCount,
 }) => {
   const classes = useStyle();
-
   return (
     <div className={classes.root}>
       <div className={classes.content}>
-        <div className={classes.entitySection}>
-          <MetricColumn title="pipelines" metric={pipelinesCount} />
-          <MetricColumn title="datasets" metric={datasetsCount} />
-        </div>
-        <ProfileMetric />
-        <MetricColumn title="preferences" metric={preferencesCount} />
-        <MetricColumn title="connections" metric={connectionsCount} />
-        <MetricColumn title="drivers" metric={driversCount} />
+        <MetricCard title={T.translate(`${PREFIX}.pipelines`)} metric={pipelinesCount} />
+        <MetricCard title={T.translate(`${PREFIX}.datasets`)} metric={datasetsCount} />
+        <ProfileMetric title={T.translate(`${PREFIX}.profiles`)} />
+        <MetricCard title={T.translate(`${PREFIX}.preferences`)} metric={preferencesCount} />
+        <MetricCard title={T.translate(`${PREFIX}.connections`)} metric={connectionsCount} />
+        <MetricCard title={T.translate(`${PREFIX}.drivers`)} metric={driversCount} />
       </div>
     </div>
   );

--- a/app/cdap/components/NamespaceAdmin/Toppanel.tsx
+++ b/app/cdap/components/NamespaceAdmin/Toppanel.tsx
@@ -20,20 +20,15 @@ import styled from 'styled-components';
 import CreateIcon from '@material-ui/icons/Create';
 import AbstractWizard from 'components/AbstractWizard';
 import T from 'i18n-react';
+import { FormControl, MenuItem, Select } from '@material-ui/core';
+import { useSelector } from 'react-redux';
 
 const PREFIX = 'features.NamespaceAdmin.toppanel';
 
 const StyledToppanel = styled.div`
   display: flex;
-  border-bottom: 1px solid #e4e4e4;
-  div {
-    margin-left: 16.19px;
-    margin-top: 12.5px;
-    margin-bottom: 11.5px;
-    width: 148px;
-    font-size: 18px;
-    border-right: 1px solid #e4e4e4;
-  }
+  height: 50px;
+  background: #eeeeee;
   span {
     padding-top: 2px;
     padding-left: 2px;
@@ -44,18 +39,58 @@ const StyledToppanel = styled.div`
   }
 `;
 
+const StyledTitle = styled.div`
+  margin-left: 16.19px;
+  padding-top: 12px;
+  width: 200px;
+  font-size: 18px;
+  border-right: 1px solid #e4e4e4;
+`;
+
+const StyledSelect = styled(Select)`
+  min-width: 150px;
+  font-size: 16px;
+`;
+
 export const NamespaceAdminToppanel = () => {
+  const namespace = useSelector((state) => state.namespace);
+  const namespaces = useSelector((state) => state.namespaces);
   const [isWizardOpen, setIsWizardOpen] = useState(false);
   const toggleWizard = () => {
     setIsWizardOpen(!isWizardOpen);
   };
 
+  const onNamespaceChange = (event) => {
+    window.location.href = `/cdap/ns/${event.target.value}/details`;
+  };
+
   return (
     <>
       <StyledToppanel>
-        <div>{T.translate(`${PREFIX}.datafusion`)}</div>
-        <div>{T.translate(`${PREFIX}.namespaces`)}</div>
-
+        <StyledTitle>{T.translate(`${PREFIX}.title`, { name: namespace })}</StyledTitle>
+        <StyledTitle>
+          <FormControl variant="standard">
+            <StyledSelect
+              value={namespace}
+              onChange={onNamespaceChange}
+              MenuProps={{
+                anchorOrigin: {
+                  vertical: 'bottom',
+                  horizontal: 'left',
+                },
+                transformOrigin: {
+                  vertical: 'top',
+                  horizontal: 'left',
+                },
+                getContentAnchorEl: null,
+              }}
+            >
+              {namespaces.map((ns) => (
+                <MenuItem value={ns}>{ns}</MenuItem>
+              ))}
+            </StyledSelect>
+          </FormControl>
+        </StyledTitle>
         <PrimaryTextButton
           children={
             <>

--- a/app/cdap/components/NamespaceAdmin/Toppanel.tsx
+++ b/app/cdap/components/NamespaceAdmin/Toppanel.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import PrimaryTextButton from 'components/shared/Buttons/PrimaryTextButton';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import CreateIcon from '@material-ui/icons/Create';
+import AbstractWizard from 'components/AbstractWizard';
+import T from 'i18n-react';
+
+const PREFIX = 'features.NamespaceAdmin.toppanel';
+
+const StyledToppanel = styled.div`
+  display: flex;
+  border-bottom: 1px solid #e4e4e4;
+  div {
+    margin-left: 16.19px;
+    margin-top: 12.5px;
+    margin-bottom: 11.5px;
+    width: 148px;
+    font-size: 18px;
+    border-right: 1px solid #e4e4e4;
+  }
+  span {
+    padding-top: 2px;
+    padding-left: 2px;
+    font-size: 14px;
+  }
+  button {
+    margin-left: 10px;
+  }
+`;
+
+export const NamespaceAdminToppanel = () => {
+  const [isWizardOpen, setIsWizardOpen] = useState(false);
+  const toggleWizard = () => {
+    setIsWizardOpen(!isWizardOpen);
+  };
+
+  return (
+    <>
+      <StyledToppanel>
+        <div>{T.translate(`${PREFIX}.datafusion`)}</div>
+        <div>{T.translate(`${PREFIX}.namespaces`)}</div>
+
+        <PrimaryTextButton
+          children={
+            <>
+              <CreateIcon />
+              <span>{T.translate(`${PREFIX}.addNamespaceButton`)}</span>
+            </>
+          }
+          onClick={toggleWizard}
+        />
+      </StyledToppanel>
+      <AbstractWizard isOpen={isWizardOpen} onClose={toggleWizard} wizardType="add_namespace" />
+    </>
+  );
+};

--- a/app/cdap/components/NamespaceAdmin/Toppanel.tsx
+++ b/app/cdap/components/NamespaceAdmin/Toppanel.tsx
@@ -53,8 +53,12 @@ const StyledSelect = styled(Select)`
 `;
 
 export const NamespaceAdminToppanel = () => {
-  const namespace = useSelector((state) => state.namespace);
-  const namespaces = useSelector((state) => state.namespaces);
+  const { namespace, namespaces } = useSelector((state) => {
+    return {
+      namespace: state.namespace,
+      namespaces: state.namespaces,
+    };
+  });
   const [isWizardOpen, setIsWizardOpen] = useState(false);
   const toggleWizard = () => {
     setIsWizardOpen(!isWizardOpen);

--- a/app/cdap/components/NamespaceAdmin/index.tsx
+++ b/app/cdap/components/NamespaceAdmin/index.tsx
@@ -24,6 +24,7 @@ import {
   getPreferences,
   getDrivers,
   getConnections,
+  getNamespacesList,
 } from 'components/NamespaceAdmin/store/ActionCreator';
 import { Provider } from 'react-redux';
 import Store from 'components/NamespaceAdmin/store';
@@ -33,6 +34,7 @@ import Tabs from 'components/NamespaceAdmin/Tabs';
 import ee from 'event-emitter';
 import globalEvents from 'services/global-events';
 import { getProfiles, resetProfiles } from 'components/Cloud/Profiles/Store/ActionCreator';
+import { NamespaceAdminToppanel } from './Toppanel';
 
 const eventEmitter = ee(ee);
 
@@ -54,6 +56,7 @@ const NamespaceAdmin: React.FC = () => {
     getDrivers(namespace);
     getConnections(namespace);
     getProfiles(namespace);
+    getNamespacesList();
 
     eventEmitter.on(globalEvents.NSPREFERENCESSAVED, getPreferences);
     eventEmitter.on(globalEvents.ARTIFACTUPLOAD, getDrivers);
@@ -69,7 +72,7 @@ const NamespaceAdmin: React.FC = () => {
   return (
     <Provider store={Store}>
       <div>
-        <EntityTopPanel title={`Namespace '${namespace}'`} />
+        <NamespaceAdminToppanel />
         <div className={classes.content}>
           <Description />
           <Metrics />

--- a/app/cdap/components/NamespaceAdmin/store/ActionCreator.ts
+++ b/app/cdap/components/NamespaceAdmin/store/ActionCreator.ts
@@ -192,3 +192,18 @@ export function reset() {
     type: NamespaceAdminActions.reset,
   });
 }
+
+// I tried not to add this function
+// and use namespaces from NamespaceStore.getState()
+// but async will cause reload sometimes not getting the data before rendering
+export const getNamespacesList = () => {
+  MyNamespaceApi.list().subscribe((res: any[]) => {
+    const namespaces = res.map((namespace) => namespace.name);
+    Store.dispatch({
+      type: NamespaceAdminActions.setNamespaceList,
+      payload: {
+        namespaces,
+      },
+    });
+  });
+};

--- a/app/cdap/components/NamespaceAdmin/store/index.ts
+++ b/app/cdap/components/NamespaceAdmin/store/index.ts
@@ -25,6 +25,7 @@ export const NamespaceAdminActions = {
   setPreferences: 'SET_PREFERENCES',
   setDrivers: 'SET_DRIVERS',
   setConnections: 'SET_CONNECTIONS',
+  setNamespaceList: 'SET_NAMESPACE_LIST',
   reset: 'NAMESPACE_ADMIN_RESET',
 };
 
@@ -71,8 +72,9 @@ export interface IConnection {
   plugin: IPlugin;
 }
 
-interface INamespaceAdmin {
+export interface INamespaceAdmin {
   namespace: string;
+  namespaces: string[];
   generation: number;
   description: string;
   exploreAsPrincipal: string;
@@ -89,6 +91,7 @@ type INamespaceAdminState = Partial<INamespaceAdmin>;
 
 const defaultInitialState: Partial<INamespaceAdminState> = {
   namespace: null,
+  namespaces: [],
   generation: null,
   description: null,
   exploreAsPrincipal: null,
@@ -137,6 +140,11 @@ const namespaceAdmin: Reducer<INamespaceAdminState> = (state = defaultInitialSta
       return {
         ...state,
         connections: action.payload.connections,
+      };
+    case NamespaceAdminActions.setNamespaceList:
+      return {
+        ...state,
+        namespaces: action.payload.namespaces,
       };
     case NamespaceAdminActions.reset:
       return {

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -2027,8 +2027,6 @@ features:
   MarketEntityModal:
     version: "Version :"
   NamespaceAdmin:
-    description:
-      title: Namespace '{name}'
     metrics:
       connections: connections
       datasets: datasets
@@ -2037,8 +2035,7 @@ features:
       preferences: preferences
       profiles: profiles
     toppanel:
-      datafusion: Data Fusion
-      namespaces: Namespaces
+      title: Namespace '{name}'
       addNamespaceButton: Add new namespace
   NamespaceDetails:
     computeProfiles:

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -2026,6 +2026,20 @@ features:
         moreInfo: More Info.
   MarketEntityModal:
     version: "Version :"
+  NamespaceAdmin:
+    description:
+      title: Namespace '{name}'
+    metrics:
+      connections: connections
+      datasets: datasets
+      drivers: drivers
+      pipelines: pipelines
+      preferences: preferences
+      profiles: profiles
+    toppanel:
+      datafusion: Data Fusion
+      namespaces: Namespaces
+      addNamespaceButton: Add new namespace
   NamespaceDetails:
     computeProfiles:
       create: Create New


### PR DESCRIPTION
# [CDAP-20279] change namespace admin looks

## Description
* styles change
* can add new namespace in namespace admin
* can switch namespace in namespace admin

figma: https://www.figma.com/file/zHJixa1FDNux4upVFJdnFh/Lifecycle-Management-CDF-Pipelines?node-id=942%3A3672&t=vRG1tKhIaI6P1JeJ-0

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20279](https://cdap.atlassian.net/browse/CDAP-20279)

## Screenshots
![image](https://user-images.githubusercontent.com/98125204/213292599-3e42d565-cdf3-44ba-af39-fa59d933479f.png)




[CDAP-20279]: https://cdap.atlassian.net/browse/CDAP-20279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20279]: https://cdap.atlassian.net/browse/CDAP-20279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ