### PR TITLE
CDAP-20331 Ensure Hub icons can be loaded without CORS errors

### DIFF
--- a/server/express.js
+++ b/server/express.js
@@ -173,7 +173,10 @@ function makeApp(authAddress, cdapConfig, uiSettings) {
         hsts: {
           includeSubDomains: true,
           preload: true,
-        }
+        },
+        // Hub icons are cross-origin but don't supply CORS headers
+        // TODO credentialless will also work but isn't supported by FF and Safari
+        crossOriginEmbedderPolicy: false
       })
     );
   }


### PR DESCRIPTION
# CDAP-20331 Ensure Hub icons can be loaded without CORS errors

## Description
Unsets the Cross Origin Embedder Property so icons from the Hub can be shown

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20331](https://cdap.atlassian.net/browse/CDAP-20331)

## Test Plan
Manually verify

## Screenshots
N/A




[CDAP-20331]: https://cdap.atlassian.net/browse/CDAP-20331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ