### PR TITLE
CDAP-20392 Handle missing useConnection plugin property

### DIFF
--- a/app/cdap/components/shared/ConfigurationGroup/utilities/DynamicPluginFilters.ts
+++ b/app/cdap/components/shared/ConfigurationGroup/utilities/DynamicPluginFilters.ts
@@ -103,7 +103,14 @@ export function evaluateFilter(
     ...getTypedPropertyValues(propertyValues, propertiesFromBackend),
   };
 
-  return jexl.evalSync(`${filter.condition.expression}`, typedPropertyValues);
+  // Some upgrade scenarios leave useConnection as null,
+  // which prevents the connection properties from being shown
+  // Modify any expression which depends on useConnection equaling false
+  const expressionHandleUseConnectionNull = filter.condition.expression.replace(
+    'useConnection == false',
+    'useConnection != true'
+  );
+  return jexl.evalSync(expressionHandleUseConnectionNull, typedPropertyValues);
 }
 
 /**


### PR DESCRIPTION
# CDAP-20392 Handle missing useConnection plugin property

## Description
In certain upgrade/migration flows, source and sink plugins might not have the `useConnection` property set. Because the filter expression checks explicitly for `== false`, the properties used to connect are hidden from view. This PR updates those expressions before evaluation by changing the condition to `!= true`.

Will be cherry-picked to 6.8 and 6.7 branches

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20392](https://cdap.atlassian.net/browse/CDAP-20392)

## Test Plan
Manually verify

## Screenshots
N/A




[CDAP-20392]: https://cdap.atlassian.net/browse/CDAP-20392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ