### PR TITLE
[CDAP-20287] disable edit for stream pipeline

### DIFF
--- a/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/PipelineDetailsActionsButton/index.js
+++ b/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/PipelineDetailsActionsButton/index.js
@@ -37,12 +37,14 @@ require('./PipelineDetailsActionsButton.scss');
 const PREFIX = 'features.PipelineDetails.TopPanel';
 
 const StyledLi = styled.li`
-  ${({ isLatestVersion }) =>
-    !isLatestVersion &&
-    `opacity: 0.5;
-    &:hover {
+  ${({ isLatestVersion, isBatchPipeline }) =>
+    (!isLatestVersion || !isBatchPipeline) &&
+    `&:hover {
       background: white !important;
       cursor: not-allowed !important;
+    }
+    span {
+        opacity: 0.5;
     }`}
 `;
 
@@ -126,7 +128,7 @@ export default class PipelineDetailsActionsButton extends Component {
   };
 
   handlePipelineEdit = () => {
-    if (!this.props.isLatestVersion) {
+    if (!this.props.isLatestVersion || this.props.artifact.name !== 'cdap-data-pipeline') {
       return;
     }
     if (!this.props.editDraftId) {
@@ -293,6 +295,9 @@ export default class PipelineDetailsActionsButton extends Component {
       );
     };
 
+    const editEnabled =
+      this.props.isLatestVersion && this.props.artifact.name === 'cdap-data-pipeline';
+
     return (
       <div
         className={classnames('pipeline-action-container pipeline-actions-container', {
@@ -313,10 +318,29 @@ export default class PipelineDetailsActionsButton extends Component {
             {this.props.lifecycleManagementEditEnabled && (
               <StyledLi
                 isLatestVersion={this.props.isLatestVersion}
+                isBatchPipeline={this.props.artifact.name === 'cdap-data-pipeline'}
                 onClick={this.handlePipelineEdit}
                 data-testid="pipeline-edit-btn"
               >
-                {T.translate(`${PREFIX}.edit`)}
+                {!this.props.isLatestVersion && (
+                  <Popover
+                    target={() => <span>{T.translate(`${PREFIX}.edit`)}</span>}
+                    showOn="Hover"
+                    placement="left"
+                  >
+                    {T.translate('commons.editTooltip.notLatest')}
+                  </Popover>
+                )}
+                {this.props.artifact.name !== 'cdap-data-pipeline' && (
+                  <Popover
+                    target={() => <span>{T.translate(`${PREFIX}.edit`)}</span>}
+                    showOn="Hover"
+                    placement="left"
+                  >
+                    {T.translate('commons.editTooltip.notBatch')}
+                  </Popover>
+                )}
+                {editEnabled && <span>{T.translate(`${PREFIX}.edit`)}</span>}
               </StyledLi>
             )}
             <li onClick={this.duplicateConfigAndNavigate}>{T.translate(`${PREFIX}.duplicate`)}</li>

--- a/app/cdap/components/PipelineList/DeployedPipelineView/DeployedActions/index.tsx
+++ b/app/cdap/components/PipelineList/DeployedPipelineView/DeployedActions/index.tsx
@@ -246,47 +246,37 @@ class DeployedActionsView extends React.PureComponent<IProps, IState> {
     window.location.href = link;
   };
 
-  private actions: IAction[] = this.props.lifecycleManagementEditEnabled
-    ? [
-        {
-          label: T.translate('commons.edit'),
-          actionFn: this.handlePipelineEdit,
-        },
-        {
-          label: T.translate('commons.duplicate'),
-          actionFn: duplicatePipeline.bind(null, this.props.pipeline.name),
-        },
-        {
-          label: T.translate('commons.export'),
-          actionFn: this.handlePipelineExport,
-        },
-        {
-          label: 'separator',
-        },
-        {
-          label: T.translate('commons.delete'),
-          actionFn: this.showDeleteConfirmation,
-          className: 'delete',
-        },
-      ]
-    : [
-        {
-          label: T.translate('commons.duplicate'),
-          actionFn: duplicatePipeline.bind(null, this.props.pipeline.name),
-        },
-        {
-          label: T.translate('commons.export'),
-          actionFn: this.handlePipelineExport,
-        },
-        {
-          label: 'separator',
-        },
-        {
-          label: T.translate('commons.delete'),
-          actionFn: this.showDeleteConfirmation,
-          className: 'delete',
-        },
-      ];
+  private getActionsList = () => {
+    const actions: IAction[] = [
+      {
+        label: T.translate('commons.duplicate'),
+        actionFn: duplicatePipeline.bind(null, this.props.pipeline.name),
+      },
+      {
+        label: T.translate('commons.export'),
+        actionFn: this.handlePipelineExport,
+      },
+      {
+        label: 'separator',
+      },
+      {
+        label: T.translate('commons.delete'),
+        actionFn: this.showDeleteConfirmation,
+        className: 'delete',
+      },
+    ];
+    if (this.props.lifecycleManagementEditEnabled) {
+      actions.splice(0, 0, {
+        label: T.translate('commons.edit'),
+        actionFn: this.handlePipelineEdit,
+        disabled: this.props.pipeline.artifact.name !== 'cdap-data-pipeline',
+        disabledTooltip: T.translate('commons.editTooltip.notBatch').toString(),
+      });
+    }
+    return actions;
+  };
+
+  private actions: IAction[] = this.getActionsList();
 
   public render() {
     return (

--- a/app/cdap/components/shared/ActionsPopover/index.tsx
+++ b/app/cdap/components/shared/ActionsPopover/index.tsx
@@ -27,6 +27,7 @@ export interface IAction {
   disabled?: boolean;
   className?: string;
   title?: string;
+  disabledTooltip?: string;
 }
 
 interface IActionsPopoverProps {
@@ -101,7 +102,13 @@ const ActionsPopover: React.SFC<IActionsPopoverProps> = ({
               title={action.title}
               data-testid={action.label + '-on-popover'}
             >
-              {action.label}
+              {action.disabled && action.disabledTooltip ? (
+                <Popover target={() => <>{action.label}</>} showOn="Hover" placement="right">
+                  {action.disabledTooltip}
+                </Popover>
+              ) : (
+                <>{action.label}</>
+              )}
             </li>
           );
         })}

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -18,6 +18,9 @@ commons:
     placeholder: value
   dataset: Dataset
   edit: Edit
+  editTooltip:
+    notLatest: Edit is not allowed for past versions
+    notBatch: Edit is currently not supported for non batch pipelines
   entity:
     application:
       plural: Applications


### PR DESCRIPTION
# [CDAP-20287] disable edit for stream pipeline with tooltip

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [x] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20287](https://cdap.atlassian.net/browse/CDAP-20287)

## Screenshots
<img width="2459" alt="image" src="https://user-images.githubusercontent.com/98125204/216725938-92d3986a-cac5-4549-b715-42311d68cf5d.png">
<img width="2538" alt="image" src="https://user-images.githubusercontent.com/98125204/216726067-c6298512-ca9c-412a-b316-cce19a5e667f.png">




[CDAP-20287]: https://cdap.atlassian.net/browse/CDAP-20287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20287]: https://cdap.atlassian.net/browse/CDAP-20287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ