### PR TITLE
CDAP-20138 CDAP-20345 Cherry pick to 6.8.1

### DIFF
--- a/app/cdap/components/CaskWizards/AddNamespace/ResourcesStep/index.tsx
+++ b/app/cdap/components/CaskWizards/AddNamespace/ResourcesStep/index.tsx
@@ -131,6 +131,10 @@ const InputK8sServiceAccountEmail = connect(
 )(InputWithValidations);
 
 export default function ResourcesStep() {
+  const shouldDisplayServiceAccountEmailField =
+    window.CDAP_CONFIG.cdap.k8sWorkloadIdentityEnabled === 'true' &&
+    window.CDAP_CONFIG.cdap.namespaceCreationHookEnabled === 'true';
+
   return (
     <Provider store={AddNamespaceStore}>
       <Form
@@ -170,18 +174,20 @@ export default function ResourcesStep() {
             <InputK8sMemoryLimit />
           </Col>
         </FormGroup>
-        <FormGroup row>
-          <Col xs="4">
-            <Label className="control-label">
-              {T.translate(
-                'features.Wizard.Add-Namespace.ResourcesStep.service-account-email-label'
-              )}
-            </Label>
-          </Col>
-          <Col xs="7">
-            <InputK8sServiceAccountEmail />
-          </Col>
-        </FormGroup>
+        {shouldDisplayServiceAccountEmailField && (
+          <FormGroup row>
+            <Col xs="4">
+              <Label className="control-label">
+                {T.translate(
+                  'features.Wizard.Add-Namespace.ResourcesStep.service-account-email-label'
+                )}
+              </Label>
+            </Col>
+            <Col xs="7">
+              <InputK8sServiceAccountEmail />
+            </Col>
+          </FormGroup>
+        )}
       </Form>
     </Provider>
   );

--- a/app/cdap/services/ThemeHelper.ts
+++ b/app/cdap/services/ThemeHelper.ts
@@ -82,7 +82,7 @@ interface IOnePoint0SpecJSON extends IThemeJSON {
     'wrangler-data-model'?: boolean;
     'wrangler-datamodel-viewer'?: boolean;
     pipelines?: boolean;
-    pipelineStudio?: boolean;
+    'pipeline-studio'?: boolean;
     analytics?: boolean;
     'rules-engine'?: boolean;
     metadata?: boolean;
@@ -437,6 +437,7 @@ function parse1Point0Spec(themeJSON: IOnePoint0SpecJSON): IThemeObj {
       showSqlPipeline: true,
       showCDC: false,
       isMetadataInReact: false,
+      onPremTetheredInstance: false,
     };
     if (isNilOrEmpty(featuresJson)) {
       return features;

--- a/server/express.js
+++ b/server/express.js
@@ -229,6 +229,8 @@ function makeApp(authAddress, cdapConfig, uiSettings) {
         proxyBaseUrl: cdapConfig['dashboard.proxy.base.url'],
         maxRecordsPreview: cdapConfig['preview.max.num.records'],
         ui: uiSettings['ui'],
+        k8sWorkloadIdentityEnabled: cdapConfig['master.environment.k8s.workload.identity.enabled'],
+        namespaceCreationHookEnabled: cdapConfig['namespaces.creation.hook.enabled'],
       },
       hydrator: {
         previewEnabled: cdapConfig['enable.preview'] === 'true',


### PR DESCRIPTION
# CDAP-20138 CDAP-20345 Cherry pick to 6.8.1

## Description
Cherry picks for:
CDAP-20138 #839 Hide service account field on namespace creation unless it's needed
CDAP-20345 #898 Hie resources tab on namespace creation if the field is not set

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [X] Cherry Pick

## Links
Jira: [CDAP-20138](https://cdap.atlassian.net/browse/CDAP-20138)
Jira: [CDAP-20345](https://cdap.atlassian.net/browse/CDAP-20345)

## Test Plan
Manually verify

## Screenshots
N/A




[CDAP-20138]: https://cdap.atlassian.net/browse/CDAP-20138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20345]: https://cdap.atlassian.net/browse/CDAP-20345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ