### PR TITLE
chore(CDAP-20459): use non-directional "Connected" status in UI

### DIFF
--- a/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsMetadata.tsx
+++ b/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsMetadata.tsx
@@ -122,7 +122,7 @@ const PipelineDetailsMetadata = ({
             target={() => (
               <StyledChip
                 variant="outlined"
-                label={T.translate(`${SCM_PREFIX}.table.connected`)}
+                label={T.translate(`${SCM_PREFIX}.table.gitStatus`)}
                 onClick={() => pullPipeline(getCurrentNamespace(), name)}
               />
             )}

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -3189,9 +3189,9 @@ features:
       searchLabel: Search by batch pipeline name
       tab: Local pipelines
     table:
-      connected: Connected to Git
+      connected: Connected
       pipelineName: Pipeline name
-      gitStatus: Pushed to Git
+      gitStatus: Connected to Git
       pullFail: Failed to pull this pipeline from remote.
       pushFail: Failed to push this pipeline to remote.
       synced: Synced


### PR DESCRIPTION
chore(CDAP-20459): use non-directional "Connected" status in UI

Because the filehash can be generated both in pull and push, we should use non-directional wording

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [Jira issue #](fill-in.org)

## Test Plan

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/20428112/225764346-be08dd9a-583a-4eb6-a43b-bfbdfcffaca6.png)


After: 
![image](https://user-images.githubusercontent.com/20428112/225764262-5e070543-ff3c-4c90-8811-86033ba5dafc.png)
