### PR TITLE
[CDAP-20338] fix overwriteConfig is not set

### DIFF
--- a/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ConfigModelessActionButtons/index.tsx
+++ b/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ConfigModelessActionButtons/index.tsx
@@ -89,7 +89,7 @@ export const ConfigModelessActionButtons = ({ ...props }: IConfigModelessActionB
     setSaveLoading(true);
     let observable;
     if (lifecycleManagementEditEnabled) {
-      observable = updatePreferences();
+      observable = updatePreferences(lifecycleManagementEditEnabled);
     } else {
       observable = Observable.forkJoin(updatePipeline(), updatePreferences());
     }

--- a/app/cdap/components/PipelineConfigurations/Store/ActionCreator.js
+++ b/app/cdap/components/PipelineConfigurations/Store/ActionCreator.js
@@ -132,7 +132,7 @@ const getMacrosResolvedByPrefs = (resolvedPrefs = {}, macrosMap = {}) => {
   return resolvedMacros;
 };
 
-const updatePreferences = () => {
+const updatePreferences = (lifecycleManagementEditEnabled = false) => {
   const { runtimeArgs } = PipelineConfigurationsStore.getState();
   let filteredRuntimeArgs = cloneDeep(runtimeArgs);
   filteredRuntimeArgs.pairs = filteredRuntimeArgs.pairs.filter(
@@ -140,6 +140,9 @@ const updatePreferences = () => {
   );
   let appId = PipelineDetailStore.getState().name;
   let prefObj = convertKeyValuePairsObjToMap(runtimeArgs);
+  if (lifecycleManagementEditEnabled) {
+    prefObj = { ...prefObj, 'app.pipeline.overwriteConfig': 'true' };
+  }
 
   return MyPreferenceApi.setAppPreferences(
     {

--- a/src/e2e-test/features/pipeline.edit.feature
+++ b/src/e2e-test/features/pipeline.edit.feature
@@ -35,6 +35,20 @@ Feature: Pipeline Edit
 
   @PIPELINE_EDIT_TEST
   @ignore
+  Scenario: Pipeline configuration should save to runtime arguments
+    When Open pipeline list page
+    Then Go to pipeline "pipeline_edit_test" details
+    When Run down arrow is clicked
+    Then Generated runtime arguments should be empty
+    Then Open pipeline configure
+    Then Click on "Pipeline config" tab in pipeline configure
+    Then Toggle instrumentation settings in pipeline config
+    Then Save pipeline configure
+    When Run down arrow is clicked
+    Then Generated runtime arguments should not be empty
+
+  @PIPELINE_EDIT_TEST
+  @ignore
   Scenario: Discarding a draft should delete it from draft list
     When Open pipeline list page
     Then Go to pipeline "pipeline_edit_test" details
@@ -68,18 +82,5 @@ Feature: Pipeline Edit
     Then Click Continue draft
     Then Verify changes were saved
 
-  @PIPELINE_EDIT_TEST
-  @ignore
-  Scenario: Pipeline configuration should save to runtime arguments
-    When Open pipeline list page
-    Then Go to pipeline "pipeline_edit_test" details
-    When Run down arrow is clicked
-    Then Generated runtime arguments should be empty
-    Then Open pipeline configure
-    Then Click on "Pipeline config" tab in pipeline configure
-    Then Toggle instrumentation settings in pipeline config
-    Then Save pipeline configure
-    When Run down arrow is clicked
-    Then Generated runtime arguments should not be empty
     
 


### PR DESCRIPTION
# [CDAP-20338] fix overwriteConfig is not set

## Description
fixed a regression that overwriteConfig args is not set for LCM. It is required for the workflow to use key value pairs as pipeline configs during runtime. 

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20338](https://cdap.atlassian.net/browse/CDAP-20338)

## Test Plan
pipeline.edit.feature test passed

## Screenshots
<img width="1189" alt="image" src="https://user-images.githubusercontent.com/98125204/217089476-3992f97d-d0ab-4fb3-979a-b39755205cdb.png">




[CDAP-20338]: https://cdap.atlassian.net/browse/CDAP-20338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20338]: https://cdap.atlassian.net/browse/CDAP-20338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ