### PR TITLE
CDAP-20345 Correctly configure if "Resources" should be shown for namespace creation

### DIFF
--- a/app/cdap/services/ThemeHelper.ts
+++ b/app/cdap/services/ThemeHelper.ts
@@ -82,7 +82,7 @@ interface IOnePoint0SpecJSON extends IThemeJSON {
     'wrangler-data-model'?: boolean;
     'wrangler-datamodel-viewer'?: boolean;
     pipelines?: boolean;
-    pipelineStudio?: boolean;
+    'pipeline-studio'?: boolean;
     analytics?: boolean;
     'rules-engine'?: boolean;
     metadata?: boolean;
@@ -435,6 +435,7 @@ function parse1Point0Spec(themeJSON: IOnePoint0SpecJSON): IThemeObj {
       showReloadSystemArtifacts: true,
       showSqlPipeline: true,
       showCDC: false,
+      onPremTetheredInstance: false,
     };
     if (isNilOrEmpty(featuresJson)) {
       return features;


### PR DESCRIPTION
# CDAP-20345 Correctly configure if "Resources" should be shown for namespace creation

## Description
The UI component explicitly checks for `false` so if no default value is set, the Resources tab is shown. Will be cherry-picked for 6.8.1.

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20345](https://cdap.atlassian.net/browse/CDAP-20345)

## Test Plan
Manually verify

## Screenshots
N/A




[CDAP-20345]: https://cdap.atlassian.net/browse/CDAP-20345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ