### PR TITLE
[CDAP-20402] (fix) add return to latest link

### DIFF
--- a/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/index.js
+++ b/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/index.js
@@ -17,10 +17,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import styled from 'styled-components';
+import T from 'i18n-react';
 import PipelineDetailsActionsButton from 'components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/PipelineDetailsActionsButton';
 import { useFeatureFlagDefaultFalse } from 'services/react/customHooks/useFeatureFlag';
+import { getCurrentNamespace } from 'services/NamespaceStore';
+import { getHydratorUrl } from 'services/UiUtils/UrlGenerator';
 
 require('./PipelineDetailsDetailsActions.scss');
+
+const StyledLinkToLatest = styled.a`
+  padding-top: 22px;
+  font-size: 10px;
+  cursor: pointer;
+`;
 
 const mapDetailsStateToProps = (state) => {
   return {
@@ -52,6 +62,21 @@ const PipelineDetailsDetailsActions = ({
   const isLatestVersion = change ? change.latest : true;
   return (
     <div className="pipeline-details-buttons pipeline-details-details-actions">
+      {!isLatestVersion && (
+        <StyledLinkToLatest
+          onClick={() => {
+            window.location.href = getHydratorUrl({
+              stateName: 'hydrator.detail',
+              stateParams: {
+                namespace: getCurrentNamespace(),
+                pipelineId: pipelineName,
+              },
+            });
+          }}
+        >
+          {T.translate('features.LifeCycleManagement.returnToLatest')}
+        </StyledLinkToLatest>
+      )}
       <PipelineDetailsActionsButton
         pipelineName={pipelineName}
         description={description}

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -1963,6 +1963,7 @@ features:
       outdatedDraftActionButton: Export and Rebase
       outdatedDraftError: A new version of pipeline "{pipelineName}" has been deployed. 
         This draft is outdated and please export the draft for manual reconciliation.
+    returnToLatest: return to the latest version
 
   LoadingIndicator:
     contactadmin: It could take a few minutes for the system to self-heal.


### PR DESCRIPTION
# [CDAP-20402] (fix) add return to latest link

## Description
When viewing past versions, a return to latest link will appear next to actions button

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [x] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20402](https://cdap.atlassian.net/browse/CDAP-20402)

## Screenshots
![image](https://user-images.githubusercontent.com/98125204/224180362-dd4ba28a-9ac3-4bb0-b11d-da6c9bb4f3ee.png)




[CDAP-20402]: https://cdap.atlassian.net/browse/CDAP-20402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20402]: https://cdap.atlassian.net/browse/CDAP-20402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ