### PR TITLE
[CDAP-20345] (feat) Add e2e test pull/push from scm sync page happy path

### DIFF
--- a/app/cdap/components/ResourceCenterEntity/ResourceCenterPipelineEntity.tsx
+++ b/app/cdap/components/ResourceCenterEntity/ResourceCenterPipelineEntity.tsx
@@ -178,7 +178,11 @@ export default function ResourceCenterPipelineEntity({
             </StyledButton>
           </label>
           {sourceControlManagementEnabled && (
-            <StyledButton onClick={pullPipelineBtnHandler} loading={pullPipelineModalState.loading}>
+            <StyledButton
+              onClick={pullPipelineBtnHandler}
+              loading={pullPipelineModalState.loading}
+              data-testid="pull-pipeline-button"
+            >
               {T.translate(`${PREFIX}.actionbtn2`)}
             </StyledButton>
           )}

--- a/app/cdap/components/SourceControlManagement/LocalPipelineListView/PipelineTable.tsx
+++ b/app/cdap/components/SourceControlManagement/LocalPipelineListView/PipelineTable.tsx
@@ -115,11 +115,16 @@ export const LocalPipelineTable = ({
                 key={pipeline.name}
                 selected={isPipelineSelected}
                 onClick={(e) => handleClick(e, pipeline.name)}
+                data-testid={`local-${pipeline.name}`}
               >
                 <TableCell padding="checkbox">
                   <Checkbox color="primary" checked={isPipelineSelected} />
                 </TableCell>
-                <StatusCell>
+                <StatusCell
+                  data-testid={
+                    pipeline.status === SUPPORT.yes ? 'push-success-status' : 'push-failure-status'
+                  }
+                >
                   {pipeline.status !== null && (
                     <StatusButton
                       status={pipeline.status}

--- a/app/cdap/components/SourceControlManagement/LocalPipelineListView/index.tsx
+++ b/app/cdap/components/SourceControlManagement/LocalPipelineListView/index.tsx
@@ -106,6 +106,7 @@ export const LocalPipelineListView = () => {
             onClick={toggleCommitModal}
             size="large"
             disabled={!selectedPipelines.length}
+            data-testid="remote-push-button"
           >
             {T.translate(`${PREFIX}.pushButton`)}
           </PrimaryContainedButton>

--- a/app/cdap/components/SourceControlManagement/RemotePipelineListView/RemotePipelineTable.tsx
+++ b/app/cdap/components/SourceControlManagement/RemotePipelineListView/RemotePipelineTable.tsx
@@ -50,7 +50,7 @@ export const RemotePipelineTable = ({
 
   return (
     <TableBox>
-      <Table stickyHeader>
+      <Table data-testid="remote-pipelines-table" stickyHeader>
         <TableHead>
           <TableRow>
             <TableCell padding="checkbox"></TableCell>
@@ -72,11 +72,17 @@ export const RemotePipelineTable = ({
                 key={pipeline.name}
                 selected={isPipelineSelected}
                 onClick={(e) => handleClick(e, pipeline.name)}
+                data-testid={`remote-${pipeline.name}`}
               >
                 <TableCell padding="checkbox">
                   <Checkbox color="primary" checked={isPipelineSelected} />
                 </TableCell>
-                <TableCell style={{ width: '40px' }}>
+                <TableCell
+                  style={{ width: '40px' }}
+                  data-testid={
+                    pipeline.status === SUPPORT.yes ? 'pull-success-status' : 'pull-failure-status'
+                  }
+                >
                   {pipeline.status !== null && (
                     <StatusButton
                       status={pipeline.status}

--- a/app/cdap/components/SourceControlManagement/RemotePipelineListView/index.tsx
+++ b/app/cdap/components/SourceControlManagement/RemotePipelineListView/index.tsx
@@ -115,6 +115,7 @@ export const RemotePipelineListView = ({ redirectOnSubmit }: IRemotePipelineList
           <PrimaryContainedButton
             size="large"
             disabled={!selectedPipelines.length}
+            data-testid="remote-pull-button"
             onClick={onPullSubmit}
           >
             {T.translate(`${PREFIX}.pullButton`)}

--- a/app/cdap/components/SourceControlManagement/index.tsx
+++ b/app/cdap/components/SourceControlManagement/index.tsx
@@ -60,8 +60,8 @@ const SourceControlManagementSyncView = () => {
           textColor="primary"
           indicatorColor="primary"
         >
-          <Tab label={T.translate(`${PREFIX}.push.tab`)} />
-          <Tab label={T.translate(`${PREFIX}.pull.tab`)} />
+          <Tab data-testid="local-pipeline-tab" label={T.translate(`${PREFIX}.push.tab`)} />
+          <Tab data-testid="remote-pipeline-tab" label={T.translate(`${PREFIX}.pull.tab`)} />
         </Tabs>
       </StyledDiv>
       <StyledDiv>

--- a/src/e2e-test/features/source.control.management.sync.apps.feature
+++ b/src/e2e-test/features/source.control.management.sync.apps.feature
@@ -28,3 +28,28 @@ Feature: Source Control Management - Pulling and pushing applications
     Then Clean up pipeline "test_pipeline2_fll_airport" which is created for testing
     When Open Source Control Management Page
     Then Delete the repo config
+
+  @SOURCE_CONTROL_MANAGEMENT_TEST
+  Scenario: Remote pipeline tab loads pipelines from git
+    # Setup
+    When Open Source Control Management Page
+    When Initialize the repository config
+    When Deploy and test pipeline "test_pipeline2_fll_airport" with pipeline JSON file "fll_airport_pipeline2.json"
+    # Test push from SCM sync page
+    When Open Source Control Sync Page
+    When Select "test_pipeline2_fll_airport" pipeline and push
+    Then Commit changes with message "upload pipeline to Git"
+    Then Push success indicator is shown for pipeline "test_pipeline2_fll_airport"
+    When Select remote pipelines tab
+    Then Verify pipeline list size 1
+    Then Verify "test_pipeline2_fll_airport" pipeline exist in list
+    # Test pull from SCM sync page
+    Then Clean up pipeline "test_pipeline2_fll_airport" which is created for testing
+    When Open Source Control Sync Page
+    When Select remote pipelines tab
+    Then Select "test_pipeline2_fll_airport" pipeline and pull
+    Then Pull success indicator is shown for pipeline "test_pipeline2_fll_airport"
+    # Clean up
+    Then Clean up pipeline "test_pipeline2_fll_airport" which is created for testing
+    When Open Source Control Management Page
+    Then Delete the repo config

--- a/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/CommonSteps.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/CommonSteps.java
@@ -89,6 +89,12 @@ public class CommonSteps {
     WaitHelper.waitForPageToLoad();
   }
 
+  @When("Open Source Control Sync Page")
+  public void openRemotePipelinesPage() {
+    SeleniumDriver.openPage(Constants.SOURCE_CONTROL_SYNC_URL);
+    WaitHelper.waitForPageToLoad();
+  }
+
   @When("Create a simple pipeline")
   public void createSimplePipeline() {
     Commands.createSimplePipeline();

--- a/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/SourceControlManagement.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/SourceControlManagement.java
@@ -160,4 +160,61 @@ public class SourceControlManagement {
     addPathPrefix(PluginPropertyUtils.pluginProp(Constants.GIT_PATH_PREFIX_PROP_NAME));
     clickOnSaveButton();
   }
+
+  @When("Select remote pipelines tab")
+  public void selectRemotePipelinesTab() {
+    ElementHelper.clickOnElement(Helper.locateElementByTestId("remote-pipeline-tab"));
+    WaitHelper.waitForPageToLoad();
+  }
+
+  @When("Select local pipelines tab")
+  public void selectLocalPipelinesTab() {
+    ElementHelper.clickOnElement(Helper.locateElementByTestId("local-pipeline-tab"));
+    WaitHelper.waitForPageToLoad();
+  }
+
+  @Then("Verify pipeline list size {int}")
+  public void verifyPipelineList(int size) {
+    Assert.assertEquals(
+        Helper.locateElementsByXPath("//table[@data-testid=\"remote-pipelines-table\"]/tbody/tr").size(),
+        size
+    );
+  }
+
+  @Then("Verify {string} pipeline exist in list")
+  public void verifyPipelineList(String pipeline) {
+    Assert.assertTrue(
+        Helper.isElementExists(Helper.getCssSelectorByDataTestId("remote-" + pipeline))
+    );
+  }
+
+  @When("Select {string} pipeline and push")
+  public void pushPipelineInRemotePage(String pipeline) {
+    ElementHelper.clickOnElement(Helper.locateElementByTestId("local-" + pipeline));
+    ElementHelper.clickOnElement(Helper.locateElementByTestId("remote-push-button"));
+  }
+
+  @Then("Push success indicator is shown for pipeline {string}")
+  public void verifyPushSuccessInLocalTable(String pipeline) {
+    String pushStatusXpath = String.format(
+        "//*[@data-testid=\"local-%s\"]//*[@data-testid=\"push-success-status\"]",
+        pipeline
+    );
+    ElementHelper.isElementDisplayed(Helper.locateElementByXPath(pushStatusXpath));
+  }
+
+  @When("Select {string} pipeline and pull")
+  public void pullPipelineInRemotePage(String pipeline) {
+    ElementHelper.clickOnElement(Helper.locateElementByTestId("remote-" + pipeline));
+    ElementHelper.clickOnElement(Helper.locateElementByTestId("remote-pull-button"));
+  }
+
+  @Then("Pull success indicator is shown for pipeline {string}")
+  public void verifyPullSuccessInRemoteTable(String pipeline) {
+    String pushStatusXpath = String.format(
+        "//*[@data-testid=\"remote-%s\"]//*[@data-testid=\"pull-success-status\"]",
+        pipeline
+    );
+    ElementHelper.isElementDisplayed(Helper.locateElementByXPath(pushStatusXpath));
+  }
 }

--- a/src/e2e-test/java/io/cdap/cdap/ui/utils/Constants.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/utils/Constants.java
@@ -33,6 +33,7 @@ public class Constants {
   public static final String CDAP_URL = BASE_URL + "/cdap";
   public static final String CONFIGURATION_URL = BASE_URL + "/cdap/administration/configuration";
   public static final String SOURCE_CONTROL_MANAGEMENT_URL = BASE_URL + "/cdap/ns/default/details/scm";
+  public static final String SOURCE_CONTROL_SYNC_URL = BASE_URL + "/cdap/ns/default/scm/sync";
   public static final String NAMESPACE_URL = BASE_URL + "/cdap/ns";
   public static final String BASE_STUDIO_URL = BASE_URL + "/cdap/ns/default/";
   public static final String SYSTEM_PROFILES_CREATE_URL = BASE_URL + "/cdap/ns/system/profiles/create";


### PR DESCRIPTION
# Add e2e test pull/push from scm sync page happy path

Added e2e test for CUJ where user 
- pushes a pipeline to git from remote sync page
- deletes the pipeline locally 
- finally pulling it again from remote repo in remote sync page

## Description
Summary of changes

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [x] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20345](https://cdap.atlassian.net/browse/CDAP-20435)


## Test Plan
Github action pipeline

## Screenshots




[CDAP-20345]: https://cdap.atlassian.net/browse/CDAP-20345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ