### PR TITLE
Add bigdecimal scale and rounding modes

### DIFF
--- a/app/cdap/components/DataPrep/Directives/ChangeDataType/ChangeDataType.scss
+++ b/app/cdap/components/DataPrep/Directives/ChangeDataType/ChangeDataType.scss
@@ -23,6 +23,7 @@
         padding: 0;
 
         .option {
+          position: relative;
           padding: 5px 10px;
           cursor: pointer;
           line-height: 1.5;

--- a/app/cdap/components/DataPrep/Directives/ChangeDataType/DecimalOptions.tsx
+++ b/app/cdap/components/DataPrep/Directives/ChangeDataType/DecimalOptions.tsx
@@ -18,11 +18,6 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import T from 'i18n-react';
 
-import {
-  ISubmenuProps,
-  SubmenuContainer,
-} from 'components/DataPrep/Directives/ChangeDataType/submenu';
-
 import { makeStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
 import FormControl from '@material-ui/core/FormControl';
@@ -36,6 +31,15 @@ import MenuItem from '@material-ui/core/MenuItem';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import Button from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
+
+import {
+  ISubmenuProps,
+  SubmenuContainer,
+} from 'components/DataPrep/Directives/ChangeDataType/submenu';
+import {
+  FormContainer,
+  ButtonsContainer,
+} from 'components/DataPrep/Directives/ChangeDataType/styles';
 
 const PREFIX = 'features.DataPrep.Directives.ChangeDataType.decimalConfig';
 const ROUNDING_PREFIX = `${PREFIX}.roundingOptions`;
@@ -108,7 +112,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export const DecimalOptions: React.FC<ISubmenuProps> = ({ onApply, onCancel }) => {
+export const DecimalOptions = ({ onApply, onCancel }: ISubmenuProps): JSX.Element => {
   const [scale, setScale] = useState<string>('');
   const [rounding, setRounding] = useState<string>('');
 
@@ -236,58 +240,3 @@ export const DecimalOptions: React.FC<ISubmenuProps> = ({ onApply, onCancel }) =
     </SubmenuContainer>
   );
 };
-
-const FormContainer = styled.div`
-  width: fit-content;
-  padding: 16px;
-
-  .MuiFormControl-root {
-    margin-bottom: 16px;
-
-    .MuiFormHelperText-root {
-      font-size: 12px;
-    }
-
-    fieldset legend {
-      font-size: 13px;
-    }
-  }
-
-  .MuiOutlinedInput-root {
-    width: 300px;
-    height: 39px;
-    font-size: 13px;
-  }
-
-  .MuiOutlinedInput-input {
-    padding: 13px 14px;
-    width: 100%;
-    padding-right: 0;
-  }
-
-  .MuiInputLabel-formControl.MuiInputLabel-shrink {
-    transform: translate(14px, -7px) scale(1);
-  }
-
-  .MuiInputLabel-outlined {
-    transform: translate(14px, 13px) scale(1);
-  }
-
-  .MuiInputLabel-root {
-    font-size: 13px;
-  }
-
-  .MuiSelect-root {
-    position: relative;
-  }
-
-  .MuiSelect-icon.MuiSelect-iconOutlined {
-    right: 50px;
-    top: calc(50% - 10px);
-  }
-`;
-
-const ButtonsContainer = styled.div`
-  display: flex;
-  gap: 10px;
-`;

--- a/app/cdap/components/DataPrep/Directives/ChangeDataType/DecimalOptions.tsx
+++ b/app/cdap/components/DataPrep/Directives/ChangeDataType/DecimalOptions.tsx
@@ -1,0 +1,293 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import T from 'i18n-react';
+
+import {
+  ISubmenuProps,
+  SubmenuContainer,
+} from 'components/DataPrep/Directives/ChangeDataType/submenu';
+
+import { makeStyles } from '@material-ui/core/styles';
+import Paper from '@material-ui/core/Paper';
+import FormControl from '@material-ui/core/FormControl';
+import InputLabel from '@material-ui/core/InputLabel';
+import OutlinedInput from '@material-ui/core/OutlinedInput';
+import InputAdornment from '@material-ui/core/InputAdornment';
+import IconButton from '@material-ui/core/IconButton';
+import HelpIcon from '@material-ui/icons/Help';
+import Select from '@material-ui/core/Select';
+import MenuItem from '@material-ui/core/MenuItem';
+import FormHelperText from '@material-ui/core/FormHelperText';
+import Button from '@material-ui/core/Button';
+import Tooltip from '@material-ui/core/Tooltip';
+
+const PREFIX = 'features.DataPrep.Directives.ChangeDataType.decimalConfig';
+const ROUNDING_PREFIX = `${PREFIX}.roundingOptions`;
+
+const ID_PREFIX = 'DataPrep-Directives-ChangeDataType-decimal';
+
+const SCALE_INPUT_ID = `${ID_PREFIX}-scaleInputId`;
+const ROUNDING_INPUT_ID = `${ID_PREFIX}-roundingInputId`;
+const ROUNDING_LABEL_ID = `${ID_PREFIX}-roundingLableId`;
+
+interface IRoundingMode {
+  value: string;
+  text: string;
+  description?: string;
+}
+
+const ROUNDING_MODES: IRoundingMode[] = [
+  {
+    value: 'CEILING',
+    text: T.translate(`${ROUNDING_PREFIX}.CEILING.label`).toString(),
+    description: T.translate(`${ROUNDING_PREFIX}.CEILING.description`).toString(),
+  },
+  {
+    value: 'DOWN',
+    text: T.translate(`${ROUNDING_PREFIX}.DOWN.label`).toString(),
+    description: T.translate(`${ROUNDING_PREFIX}.DOWN.description`).toString(),
+  },
+  {
+    value: 'FLOOR',
+    text: T.translate(`${ROUNDING_PREFIX}.FLOOR.label`).toString(),
+    description: T.translate(`${ROUNDING_PREFIX}.FLOOR.description`).toString(),
+  },
+  {
+    value: 'HALF_DOWN',
+    text: T.translate(`${ROUNDING_PREFIX}.HALF_DOWN.label`).toString(),
+    description: T.translate(`${ROUNDING_PREFIX}.HALF_DOWN.description`).toString(),
+  },
+  {
+    value: 'HALF_EVEN',
+    text: T.translate(`${ROUNDING_PREFIX}.HALF_EVEN.label`).toString(),
+    description: T.translate(`${ROUNDING_PREFIX}.HALF_EVEN.description`).toString(),
+  },
+  {
+    value: 'HALF_UP',
+    text: T.translate(`${ROUNDING_PREFIX}.HALF_UP.label`).toString(),
+    description: T.translate(`${ROUNDING_PREFIX}.HALF_UP.description`).toString(),
+  },
+  {
+    value: 'UNNECESSARY',
+    text: T.translate(`${ROUNDING_PREFIX}.UNNECESSARY.label`).toString(),
+    description: T.translate(`${ROUNDING_PREFIX}.UNNECESSARY.description`).toString(),
+  },
+  {
+    value: 'UP',
+    text: T.translate(`${ROUNDING_PREFIX}.UP.label`).toString(),
+    description: T.translate(`${ROUNDING_PREFIX}.UP.description`).toString(),
+  },
+];
+
+const useStyles = makeStyles((theme) => ({
+  customTooltip: {
+    maxWidth: 300,
+    background: 'rgba(0, 0, 0, 0.8)',
+    fontSize: '11px',
+  },
+  customTooltipArrow: {
+    '&::before': {
+      backgroundColor: 'rgba(0, 0, 0, 0.8)',
+    },
+  },
+}));
+
+export const DecimalOptions: React.FC<ISubmenuProps> = ({ onApply, onCancel }) => {
+  const [scale, setScale] = useState<string>('');
+  const [rounding, setRounding] = useState<string>('');
+
+  const classes = useStyles();
+  const isRoundingDisabled = scale === '';
+
+  function handleScaleChange(event) {
+    const val = event.target.value;
+    setScale(val);
+  }
+
+  function handleRoundingChange(event) {
+    const val = event.target.value;
+    setRounding(val);
+  }
+
+  function applyDirective() {
+    const option = 'decimal';
+    const extraArgs = scale !== '' ? `${scale} ${rounding || 'HALF_EVEN'}` : '';
+    return onApply(option, extraArgs);
+  }
+
+  return (
+    <SubmenuContainer>
+      <Paper elevation={3}>
+        <FormContainer>
+          <FormControl variant="outlined">
+            <InputLabel htmlFor={SCALE_INPUT_ID}>{T.translate(`${PREFIX}.scaleLabel`)}</InputLabel>
+            <OutlinedInput
+              fullWidth
+              labelWidth={42}
+              id={SCALE_INPUT_ID}
+              type="number"
+              value={scale}
+              onChange={handleScaleChange}
+              endAdornment={
+                <InputAdornment position="end">
+                  <Tooltip
+                    arrow
+                    enterDelay={500}
+                    title={T.translate(`${PREFIX}.scaleTooltip`).toString()}
+                    classes={{ tooltip: classes.customTooltip, arrow: classes.customTooltipArrow }}
+                  >
+                    <IconButton
+                      aria-label={T.translate(`${PREFIX}.scaleHelpButton`).toString()}
+                      edge="end"
+                    >
+                      <HelpIcon />
+                    </IconButton>
+                  </Tooltip>
+                </InputAdornment>
+              }
+            />
+            <FormHelperText>{T.translate(`${PREFIX}.scaleHelperText`)}</FormHelperText>
+          </FormControl>
+          <Tooltip
+            arrow
+            placement="top"
+            disableFocusListener={!isRoundingDisabled}
+            disableHoverListener={!isRoundingDisabled}
+            disableTouchListener={!isRoundingDisabled}
+            title={T.translate(`${PREFIX}.roundingDisabledTooltip`).toString()}
+            classes={{ tooltip: classes.customTooltip, arrow: classes.customTooltipArrow }}
+          >
+            <FormControl variant="outlined" disabled={isRoundingDisabled}>
+              <InputLabel id={ROUNDING_LABEL_ID} htmlFor={ROUNDING_INPUT_ID}>
+                {T.translate(`${PREFIX}.roundingLabel`)}
+              </InputLabel>
+              <Select
+                labelId={ROUNDING_LABEL_ID}
+                id={ROUNDING_INPUT_ID}
+                value={rounding}
+                onChange={handleRoundingChange}
+                label={T.translate(`${PREFIX}.roundingLabel`)}
+                endAdornment={
+                  <InputAdornment position="end">
+                    <Tooltip
+                      arrow
+                      enterDelay={500}
+                      title={T.translate(`${PREFIX}.roundingTooltip`).toString()}
+                      classes={{
+                        tooltip: classes.customTooltip,
+                        arrow: classes.customTooltipArrow,
+                      }}
+                    >
+                      <IconButton
+                        aria-label={T.translate(`${PREFIX}.roundingHelpButton`).toString()}
+                        edge="end"
+                      >
+                        <HelpIcon />
+                      </IconButton>
+                    </Tooltip>
+                  </InputAdornment>
+                }
+              >
+                {ROUNDING_MODES.map((mode: IRoundingMode) => (
+                  <MenuItem value={mode.value} key={mode.value}>
+                    <Tooltip
+                      arrow
+                      enterDelay={500}
+                      title={mode.description}
+                      classes={{
+                        tooltip: classes.customTooltip,
+                        arrow: classes.customTooltipArrow,
+                      }}
+                    >
+                      <span>{mode.text}</span>
+                    </Tooltip>
+                  </MenuItem>
+                ))}
+              </Select>
+              <FormHelperText>{T.translate(`${PREFIX}.roundingHelperText`)}</FormHelperText>
+            </FormControl>
+          </Tooltip>
+          <ButtonsContainer>
+            <Button variant="contained" color="primary" disableElevation onClick={applyDirective}>
+              {T.translate(`${PREFIX}.applyButton`)}
+            </Button>
+            <Button color="primary" onClick={onCancel}>
+              {T.translate(`${PREFIX}.cancelButton`)}
+            </Button>
+          </ButtonsContainer>
+        </FormContainer>
+      </Paper>
+    </SubmenuContainer>
+  );
+};
+
+const FormContainer = styled.div`
+  width: fit-content;
+  padding: 16px;
+
+  .MuiFormControl-root {
+    margin-bottom: 16px;
+
+    .MuiFormHelperText-root {
+      font-size: 12px;
+    }
+
+    fieldset legend {
+      font-size: 13px;
+    }
+  }
+
+  .MuiOutlinedInput-root {
+    width: 300px;
+    height: 39px;
+    font-size: 13px;
+  }
+
+  .MuiOutlinedInput-input {
+    padding: 13px 14px;
+    width: 100%;
+    padding-right: 0;
+  }
+
+  .MuiInputLabel-formControl.MuiInputLabel-shrink {
+    transform: translate(14px, -7px) scale(1);
+  }
+
+  .MuiInputLabel-outlined {
+    transform: translate(14px, 13px) scale(1);
+  }
+
+  .MuiInputLabel-root {
+    font-size: 13px;
+  }
+
+  .MuiSelect-root {
+    position: relative;
+  }
+
+  .MuiSelect-icon.MuiSelect-iconOutlined {
+    right: 50px;
+    top: calc(50% - 10px);
+  }
+`;
+
+const ButtonsContainer = styled.div`
+  display: flex;
+  gap: 10px;
+`;

--- a/app/cdap/components/DataPrep/Directives/ChangeDataType/__test__/DecimalOptions.test.tsx
+++ b/app/cdap/components/DataPrep/Directives/ChangeDataType/__test__/DecimalOptions.test.tsx
@@ -37,11 +37,17 @@ describe('DecimalOptions component', () => {
   const FLOOR = T.translate(`${PREFIX}.roundingOptions.FLOOR.label`).toString();
   const APPLY = T.translate(`${PREFIX}.applyButton`).toString();
 
-  let submenu, onApply, onCancel;
+  let submenu;
+  let onApply;
+  let onCancel;
 
   beforeEach(() => {
-    onApply = jest.fn((option: string, extraArgs?: string): void => {});
-    onCancel = jest.fn((event: React.MouseEvent<HTMLElement>): void => {});
+    onApply = jest.fn((option: string, extraArgs?: string): void => {
+      return;
+    });
+    onCancel = jest.fn((event: React.MouseEvent<HTMLElement>): void => {
+      return;
+    });
     submenu = render(<DecimalOptions onApply={onApply} onCancel={onCancel} />);
   });
 

--- a/app/cdap/components/DataPrep/Directives/ChangeDataType/__test__/DecimalOptions.test.tsx
+++ b/app/cdap/components/DataPrep/Directives/ChangeDataType/__test__/DecimalOptions.test.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import T from 'i18n-react';
+import { DecimalOptions } from 'components/DataPrep/Directives/ChangeDataType/DecimalOptions';
+
+const PREFIX = 'features.DataPrep.Directives.ChangeDataType.decimalConfig';
+const ROUNDING_OPTIONS = ['CEILING', 'DOWN', 'FLOOR', 'HALF_DOWN', 'HALF_EVEN', 'HALF_UP', 'UNNECESSARY', 'UP'];
+
+describe('DecimalOptions component', () => {
+  const SCALE_LABEL = T.translate(`${PREFIX}.scaleLabel`).toString();
+  const ROUNDING_LABEL = T.translate(`${PREFIX}.roundingLabel`).toString();
+  const FLOOR = T.translate(`${PREFIX}.roundingOptions.FLOOR.label`).toString();
+  const APPLY = T.translate(`${PREFIX}.applyButton`).toString();
+
+  let submenu, onApply, onCancel;
+
+  beforeEach(() => {
+    onApply = jest.fn((option: string, extraArgs?: string): void => {});
+    onCancel = jest.fn((event: React.MouseEvent<HTMLElement>): void => {});
+    submenu = render(<DecimalOptions onApply={onApply} onCancel={onCancel} />);
+  });
+
+  it('should render a number input for scale and a select dropdown for rounding mode', () => {
+    const scaleInput = submenu.getByLabelText(SCALE_LABEL);
+    const roundingInput = submenu.getByLabelText(ROUNDING_LABEL);
+
+    expect(scaleInput).toBeVisible();
+    expect(scaleInput).toBeEnabled();
+    expect(scaleInput).toHaveAttribute('type', 'number');
+
+    // Rounding mode select dropdown should be disabled initially as no scale
+    // has been specified yet.
+    expect(roundingInput).toBeVisible();
+    expect(roundingInput).toHaveClass('Mui-disabled');
+  });
+
+  it('should enable the rounding mode input only when scale is specified', () => {
+    const scaleInput = submenu.getByLabelText(SCALE_LABEL);
+    const roundingInput = submenu.getByLabelText(ROUNDING_LABEL);
+
+    expect(roundingInput).toHaveClass('Mui-disabled');
+    fireEvent.change(scaleInput, { target: { value: '4' } });
+    expect(roundingInput).not.toHaveClass('Mui-disabled');
+
+    fireEvent.mouseDown(roundingInput);
+    const listbox = within(screen.getByRole('presentation')).getByRole('listbox');
+    const options = within(listbox).getAllByRole('option');
+    const optionValues = options.map((li) => li.getAttribute('data-value'));
+
+    // The roundig modes select menu should have the 8 rounding modes
+    // in any order
+    expect(optionValues).toHaveLength(8);
+    ROUNDING_OPTIONS.forEach((opt) => expect(optionValues).toContain(opt));
+
+    fireEvent.change(scaleInput, { target: { value: '' } });
+    expect(roundingInput).toHaveClass('Mui-disabled');
+  });
+
+  it('should pass correct args to the directive on apply', () => {
+    const scaleInput = submenu.getByLabelText(SCALE_LABEL);
+    const roundingInput = submenu.getByLabelText(ROUNDING_LABEL);
+
+    fireEvent.change(scaleInput, { target: { value: '4' } });
+    fireEvent.mouseDown(roundingInput);
+    fireEvent.click(submenu.getByText(FLOOR));
+    fireEvent.click(submenu.getByText(APPLY));
+
+    expect(onApply.mock.calls).toHaveLength(1);
+    expect(onApply.mock.calls[0]).toHaveLength(2);
+    expect(onApply.mock.calls[0][0]).toBe('decimal');
+    expect(onApply.mock.calls[0][1]).toBe('4 FLOOR');
+  });
+
+  it('should default rouding mode to HALF_EVEN if scale is specified and rounding mode is not specified', () => {
+    const scaleInput = submenu.getByLabelText(SCALE_LABEL);
+    fireEvent.change(scaleInput, { target: { value: '2' } });
+    fireEvent.click(submenu.getByText(APPLY));
+
+    expect(onApply.mock.calls).toHaveLength(1);
+    expect(onApply.mock.calls[0]).toHaveLength(2);
+    expect(onApply.mock.calls[0][0]).toBe('decimal');
+    expect(onApply.mock.calls[0][1]).toBe('2 HALF_EVEN');
+  });
+
+  it('should not add any extra args if scale is not specified', () => {
+    fireEvent.click(submenu.getByText(APPLY));
+    expect(onApply.mock.calls).toHaveLength(1);
+    expect(onApply.mock.calls[0]).toHaveLength(2);
+    expect(onApply.mock.calls[0][0]).toBe('decimal');
+    expect(onApply.mock.calls[0][1]).toBe('');
+  });
+});

--- a/app/cdap/components/DataPrep/Directives/ChangeDataType/__test__/DecimalOptions.test.tsx
+++ b/app/cdap/components/DataPrep/Directives/ChangeDataType/__test__/DecimalOptions.test.tsx
@@ -20,7 +20,16 @@ import T from 'i18n-react';
 import { DecimalOptions } from 'components/DataPrep/Directives/ChangeDataType/DecimalOptions';
 
 const PREFIX = 'features.DataPrep.Directives.ChangeDataType.decimalConfig';
-const ROUNDING_OPTIONS = ['CEILING', 'DOWN', 'FLOOR', 'HALF_DOWN', 'HALF_EVEN', 'HALF_UP', 'UNNECESSARY', 'UP'];
+const ROUNDING_OPTIONS = [
+  'CEILING',
+  'DOWN',
+  'FLOOR',
+  'HALF_DOWN',
+  'HALF_EVEN',
+  'HALF_UP',
+  'UNNECESSARY',
+  'UP',
+];
 
 describe('DecimalOptions component', () => {
   const SCALE_LABEL = T.translate(`${PREFIX}.scaleLabel`).toString();

--- a/app/cdap/components/DataPrep/Directives/ChangeDataType/styles.ts
+++ b/app/cdap/components/DataPrep/Directives/ChangeDataType/styles.ts
@@ -1,0 +1,56 @@
+import styled from 'styled-components';
+
+export const FormContainer = styled.div`
+  width: fit-content;
+  padding: 16px;
+
+  .MuiFormControl-root {
+    margin-bottom: 16px;
+
+    .MuiFormHelperText-root {
+      font-size: 12px;
+    }
+
+    fieldset legend {
+      font-size: 13px;
+    }
+  }
+
+  .MuiOutlinedInput-root {
+    width: 300px;
+    height: 39px;
+    font-size: 13px;
+  }
+
+  .MuiOutlinedInput-input {
+    padding: 13px 14px;
+    width: 100%;
+    padding-right: 0;
+  }
+
+  .MuiInputLabel-formControl.MuiInputLabel-shrink {
+    transform: translate(14px, -7px) scale(1);
+  }
+
+  .MuiInputLabel-outlined {
+    transform: translate(14px, 13px) scale(1);
+  }
+
+  .MuiInputLabel-root {
+    font-size: 13px;
+  }
+
+  .MuiSelect-root {
+    position: relative;
+  }
+
+  .MuiSelect-icon.MuiSelect-iconOutlined {
+    right: 50px;
+    top: calc(50% - 10px);
+  }
+`;
+
+export const ButtonsContainer = styled.div`
+  display: flex;
+  gap: 10px;
+`;

--- a/app/cdap/components/DataPrep/Directives/ChangeDataType/submenu.ts
+++ b/app/cdap/components/DataPrep/Directives/ChangeDataType/submenu.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React from 'react';
+import styled from 'styled-components';
+
+export interface ISubmenuProps {
+  onApply(option: string, extraArgs?: string): void;
+  onCancel(event: React.MouseEvent<HTMLElement>): void;
+}
+
+export const SubmenuContainer = styled.div`
+  position: absolute;
+  left: 100%;
+  top: 0;
+`;

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -757,6 +757,43 @@ features:
           string: String
           decimal: Decimal
         title: Change data type
+        decimalConfig:
+          applyButton: APPLY
+          cancelButton: CANCEL
+          scaleLabel: Scale
+          scaleHelpButton: Tooltip for scale input
+          scaleHelperText: Define scale here
+          scaleTooltip: Specifies the scale of the decimal. If zero or positive, the scale is the number of digits to the right of the decimal point. If negative, the unscaled value of the number is multiplied by ten to the power of the negation of the scale.
+          roundingLabel: Rounding
+          roundingHelpButton: Tooltip for rounding mode
+          roundingHelperText: Rounding modes
+          roundingDisabledTooltip: Rounding mode is disabled when scale is not specified.
+          roundingTooltip: Specifies a rounding behavior for numerical operations. Each rounding mode indicates how the least significant returned digit of a rounded result is to be calculated. If scale is specified and rounding mode is not specified, then rounding mode defaults to HALF_EVEN.
+          roundingOptions:
+            CEILING:
+              label: Ceiling
+              description: Rounding mode to round towards positive infinity.
+            DOWN:
+              label: Down
+              description: Rounding mode to round towards zero.
+            FLOOR:
+              label: Floor
+              description: Rounding mode to round towards negative infinity.
+            HALF_DOWN:
+              label: Half down
+              description: Rounding mode to round towards "nearest neighbor" unless both neighbors are equidistant, in which case round down.
+            HALF_EVEN:
+              label: Half even
+              description: Rounding mode to round towards the "nearest neighbor" unless both neighbors are equidistant, in which case, round towards the even neighbor.
+            HALF_UP:
+              label: Half up
+              description: Rounding mode to round towards "nearest neighbor" unless both neighbors are equidistant, in which case round up.
+            UNNECESSARY:
+              label: Unnecessary
+              description: Rounding mode to assert that the requested operation has an exact result, hence no rounding is necessary.
+            UP:
+              label: Up
+              description: Rounding mode to round away from zero.
       ColumnActions:
         label: Column names
         actions:


### PR DESCRIPTION
# Add bigdecimal scale and rounding modes in the ChangeDataType directive

## Description
Support for specifying scale and rounding mode in `set-type` directive was added in the PR https://github.com/data-integrations/wrangler/pull/609 . This PR, i.e. https://github.com/cdapio/cdap-ui/pull/948 adds support for decimal scale and rounding mode in the `ChangeDataType` directive in the `ColumnActionsDropdown`.

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [x] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: https://cdap.atlassian.net/browse/CDAP-20484

## Test Plan

+ unit tests for the new component to set scale and rounding mode are added in this PR.
+ e2e tests are not automated yet. The feature was tested manually.

## Screenshots

<img width="739" alt="Screenshot 2023-03-21 at 6 11 37 PM" src="https://user-images.githubusercontent.com/4161531/226609024-511fa91e-a2b7-450e-991c-068a5f23c2b7.png">
