### PR TITLE
fix the flaky test in pipeline.runtimeargs.spec.ts

### DIFF
--- a/cypress/integration/pipeline.runtimeargs.spec.ts
+++ b/cypress/integration/pipeline.runtimeargs.spec.ts
@@ -284,6 +284,7 @@ unknown`;
     cy.add_runtime_args_row_with_value(3, 'runtime_args_key3', 'runtime_args_value3');
     // dismissing the modeless by clicking close button.
     cy.get(dataCy('pipeline-modeless-close-btn')).click();
+    cy.wait(1000);
     cy.get('.arrow-btn-container').click();
     cy.get(dataCy(RUNTIME_ARGS_MODELESS_LOADING_SELECTOR)).should('not.exist');
     cy.get(dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)).should('exist');


### PR DESCRIPTION
# fix the flaky test in pipeline.runtimeargs.spec.ts

## Description
The testcase `it should not persist unsaved arguments` was failing because of an unrelated change to the modal outside click handler. On closer inspection it was found to be caused by lack of any delay between 2 consecutive clicks, that triggered handlers updating the same state; in this case `this.toggleRunConfigOption` of class `app/cdap/components/PipelineDetails/PipelineRuntimeArgsDropdownBtn` was called with `false` and `true` consecutively on the same instance. 

How did we fix this ? **Added a 1s delay between the two clicks**

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [x] Build Fix
- [x] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: NA

## Test Plan
NA

## Screenshots
<img width="1000" alt="Screenshot 2023-03-06 at 1 22 55 PM" src="https://user-images.githubusercontent.com/4161531/223050101-438f1a98-7b13-4905-aed5-3ea2bf09bb51.png">



