### PR TITLE
[CDAP-20474-20475] (fix) LCM config description and some other styles

### DIFF
--- a/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/PipelineDetailsDetailsActions.scss
+++ b/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/PipelineDetailsDetailsActions.scss
@@ -17,7 +17,8 @@
 @import "../../../../styles/variables.scss";
 
 .pipeline-details-details-actions {
-  justify-content: center;
+  justify-content: end;
+  margin-right: 80px;
   .pipeline-details-container {
     .pipeline-details-btn {
       .icon-info-circle {

--- a/app/cdap/components/hydrator/components/TopPanel/TopPanel.tsx
+++ b/app/cdap/components/hydrator/components/TopPanel/TopPanel.tsx
@@ -328,7 +328,8 @@ export const TopPanel = ({
     // first time execute before interval
     MyPipelineApi.get(params).subscribe(
       (res) => {
-        setParentConfig(JSON.parse(res.configuration));
+        // add description in case it is missing from configuration
+        setParentConfig({ ...JSON.parse(res.configuration), description: res.description });
         if (res.appVersion === getParentVersion()) {
           setEditStatus('Editing in progress');
           return;


### PR DESCRIPTION
# [CDAP-20474-20475] (fix) LCM config description and some other styles

## Description
After you deploy a pipeline without a description, when you get the pipeline, the response object will contain a description field, whereas the actual configuration does not. So checking no change will not work properly in this case.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [x] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20474](https://cdap.atlassian.net/browse/CDAP-20474)
[CDAP-20475](https://cdap.atlassian.net/browse/CDAP-20475)

## Screenshots
![image](https://user-images.githubusercontent.com/98125204/226711284-f612218b-42ee-4af9-99e7-c4ca8b95797c.png)




[CDAP-20474]: https://cdap.atlassian.net/browse/CDAP-20474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20475]: https://cdap.atlassian.net/browse/CDAP-20475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ