### PR TITLE
[CDAP-20437] fix resource center import button not working

### DIFF
--- a/app/cdap/services/UiUtils/UrlGenerator.ts
+++ b/app/cdap/services/UiUtils/UrlGenerator.ts
@@ -213,7 +213,7 @@ const addCustomQueryParams = (url, params = {}) => {
   const forEachSorted = (obj, iterator) => {
     const keys = Object.keys(params).sort();
     keys.forEach((key) => {
-      iterator.call(obj[key], key);
+      iterator(obj[key], key);
     });
     return keys;
   };


### PR DESCRIPTION
# [CDAP-20437] fix resource center import button not working

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20437](https://cdap.atlassian.net/browse/CDAP-20437)





[CDAP-20437]: https://cdap.atlassian.net/browse/CDAP-20437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20437]: https://cdap.atlassian.net/browse/CDAP-20437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ