### PR TITLE
CDAP-19245 Convert pipeline triggers tests to Cucumber

### DIFF
--- a/app/cdap/components/PipelineTriggers/EnabledTriggersTab/EnabledCompositeTriggerRow.tsx
+++ b/app/cdap/components/PipelineTriggers/EnabledTriggersTab/EnabledCompositeTriggerRow.tsx
@@ -115,8 +115,8 @@ const EnabledCompositeTriggerRowView = ({
         <PipelineName>{compositeTrigger.trigger.type}</PipelineName>
         <DisableCompositeTriggerBtn
           onClick={handleConfirmModalOpen}
-          data-cy="disable-group-trigger-btn"
-          data-testid="disable-group-trigger-btn"
+          data-cy={`${compositeTrigger.name}-disable-trigger-btn`}
+          data-testid={`${compositeTrigger.name}-disable-trigger-btn`}
         >
           <DeleteOutlineIcon />
         </DisableCompositeTriggerBtn>

--- a/app/cdap/components/PipelineTriggers/PayloadConfigModal/index.js
+++ b/app/cdap/components/PipelineTriggers/PayloadConfigModal/index.js
@@ -58,7 +58,11 @@ export default class PayloadConfigModal extends Component {
         <ModalHeader className="clearfix">
           <span className="pull-left">{T.translate(`${PREFIX}.title`)}</span>
           <div className="btn-group pull-right">
-            <a className="btn" onClick={this.props.onToggle}>
+            <a
+              className="btn"
+              onClick={this.props.onToggle}
+              data-testid="close-payload-config-modal"
+            >
               <IconSVG name="icon-close" className="fa" />
             </a>
           </div>

--- a/app/cdap/components/PipelineTriggers/PipelineListCompositeTab/index.tsx
+++ b/app/cdap/components/PipelineTriggers/PipelineListCompositeTab/index.tsx
@@ -288,6 +288,7 @@ const PipelineListCompositeTabView = ({
             placeholder="Enter the Trigger Name..."
             error={state.isNameInvalid}
             helperText={state.triggerNameError}
+            data-testid="trigger-name-text-field"
           />
         </div>
 

--- a/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/Tabs/RuntimeArgsTab/RuntimeArgRow.js
+++ b/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/Tabs/RuntimeArgsTab/RuntimeArgRow.js
@@ -87,7 +87,11 @@ export default class RuntimeArgRow extends Component {
     return (
       <Row>
         <Col xs={6}>
-          <div className="select-dropdown" data-cy="runtime-arg-of-trigger">
+          <div
+            className="select-dropdown"
+            data-cy="runtime-arg-of-trigger"
+            data-testid="runtime-arg-of-trigger"
+          >
             <select value={this.state.key} onChange={this.onKeyChange}>
               {this.getDisplayValueForTriggeringPipelineMacro(triggeringPipelineInfo)
                 .concat(triggeringPipelineInfo.macros)
@@ -105,7 +109,11 @@ export default class RuntimeArgRow extends Component {
           <span>{T.translate('commons.as')}</span>
         </Col>
         <Col xs={5}>
-          <div className="select-dropdown" data-cy="runtime-arg-of-triggered">
+          <div
+            className="select-dropdown"
+            data-cy="runtime-arg-of-triggered"
+            data-testid="runtime-arg-of-triggered"
+          >
             <select value={this.state.value} onChange={this.onValueChange}>
               {this.getDisplayValueForTriggeredPipelineMacro(
                 triggeredPipelineInfo,

--- a/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/Tabs/RuntimeArgsTab/index.js
+++ b/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/Tabs/RuntimeArgsTab/index.js
@@ -83,7 +83,7 @@ class RuntimArgsTab extends Component {
       }
 
       return (
-        <div data-cy={`row-${i}`}>
+        <div data-cy={`row-${i}`} data-testid={`row-${i}`}>
           <RuntimeArgRow mkey={key} mvalue={value} />
         </div>
       );
@@ -93,7 +93,7 @@ class RuntimArgsTab extends Component {
   renderDisabledRows(list) {
     return list.map((arg, i) => {
       return (
-        <div data-cy={`row-${i}`}>
+        <div data-cy={`row-${i}`} data-testid={`row-${i}`}>
           <RuntimeArgRow mkey={arg.key} mvalue={arg.value} />
         </div>
       );

--- a/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/index.js
+++ b/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/index.js
@@ -180,6 +180,7 @@ export default class ScheduleRuntimeArgs extends Component {
           onClick={this.configureAndEnableTrigger}
           disabled={this.isEnableTriggerDisabled()}
           data-cy="configure-and-enable-trigger-btn"
+          data-testid="configure-and-enable-trigger-btn"
         >
           {this.props.pipelineCompositeTriggersEnabled
             ? T.translate(`${PREFIX}.configure_select_btn`)

--- a/app/cdap/components/TriggeredPipelines/TriggeredPipelineRow.tsx
+++ b/app/cdap/components/TriggeredPipelines/TriggeredPipelineRow.tsx
@@ -93,6 +93,11 @@ export const TriggeredPipelineRow = ({
           ? `${schedule.application}-triggered-expanded`
           : `${schedule.application}-triggered-collapsed`
       }
+      data-testid={
+        isExpanded
+          ? `${schedule.application}-triggered-expanded`
+          : `${schedule.application}-triggered-collapsed`
+      }
     >
       <StyledAccordionSummary>
         <StyledPipelineName>{schedule.application}</StyledPipelineName>

--- a/app/cdap/components/TriggeredPipelines/index.tsx
+++ b/app/cdap/components/TriggeredPipelines/index.tsx
@@ -79,6 +79,7 @@ const TriggeredPipelinesView = ({
   return (
     <CollapsibleSidebar
       data-cy="outbound-triggers-toggle"
+      data-testid="outbound-triggers-toggle"
       position="right"
       toggleTabLabel={T.translate(`${tabText}`, { count })}
       backdrop={false}

--- a/cypress/integration/pipeline.triggers.spec.ts
+++ b/cypress/integration/pipeline.triggers.spec.ts
@@ -22,7 +22,7 @@ import {
 let headers = {};
 const TRIGGER_PIPELINE_1 = `trigger_test_pipeline_${Date.now()}`;
 const TRIGGER_PIPELINE_2 = `trigger_test_pipeline_2_${Date.now()}`;
-describe('Pipeline Studio', () => {
+describe.skip('Pipeline Studio', () => {
     // Uses API call to login instead of logging in manually through UI
     before(() => {
         loginIfRequired().then(() => {

--- a/server/config/development/cdap.json
+++ b/server/config/development/cdap.json
@@ -9,6 +9,7 @@
   "router.server.address": "127.0.0.1",
   "dashboard.bind.port": "11011",
   "enable.preview": "true",
+  "feature.pipeline.composite.triggers.enabled": "true",
   "dashboard.router.check.timeout.secs": "0",
   "market.base.url": "https://hub.cdap.io/dev/v2",
   "ui.theme.file": "config/themes/default.json",

--- a/src/e2e-test/features/pipeline.triggers.feature
+++ b/src/e2e-test/features/pipeline.triggers.feature
@@ -1,0 +1,38 @@
+#
+# Copyright © 2022 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+@Integration_Tests
+Feature: Pipeline Triggers
+
+  @PIPELINE_TRIGGERS_TEST
+  Scenario: Deploy two pipelines and enable trigger for pipeline2 when pipeline1 succeeds with a simple trigger and disabling it
+    When Deploy pipeline "trigger_test_pipeline_1" with pipeline JSON file "pipeline_with_macros.json"
+    When Deploy pipeline "trigger_test_pipeline_2" with pipeline JSON file "pipeline_with_macros.json"
+    Then Open inbound trigger and set and delete a simple trigger when "trigger_test_pipeline_1" succeeds
+    Then Cleanup pipeline "trigger_test_pipeline_1"
+    Then Cleanup pipeline "trigger_test_pipeline_2"
+
+  @PIPELINE_TRIGGERS_TEST
+  Scenario: Deploy two pipelines and enable trigger for pipeline2 when pipeline1 succeeds with a complex trigger and disabling it
+    When Deploy pipeline "trigger_test_pipeline_1" with pipeline JSON file "pipeline_with_macros.json"
+    When Deploy pipeline "trigger_test_pipeline_2" with pipeline JSON file "pipeline_with_macros.json"
+    Then Open inbound trigger and set a complex trigger when "trigger_test_pipeline_1" succeeds
+    Then Visit pipeline "trigger_test_pipeline_1"
+    Then Ensure outbound trigger to "trigger_test_pipeline_2" exists
+    Then Visit pipeline "trigger_test_pipeline_2"
+    Then Cleanup complex trigger
+    Then Cleanup pipeline "trigger_test_pipeline_1"
+    Then Cleanup pipeline "trigger_test_pipeline_2"

--- a/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/CommonSteps.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/CommonSteps.java
@@ -197,6 +197,16 @@ public class CommonSteps {
       ElementHelper.getElementText(Helper.locateElementByTestId("valium-banner-hydrator")).contains(message));
   }
 
+  @Then("Cleanup pipeline {string}")
+  public void cleanupPipeline(String pipelineName) {
+    Helper.cleanupPipelines(pipelineName);
+  }
+
+  @Then("Visit pipeline {string}")
+  public void visitPipeline(String pipelineName) {
+    Helper.gotoDeployedPipeline(pipelineName);
+  }
+
   @Then("Reload the page")
   public void reloadPage() {
     Helper.reloadPage();

--- a/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/PipelineTriggers.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/PipelineTriggers.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.ui.stepsdesign;
+
+import io.cdap.cdap.ui.utils.Commands;
+import io.cdap.cdap.ui.utils.Helper;
+import io.cdap.e2e.utils.ElementHelper;
+import io.cdap.e2e.utils.SeleniumDriver;
+import io.cdap.e2e.utils.WaitHelper;
+import io.cucumber.java.en.Then;
+import org.junit.Assert;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.Select;
+
+
+public class PipelineTriggers {
+  public static String simpleTriggerName = "simple_trigger_test";
+  public static String complexTriggerName = "complex_trigger_test";
+
+  @Then("Deploy pipeline {string} with pipeline JSON file {string}")
+  public void deployPipelineFromJson(String pipelineName, String pipelineJSONfile) {
+    Helper.deployAndTestPipeline(pipelineJSONfile, pipelineName);
+  }
+
+  @Then("Open inbound trigger and set and delete a simple trigger when {string} succeeds")
+  public void openInboundTriggerAndSetAndDeleteASimpleTrigger(String sourcePipeline) {
+    ElementHelper.clickOnElement(Helper.locateElementByTestId("inbound-triggers-toggle"));
+    WebElement triggerNameInputField = Helper.locateElementByCssSelector(
+      Helper.getCssSelectorByDataTestId("trigger-name-text-field") + " input"
+    );
+    ElementHelper.clearElementValue(triggerNameInputField);
+    ElementHelper.sendKeys(triggerNameInputField, simpleTriggerName);
+    ElementHelper.clickOnElement(Helper.locateElementByTestId(sourcePipeline + "-enable-trigger-btn"));
+    ElementHelper.clickOnElement(Helper.locateElementByTestId("enable-group-trigger-btn"));
+    Helper.isElementExists(Helper.getCssSelectorByDataTestId(simpleTriggerName + "-collapsed"));
+    ElementHelper.clickOnElement(Helper.locateElementByTestId(simpleTriggerName + "-collapsed"));
+    Helper.isElementExists(Helper.getCssSelectorByDataTestId(simpleTriggerName + "-expanded"));
+    ElementHelper.clickOnElement(Helper.locateElementByTestId(simpleTriggerName + "-disable-trigger-btn"));
+    ElementHelper.clickOnElement(Helper.locateElementByTestId("Delete"));
+    Assert.assertFalse(Helper.isElementExists(Helper.getCssSelectorByDataTestId(simpleTriggerName + "-collapsed")));
+    ElementHelper.clickOnElement(Helper.locateElementByTestId("inbound-triggers-toggle"));
+  }
+
+  private WebElement getSourceRuntimeArgElement(int index) {
+    String selector = Helper.getCssSelectorByDataTestId("row-" + index) +  " " +
+      Helper.getCssSelectorByDataTestId("runtime-arg-of-trigger") +  " select";
+    return Helper.locateElementByCssSelector(selector);
+  }
+
+  private WebElement getTargetRuntimeArgElement(int index) {
+    String selector = Helper.getCssSelectorByDataTestId("row-" + index) +  " " +
+      Helper.getCssSelectorByDataTestId("runtime-arg-of-triggered") +  " select";
+    return Helper.locateElementByCssSelector(selector);
+  }
+
+  private void selectRuntimeArg(WebElement element, String value) {
+    Select select = new Select(element);
+    select.selectByVisibleText(value);
+  }
+
+  @Then("Open inbound trigger and set a complex trigger when {string} succeeds")
+  public void openInboundTriggerAndSetAComplexTrigger(String sourcePipeline) {
+    ElementHelper.clickOnElement(Helper.locateElementByTestId("inbound-triggers-toggle"));
+    WebElement triggerNameInputField = Helper.locateElementByCssSelector(
+      "div[data-testid='trigger-name-text-field'] input"
+    );
+    ElementHelper.clearElementValue(triggerNameInputField);
+    ElementHelper.sendKeys(triggerNameInputField, complexTriggerName);
+
+    ElementHelper.clickOnElement(Helper.locateElementByTestId(sourcePipeline + "-collapsed"));
+    ElementHelper.clickOnElement(Helper.locateElementByTestId(sourcePipeline + "-trigger-config-btn"));
+
+    selectRuntimeArg(getSourceRuntimeArgElement(0), "source_path");
+    selectRuntimeArg(getTargetRuntimeArgElement(0), "source_path");
+    selectRuntimeArg(getSourceRuntimeArgElement(1), "sink_path");
+    selectRuntimeArg(getTargetRuntimeArgElement(1), "sink_path");
+
+    ElementHelper.clickOnElement(Helper.locateElementByTestId("configure-and-enable-trigger-btn"));
+    ElementHelper.clickOnElement(Helper.locateElementByTestId("enable-group-trigger-btn"));
+
+    ElementHelper.clickOnElement(Helper.locateElementByTestId(complexTriggerName + "-collapsed"));
+    ElementHelper.clickOnElement(Helper.locateElementByTestId(sourcePipeline + "-view-payload-btn"));
+
+    WebElement sourceArg0 = getSourceRuntimeArgElement(0);
+    Assert.assertEquals("source_path", sourceArg0.getAttribute("value"));
+    WebElement sourceArg1 = getSourceRuntimeArgElement(1);
+    Assert.assertEquals("sink_path", sourceArg1.getAttribute("value"));
+
+    WebElement targetArg0 = getTargetRuntimeArgElement(0);
+    Assert.assertEquals("source_path", targetArg0.getAttribute("value"));
+    WebElement targetArg1 = getTargetRuntimeArgElement(1);
+    Assert.assertEquals("sink_path", targetArg1.getAttribute("value"));
+
+    ElementHelper.clickOnElement(Helper.locateElementByTestId("close-payload-config-modal"));
+  }
+
+  @Then("Ensure outbound trigger to {string} exists")
+  public void ensureOutboundTriggerExists(String triggeredPipeline) {
+    ElementHelper.clickOnElement(Helper.locateElementByTestId("outbound-triggers-toggle"));
+    ElementHelper.clickOnElement(Helper.locateElementByTestId(triggeredPipeline + "-triggered-collapsed"));
+    // The animation triggered on the line above takes some time to complete,
+    // so wait for text at the bottom to be visible
+    WebElement outboundTrigger = Helper.locateElementByTestId(triggeredPipeline + "-triggered-expanded");
+    SeleniumDriver.getWaitDriver(3).until(ExpectedConditions.textToBePresentInElement(outboundTrigger, "Succeeds"));
+    Assert.assertTrue(ElementHelper.getElementText(outboundTrigger).contains("Succeeds"));
+  }
+
+  @Then("Cleanup complex trigger")
+  public void cleanupComplexTrigger() {
+    ElementHelper.clickOnElement(Helper.locateElementByTestId("inbound-triggers-toggle"));
+
+    ElementHelper.clickOnElement(Helper.locateElementByTestId(complexTriggerName + "-collapsed"));
+    ElementHelper.clickOnElement(Helper.locateElementByTestId(complexTriggerName + "-disable-trigger-btn"));
+    ElementHelper.clickOnElement(Helper.locateElementByTestId("Delete"));
+    Assert.assertFalse(Helper.isElementExists(Helper.getCssSelectorByDataTestId(complexTriggerName + "-collapsed")));
+    ElementHelper.clickOnElement(Helper.locateElementByTestId("inbound-triggers-toggle"));
+  }
+}

--- a/src/e2e-test/java/io/cdap/cdap/ui/utils/Helper.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/utils/Helper.java
@@ -239,7 +239,7 @@ public class Helper implements CdfHelper {
     );
 
     Assert.assertEquals(statusText, "Deployed");
-    Assert.assertTrue(SeleniumDriver.getDriver().getCurrentUrl().contains("/view/" + pipelineName));
+    Assert.assertTrue(urlHasString("/view/" + pipelineName));
   }
 
   public static void cleanupPipelines(String pipelineName) {
@@ -347,7 +347,7 @@ public class Helper implements CdfHelper {
     // wait for rendering to finish otherwise elements are not attached to dom
     Helper.waitSeconds(2);
   }
-  
+
   public static boolean urlHasString(String targetString) {
     String strUrl = SeleniumDriver.getDriver().getCurrentUrl();
     return strUrl.contains(targetString);
@@ -466,5 +466,9 @@ public class Helper implements CdfHelper {
     ElementHelper.clickOnElement(Helper.locateElementByCssSelector(
       getCssSelectorForWidgetRow(rowIndex, propertyName)
         + " " + Helper.getCssSelectorByDataTestId("remove-row")));
+  }
+
+  public static void gotoDeployedPipeline(String pipelineName) {
+    SeleniumDriver.openPage(Constants.BASE_PIPELINES_URL + "/view/" + pipelineName);
   }
 }


### PR DESCRIPTION
# CDAP-19245 Convert pipeline triggers tests to Cucumber

## Description
Converts the tests. Disables the Cypress tests because this switches the sandbox to run the new triggers UI. Completes #865 

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [X] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19245](https://cdap.atlassian.net/browse/CDAP-19245)

## Test Plan
Automated tests

## Screenshots
N/A




[CDAP-19245]: https://cdap.atlassian.net/browse/CDAP-19245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ