### PR TITLE
Fix sandbox reference for 6.8.1-SNAPSHOT so Cypress tests can pass

### DIFF
--- a/sandboxjs/sandbox_version.json
+++ b/sandboxjs/sandbox_version.json
@@ -1,4 +1,4 @@
 {
-  "release": "v6.8.0-SNAPSHOT",
-  "version": "6.8.0-SNAPSHOT"
+  "release": "v6.8.1-SNAPSHOT",
+  "version": "6.8.1-SNAPSHOT"
 }


### PR DESCRIPTION
# Fix sandbox reference for 6.8.1-SNAPSHOT so Cypress tests can pass

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [X] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: N/A

## Test Plan
Cypress tests

## Screenshots
N/A


