### PR TITLE
cdap-20173 fix replication UI loading state on assessment error

### DIFF
--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/index.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/index.tsx
@@ -32,6 +32,7 @@ import {
   IColumnTransformation,
   IDeltaConfig,
 } from 'components/Replicator/types';
+import { ErrorType } from 'components/Replicator/constants';
 import { useDebounce } from 'services/react/customHooks/useDebounce';
 
 import { ISelectColumnsProps, ReplicateSelect } from './types';
@@ -164,7 +165,10 @@ const SelectColumnsView = (props: ISelectColumnsProps) => {
         });
       },
       error: (err) => {
+        dispatch({ type: 'setLoading', payload: false });
         dispatch({ type: 'setError', payload: err });
+        props.toggle();
+        props.setErrorToast(ErrorType.tableAssessmentError);
       },
       complete: () => {
         dispatch({ type: 'setLoading', payload: false });

--- a/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/types.ts
+++ b/app/cdap/components/Replicator/Create/Content/SelectColumnsWithTransforms/types.ts
@@ -24,12 +24,14 @@ import {
   ITableAssessmentColumn,
 } from 'components/Replicator/types';
 import { Observable } from 'rxjs/Observable';
+import { ErrorType } from 'components/Replicator/constants';
 
 export interface ISelectColumnsProps {
   tableInfo?: ITableInfo;
   onSave: (tableInfo: ITableInfo, columns: ISelectedList) => void;
   initialSelected: IColumnsList;
   toggle: () => void;
+  setErrorToast: (error: ErrorType | string) => void;
   saveDraft: () => Observable<any>;
   draftId: string;
   transformations: { [tableName: string]: ITransformation };

--- a/app/cdap/components/Replicator/Create/Content/SelectTables/index.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectTables/index.tsx
@@ -462,7 +462,7 @@ class SelectTablesView extends React.PureComponent<ISelectTablesProps, ISelectTa
       return (
         <Alert
           showAlert={!!this.state.error}
-          message={T.translate(`${PREFIX}.genericErrorMessage`)}
+          message={T.translate(`${PREFIX}.genericErrorMessage`).toString()}
           onClose={this.onErrorSnackbarClose}
           type={ALERT_STATUS.Error}
           autoCloseTimeout={5000}
@@ -478,10 +478,7 @@ class SelectTablesView extends React.PureComponent<ISelectTablesProps, ISelectTa
           <span>{this.state.error}</span>
           {isUnknownDatabaseError(this.state.error) && (
             <div>
-              <span>
-                Please manually put in the correct database name and table name below, or go back to
-                "Configure source" tab and put in the correct "Database Name".
-              </span>
+              <span>{T.translate(`${PREFIX}.unknownDatabaseErrorMessage`)}</span>
             </div>
           )}
         </div>
@@ -558,7 +555,9 @@ class SelectTablesView extends React.PureComponent<ISelectTablesProps, ISelectTa
               <div className="grid-row grouping-row">
                 <div className={`${classes.tableHeaderEvents} ${classes.groupHeader}`}>
                   <hr className={classes.groupLine} />
-                  <div className={classes.groupText}>Events to replicate</div>
+                  <div className={classes.groupText}>
+                    {T.translate(`${PREFIX}.eventsToReplicate`)}
+                  </div>
                 </div>
               </div>
               <div className="grid-row">
@@ -575,7 +574,7 @@ class SelectTablesView extends React.PureComponent<ISelectTablesProps, ISelectTa
                   />
                 </div>
                 <div>Table name</div>
-                <div className={classes.count}>Columns to replicate</div>
+                <div className={classes.count}>{T.translate(`${PREFIX}.columnsToReplicate`)}</div>
                 <div />
                 <div>
                   <Checkbox
@@ -615,7 +614,9 @@ class SelectTablesView extends React.PureComponent<ISelectTablesProps, ISelectTa
                 const tableDML = this.state.dmlBlacklist.get(key) || Set<DML>();
 
                 const isTableInvalid = checked && this.isTableSelectionInvalid(row);
-                const errorDescription = !isTableInvalid ? null : 'Select events to replicate';
+                const errorDescription = !isTableInvalid
+                  ? null
+                  : T.translate(`${PREFIX}.selectEventsToReplicate`).toString();
 
                 return (
                   <div
@@ -646,7 +647,9 @@ class SelectTablesView extends React.PureComponent<ISelectTablesProps, ISelectTa
                       onClick={this.openTable.bind(this, row)}
                     >
                       <span className={classes.openOverviewLink}>
-                        {columns && columns.size > 0 ? columns.size : 'All'}
+                        {columns && columns.size > 0
+                          ? columns.size
+                          : T.translate(`${PREFIX}.all`).toString()}
                       </span>
                     </div>
                     <div />
@@ -663,7 +666,7 @@ class SelectTablesView extends React.PureComponent<ISelectTablesProps, ISelectTa
                             })}
                           />
                         }
-                        label="Inserts"
+                        label={T.translate(`${PREFIX}.inserts`).toString()}
                       />
                     </div>
                     <div>
@@ -679,7 +682,7 @@ class SelectTablesView extends React.PureComponent<ISelectTablesProps, ISelectTa
                             })}
                           />
                         }
-                        label="Updates"
+                        label={T.translate(`${PREFIX}.updates`).toString()}
                       />
                     </div>
                     <div>
@@ -695,7 +698,7 @@ class SelectTablesView extends React.PureComponent<ISelectTablesProps, ISelectTa
                             })}
                           />
                         }
-                        label="Deletes"
+                        label={T.translate(`${PREFIX}.deletes`).toString()}
                       />
                     </div>
                   </div>
@@ -719,21 +722,25 @@ class SelectTablesView extends React.PureComponent<ISelectTablesProps, ISelectTa
     }
 
     const { classes } = this.props;
+    const { selectedTables, tables } = this.state;
 
     return (
       <>
         <div className={classes.root}>
-          <Heading type={HeadingTypes.h3} label="Select tables, columns, and events to replicate" />
+          <Heading type={HeadingTypes.h3} label={T.translate(`${PREFIX}.heading`).toString()} />
           <div className={classes.subHeadingContainer}>
             <div className={classes.subHeadingText}>
-              {this.state.selectedTables.size} of {this.state.tables.length} tables selected
+              {T.translate(`${PREFIX}.numberOfTablesSelected`, {
+                selectedTablesSize: selectedTables.size,
+                totalTablesSize: tables.length,
+              })}
             </div>
 
             <div>
               <SearchBox
                 value={this.state.search}
                 onChange={this.handleSearchChange}
-                placeholder="Search tables by name"
+                placeholder={T.translate(`${PREFIX}.searchboxPlaceholder`).toString()}
               />
             </div>
           </div>

--- a/app/cdap/components/Replicator/Create/Content/SelectTables/index.tsx
+++ b/app/cdap/components/Replicator/Create/Content/SelectTables/index.tsx
@@ -15,7 +15,10 @@
  */
 
 import * as React from 'react';
+import T from 'i18n-react';
 import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
+import Alert from 'components/shared/Alert';
+import { ALERT_STATUS } from 'services/AlertStatus';
 import { createContextConnect, ICreateContext } from 'components/Replicator/Create';
 import { MyReplicatorApi } from 'api/replicator';
 import { getCurrentNamespace } from 'services/NamespaceStore';
@@ -26,6 +29,7 @@ import orderBy from 'lodash/orderBy';
 import LoadingSVGCentered from 'components/shared/LoadingSVGCentered';
 import SelectColumns from 'components/Replicator/Create/Content/SelectColumns';
 import SelectColumnsWithTransforms from 'components/Replicator/Create/Content/SelectColumnsWithTransforms';
+import { ErrorType } from 'components/Replicator/constants';
 import { extractErrorMessage, isUnknownDatabaseError } from 'services/helpers';
 import { generateTableKey, getTableDisplayName } from 'components/Replicator/utilities';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
@@ -44,6 +48,8 @@ import {
   IDMLStore,
   ITableInfo,
 } from 'components/Replicator/types';
+
+const PREFIX = `features.Replication.Create.Content.SelectTables`;
 
 const styles = (theme): StyleRules => {
   return {
@@ -439,9 +445,29 @@ class SelectTablesView extends React.PureComponent<ISelectTablesProps, ISelectTa
     });
   };
 
+  private onErrorSnackbarClose = (): void => {
+    this.setState({ error: null });
+  };
+
+  public setErrorToast = (error: ErrorType | string): void => {
+    this.setState({ error });
+  };
+
   private renderError = () => {
     if (!this.state.error) {
       return null;
+    }
+
+    if (this.state.error === ErrorType.tableAssessmentError) {
+      return (
+        <Alert
+          showAlert={!!this.state.error}
+          message={T.translate(`${PREFIX}.genericErrorMessage`)}
+          onClose={this.onErrorSnackbarClose}
+          type={ALERT_STATUS.Error}
+          autoCloseTimeout={5000}
+        />
+      );
     }
 
     return (
@@ -506,6 +532,7 @@ class SelectTablesView extends React.PureComponent<ISelectTablesProps, ISelectTa
         tableAssessments={this.props.tableAssessments[this.state.openTable.table]}
         initialSelected={this.getInitialSelected()}
         toggle={this.openTable.bind(this, null)}
+        setErrorToast={this.setErrorToast}
         onSave={this.onColumnsSelection}
         assessmentLoading={this.props.assessmentLoading}
         transformations={this.props.transformations}
@@ -517,7 +544,7 @@ class SelectTablesView extends React.PureComponent<ISelectTablesProps, ISelectTa
   };
 
   private renderContent = () => {
-    if (this.state.error) {
+    if (this.state.error && this.state.error !== ErrorType.tableAssessmentError) {
       return null;
     }
 

--- a/app/cdap/components/Replicator/constants.tsx
+++ b/app/cdap/components/Replicator/constants.tsx
@@ -23,3 +23,8 @@ export const PROGRAM_INFO = {
   programType: 'workers',
   programId: 'DeltaWorker',
 };
+
+export enum ErrorType {
+  generic = 'generic',
+  tableAssessmentError = 'tableAssessmentError',
+}

--- a/app/cdap/components/Replicator/constants.tsx
+++ b/app/cdap/components/Replicator/constants.tsx
@@ -25,6 +25,5 @@ export const PROGRAM_INFO = {
 };
 
 export enum ErrorType {
-  generic = 'generic',
   tableAssessmentError = 'tableAssessmentError',
 }

--- a/app/cdap/components/shared/Alert/index.js
+++ b/app/cdap/components/shared/Alert/index.js
@@ -40,6 +40,7 @@ export default class Alert extends Component {
     type: PropTypes.oneOf(['success', 'error', 'info']),
     canEditPageWhileOpen: PropTypes.bool,
     actionElements: PropTypes.element,
+    autoCloseTimeout: PropTypes.number,
   };
 
   alertTimeout = null;
@@ -70,6 +71,13 @@ export default class Alert extends Component {
   }
 
   resetTimeout = () => {
+    // if a custom autoCloseTimeout value is provided, then use that irrespective of the status
+    if (this.props.autoCloseTimeout && this.props.autoCloseTimeout > 0) {
+      clearTimeout(this.alertTimeout);
+      this.alertTimeout = setTimeout(this.onClose, this.props.autoCloseTimeout);
+      return;
+    }
+
     if (this.state.type === ALERT_STATUS.Success || this.state.type === ALERT_STATUS.Info) {
       clearTimeout(this.alertTimeout);
       this.alertTimeout = setTimeout(this.onClose, CLOSE_TIMEOUT);

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -2877,7 +2877,7 @@ features:
         SelectColumns:
           primaryKeyDescription: Must include primary key
         SelectTables:
-          genericErrorMessage: "Something went wrong!"
+          genericErrorMessage: "Something went wrong"
   Reports:
     Customizer:
       clear: Clear Selection

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -2876,6 +2876,8 @@ features:
       Content:
         SelectColumns:
           primaryKeyDescription: Must include primary key
+        SelectTables:
+          genericErrorMessage: "Something went wrong!"
   Reports:
     Customizer:
       clear: Clear Selection

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -2877,7 +2877,19 @@ features:
         SelectColumns:
           primaryKeyDescription: Must include primary key
         SelectTables:
-          genericErrorMessage: "Something went wrong"
+          heading: "Select tables, columns, and events to replicate"
+          genericErrorMessage: Something went wrong
+          unknownDatabaseErrorMessage: "Please manually put in the correct database name and table name below, or go back to \"Configure source\" tab and put in the correct \"Database Name\"."
+          eventsToReplicate: Events to replicate
+          columnsToReplicate: Columns to replicate
+          selectEventsToReplicate: Select events to replicate
+          all: All
+          inserts: Inserts
+          updates: Updates
+          deletes: Deletes
+          numberOfTablesSelected: "{selectedTablesSize} of {totalTablesSize} tables selected"
+          searchboxPlaceholder: Search tables by name
+
   Reports:
     Customizer:
       clear: Clear Selection


### PR DESCRIPTION
# [cdap-20173](https://cdap.atlassian.net/browse/CDAP-20173) fix replication UI loading state on assessment error

[fix] replication UI gets blocked in case of backend error on table assessment

## Description
Fixes the following:

```
Steps to reproduce:-
1. Start creating a SQL server replication pipeline
2. Reach Select table and transformations
3. Click on a table which has column of type datetimeoffset
4. Observe that server returns an error response, but UI continues to show in progress screen indefinitely.
```

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [20173](https://cdap.atlassian.net/browse/CDAP-20173)

## Test Plan
Manual

## Screenshots
![Screenshot 2023-02-08 at 12 12 18 PM](https://user-images.githubusercontent.com/4161531/217454247-94a1f779-0520-4f7e-81e4-24c4cb4d42ae.png)


