### PR TITLE
Add ability to use google tag manager (google analytics v4)

### DIFF
--- a/server/config/development/cdap.json
+++ b/server/config/development/cdap.json
@@ -13,5 +13,8 @@
   "dashboard.router.check.timeout.secs": "0",
   "market.base.url": "https://hub.cdap.io/dev/v2",
   "ui.theme.file": "config/themes/default.json",
-  "session.secret.key": "sample-secret-key-for-encryption"
+  "session.secret.key": "sample-secret-key-for-encryption",
+  "feature.lifecycle.management.edit.enabled": "true",
+  "ui.analyticsTag": "",
+  "ui.GTM": ""
 }


### PR DESCRIPTION
# Add ability to use google tag manager (GA v4)

## Description
Adds ability to use google tag manager if you include a google tag manager id in the config.

This allows us to track custom events based on css selectors etc from the analytics ui.

Helpful things for debugging - 
* make sure you're not filtering out develop traffic in google analytics
* turn off ublock origin or other add blockers
* use the google analytics extension to see events

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick



