### PR TITLE
CDAP-20392 Handle missing useConnection plugin property CHERRY PICK FOR 6.8

### DIFF
--- a/app/cdap/components/shared/ConfigurationGroup/utilities/DynamicPluginFilters.ts
+++ b/app/cdap/components/shared/ConfigurationGroup/utilities/DynamicPluginFilters.ts
@@ -103,7 +103,14 @@ export function evaluateFilter(
     ...getTypedPropertyValues(propertyValues, propertiesFromBackend),
   };
 
-  return jexl.evalSync(`${filter.condition.expression}`, typedPropertyValues);
+  // Some upgrade scenarios leave useConnection as null,
+  // which prevents the connection properties from being shown
+  // Modify any expression which depends on useConnection equaling false
+  const expressionHandleUseConnectionNull = filter.condition.expression.replace(
+    'useConnection == false',
+    'useConnection != true'
+  );
+  return jexl.evalSync(expressionHandleUseConnectionNull, typedPropertyValues);
 }
 
 /**


### PR DESCRIPTION
# CDAP-20392 Handle missing useConnection plugin property CHERRY PICK FOR 6.8

## Description
See #903 

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [X] Cherry Pick

## Links
Jira: [CDAP-20392](https://cdap.atlassian.net/browse/CDAP-20392)

## Test Plan
Manually verify

## Screenshots
N/A




[CDAP-20392]: https://cdap.atlassian.net/browse/CDAP-20392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ