### PR TITLE
[CDAP-20408] (Fix) fix securekey search undefined when desc null

### DIFF
--- a/app/cdap/components/SecureKeys/SecureKeyList/index.tsx
+++ b/app/cdap/components/SecureKeys/SecureKeyList/index.tsx
@@ -123,14 +123,16 @@ const SecureKeyListView: React.FC<ISecureKeyListProps> = ({
 
   const filteredSecureKeys = secureKeys.filter(
     (key) =>
-      key
-        .get('name')
-        .toLowerCase()
-        .includes(searchText.toLowerCase()) ||
-      key
-        .get('description')
-        .toLowerCase()
-        .includes(searchText.toLowerCase())
+      (key.get('name') &&
+        key
+          .get('name')
+          .toLowerCase()
+          .includes(searchText.toLowerCase())) ||
+      (key.get('description') &&
+        key
+          .get('description')
+          .toLowerCase()
+          .includes(searchText.toLowerCase()))
   );
 
   return (


### PR DESCRIPTION
# [CDAP-20408] (Fix) fix securekey search undefined when desc null

## Description
Since securekey can be created through api without a description, the UI will throw error when searching descriptions on keys that have no descriptions.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20408](https://cdap.atlassian.net/browse/CDAP-20408)

## Screenshots
<img width="1163" alt="image" src="https://user-images.githubusercontent.com/98125204/221657057-52f97839-68f6-4a65-8915-1099f392100e.png">




[CDAP-20408]: https://cdap.atlassian.net/browse/CDAP-20408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20408]: https://cdap.atlassian.net/browse/CDAP-20408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ