### PR TITLE
[CDAP-20350] (fix) manually overflow multiline text if description is too long

### DIFF
--- a/app/cdap/components/PipelineHistory/PipelineHistoryTableRow.tsx
+++ b/app/cdap/components/PipelineHistory/PipelineHistoryTableRow.tsx
@@ -15,13 +15,13 @@
  */
 
 import React, { ReactNode } from 'react';
+import styled from 'styled-components';
+import T from 'i18n-react';
 import { MyPipelineApi } from 'api/pipeline';
 import { getCurrentNamespace } from 'services/NamespaceStore';
-import T from 'i18n-react';
 import { getHydratorUrl } from 'services/UiUtils/UrlGenerator';
 import { PrimaryTextLowercaseButton } from 'components/shared/Buttons/PrimaryTextLowercaseButton';
 import { SNAPSHOT_VERSION } from 'services/global-constants';
-import styled from 'styled-components';
 
 interface IPipelineHistoryTableRowProps {
   pipelineName: string;
@@ -104,6 +104,7 @@ export const PipelineHistoryTableRow = ({
 
   const isLatest = appVersion === latestVersion;
   const dateLabel = isLatest ? T.translate(`${PREFIX}.latest`) : T.translate(`${PREFIX}.older`);
+  const displayedDesc = description.length > 190 ? description.slice(0, 190) + '...' : description;
 
   return (
     <>
@@ -114,7 +115,7 @@ export const PipelineHistoryTableRow = ({
             <li data-testid="pipeline-history-date-label">{dateLabel}</li>
           </VersionDateLabel>
         </div>
-        <div data-testid="pipeline-history-description">{description}</div>
+        <div data-testid="pipeline-history-description">{displayedDesc}</div>
         {appVersion !== SNAPSHOT_VERSION && (
           <>
             <PrimaryTextLowercaseButton

--- a/app/cdap/components/hydrator/components/TopPanel/TopPanel.tsx
+++ b/app/cdap/components/hydrator/components/TopPanel/TopPanel.tsx
@@ -369,7 +369,8 @@ export const TopPanel = ({
 
   const confirmationElem = (
     <StyledTextarea
-      rowsMin={3}
+      minRows={3}
+      maxRows={7}
       autoFocus={true}
       onChange={(e) => onSummaryChange(e.target.value)}
       value={changeSummary}


### PR DESCRIPTION
# [CDAP-20350] (fix) manually overflow multiline text if description is too long

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [x] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20350](https://cdap.atlassian.net/browse/CDAP-20350)

## Screenshots
![image](https://user-images.githubusercontent.com/98125204/224143399-aeac6f55-4934-4e9f-8113-6a17c8385b83.png)




[CDAP-20350]: https://cdap.atlassian.net/browse/CDAP-20350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ