### PR TITLE
[CDAP-20450] fix text go outside of the box

### DIFF
--- a/app/cdap/components/StatusButton/styles.tsx
+++ b/app/cdap/components/StatusButton/styles.tsx
@@ -51,6 +51,7 @@ export const StyledButton = styled(Button)`
 
 export const StyledP = styled.p`
   margin-bottom: 0;
+  word-break: break-word;
 `;
 
 export const BoldP = styled.p`


### PR DESCRIPTION
# [CDAP-20450] fix text go outside of the box

## Description
This is the best I can do, even though the word breaks in between characters.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20450](https://cdap.atlassian.net/browse/CDAP-20450)

## Screenshots
![image](https://user-images.githubusercontent.com/98125204/226065681-9efa6861-1ef4-46c0-87b4-740fe9745066.png)




[CDAP-20450]: https://cdap.atlassian.net/browse/CDAP-20450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20450]: https://cdap.atlassian.net/browse/CDAP-20450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ