### PR TITLE
[CDAP-20434] Add e2e test for pushing a pipeline from list page

### DIFF
--- a/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/PipelineDetailsActionsButton/index.js
+++ b/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/PipelineDetailsActionsButton/index.js
@@ -370,7 +370,7 @@ export default class PipelineDetailsActionsButton extends Component {
               {T.translate(`${PREFIX}.export`)}
             </li>
             {this.props.sourceControlManagementEnabled && (
-              <li role="button" onClick={this.toggleCommitModal}>
+              <li role="button" onClick={this.toggleCommitModal} data-testid="push-pipeline">
                 {T.translate('features.SourceControlManagement.push.pushButton')}
               </li>
             )}

--- a/app/cdap/components/SourceControlManagement/LocalPipelineListView/CommitModal.tsx
+++ b/app/cdap/components/SourceControlManagement/LocalPipelineListView/CommitModal.tsx
@@ -22,6 +22,7 @@ import { TextareaAutosize } from '@material-ui/core';
 import Alert from 'components/shared/Alert';
 import { pushSelectedPipelines } from '../store/ActionCreator';
 import { getCurrentNamespace } from 'services/NamespaceStore';
+import { SUPPORT } from 'components/StatusButton/constants';
 
 const PREFIX = 'features.SourceControlManagement.push';
 
@@ -63,7 +64,7 @@ export const CommitModal = ({
       setPushLoadingMessage
     ).subscribe((res: any) => {
       // TODO: no changes made will also be 200, need to give different warning
-      if (res.statusCode !== 200) {
+      if (res.status !== SUPPORT.yes) {
         setPushError(res.message);
         setPushSuccess(false);
       } else {
@@ -110,6 +111,7 @@ export const CommitModal = ({
               setCommitMessage(e.target.value);
             }}
             style={{ width: '100%' }}
+            data-testid="commit-message-input"
           />
         }
         closeable={true}

--- a/pom.xml
+++ b/pom.xml
@@ -657,6 +657,10 @@
           <version>0.2.0-SNAPSHOT</version>
           <scope>test</scope>
         </dependency>
+         <dependency>
+          <groupId>org.eclipse.jgit</groupId>
+          <artifactId>org.eclipse.jgit</artifactId>
+        </dependency>
       </dependencies>
 
     </profile>

--- a/sandboxjs/sandbox_starter.py
+++ b/sandboxjs/sandbox_starter.py
@@ -43,6 +43,12 @@ def enable_features(path):
             conf_root.append(property_tag)
         new_conf = ET.ElementTree(conf_root)
         new_conf.write(path)
+        # update cdap.json
+        with open('../server/config/development/cdap.json','r+') as file:
+            file_data = json.load(file)
+            file_data.update(feature_flags)
+            file.seek(0)
+            json.dump(file_data, file, indent = 2)
 
 # Start CDAP sandbox
 print("Downloading CDAP sandbox")

--- a/src/e2e-test/features/source.control.management.sync.apps.feature
+++ b/src/e2e-test/features/source.control.management.sync.apps.feature
@@ -1,0 +1,32 @@
+#
+# Copyright © 2023 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+@Integration_Tests
+Feature: Source Control Management - Pulling and pushing applications
+
+  @SOURCE_CONTROL_MANAGEMENT_TEST
+  Scenario: Should successfully push a pipeline to git from pipeline list page
+    When Open Source Control Management Page
+    When Initialize the repository config
+    When Create branch in remote repository
+    When Deploy and test pipeline "test_pipeline2_fll_airport" with pipeline JSON file "fll_airport_pipeline2.json"
+    Then Click push button in Actions dropdown
+    Then Commit changes with message "upload pipeline to Git"
+    Then Banner is shown with message "Successfully pushed pipeline test_pipeline2_fll_airport"
+    Then Clean up pipeline "test_pipeline2_fll_airport" which is created for testing
+    When Open Source Control Management Page
+    Then Delete the repo config
+    Then Cleanup the branch which is created for testing

--- a/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/BeforeActions.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/BeforeActions.java
@@ -16,12 +16,16 @@
 
 package io.cdap.cdap.ui.stepsdesign;
 
+import com.google.common.base.Strings;
+import io.cdap.cdap.ui.utils.Constants;
 import io.cdap.cdap.ui.utils.Helper;
+import io.cdap.e2e.utils.PluginPropertyUtils;
 import io.cucumber.java.Before;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.UUID;
 
 public class BeforeActions {
   private static final Logger logger = LoggerFactory.getLogger(stepsdesign.BeforeActions.class);
@@ -30,5 +34,23 @@ public class BeforeActions {
   public void loginIfRequired() throws IOException {
     logger.info("-----------------Logging in if required------------------");
     Helper.loginIfRequired();
+  }
+
+  @Before(order = 1, value = "@SOURCE_CONTROL_MANAGEMENT_TEST")
+  public void setGitBranchConfig() throws IOException {
+    if (Strings.isNullOrEmpty(PluginPropertyUtils.pluginProp(Constants.GIT_BRANCH_PROP_NAME))) {
+      String branchName =  "cdf-e2e-test-" + UUID.randomUUID();
+      PluginPropertyUtils.addPluginProp(Constants.GIT_BRANCH_PROP_NAME, branchName);
+    }
+
+    String gitRepoUrl = System.getenv("SCM_TEST_REPO_URL");
+    if (!Strings.isNullOrEmpty(gitRepoUrl)) {
+      PluginPropertyUtils.addPluginProp(Constants.GIT_REPO_URL_PROP_NAME, gitRepoUrl);
+    }
+
+    String gitPAT = System.getenv("SCM_TEST_REPO_PAT");
+    if (!Strings.isNullOrEmpty(gitPAT)) {
+      PluginPropertyUtils.addPluginProp(Constants.GIT_PAT_PROP_NAME, gitPAT);
+    }
   }
 }

--- a/src/e2e-test/java/io/cdap/cdap/ui/utils/Constants.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/utils/Constants.java
@@ -89,4 +89,8 @@ public class Constants {
   public static final String FAKE_REPO_LINK = "https://example.com";
   public static final String FAKE_TOKEN_NAME = "fake_token";
   public static final String FAKE_TOKEN = "fake token value";
+  public static final String GIT_BRANCH_PROP_NAME = "gitBranchName";
+  public static final String GIT_REPO_URL_PROP_NAME = "gitRepositoryUrl";
+  public static final String GIT_PAT_PROP_NAME = "gitPAT";
+  public static final String GIT_PATH_PREFIX_PROP_NAME = "gitRepositoryPathPrefix";
 }

--- a/src/e2e-test/resources/pluginParameters.properties
+++ b/src/e2e-test/resources/pluginParameters.properties
@@ -1,0 +1,17 @@
+ # Copyright © 2023 Cask Data, Inc.
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ # use this file except in compliance with the License. You may obtain a copy of
+ # the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ # License for the specific language governing permissions and limitations under
+ # the License.
+
+gitRepositoryUrl=replace-with-env-variable
+gitPAT=replace-with-env-variable
+gitRepositoryPathPrefix=cdap-pipelines


### PR DESCRIPTION
# Test Push  apps from Pipeline lists page.

## Description
The test performs the following steps:
1. Create a pipeline
2. Push pipeline to remote repo
3. Check if push succeeded

We DO NOT clone the repo to verify the json is present. This check will be covered by pulling the pushed pipeline back from Git in a followup PR.

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [x] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20434](https://cdap.atlassian.net/browse/CDAP-20434)

## Test Plan

## Screenshots




[CDAP-20434]: https://cdap.atlassian.net/browse/CDAP-20434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ