### PR TITLE
[CDAP-20512] fix plugins not updating when toggling runs

### DIFF
--- a/app/hydrator/controllers/detail-ctrl.js
+++ b/app/hydrator/controllers/detail-ctrl.js
@@ -146,6 +146,9 @@ angular.module(PKG.name + '.feature.hydrator')
       if (currentRun && currentRun.runid !== latestRun.runid) {
         pipelineMetricsActionCreator.reset();
         let pipelineConfig = window.CaskCommon.PipelineDetailStore.getState().config;
+        // set new available plugins
+        const pluginsToFetchDetailsFor = pipelineConfig.stages.concat(pipelineConfig.postActions || []);
+        PipelineAvailablePluginsActions.fetchPluginsForDetails($stateParams.namespace, pluginsToFetchDetailsFor);
         let nodes = this.HydratorPlusPlusHydratorService.getNodesFromStages(pipelineConfig.stages);
         this.DAGPlusPlusNodesStore.setNodes(nodes);
         this.DAGPlusPlusNodesStore.setConnections(pipelineConfig.connections);

--- a/app/hydrator/controllers/detail/canvas-ctrl.js
+++ b/app/hydrator/controllers/detail/canvas-ctrl.js
@@ -65,6 +65,9 @@ angular.module(PKG.name + '.feature.hydrator')
     };
 
     this.setActiveNode = function() {
+      // need to use new config and nodes
+      pipelineConfig = this.PipelineDetailStore.getState().config;
+      nodes = this.HydratorPlusPlusHydratorService.getNodesFromStages(pipelineConfig.stages);
       var nodeId = this.DAGPlusPlusNodesStore.getActiveNodeId();
       if (!nodeId) {
         return;


### PR DESCRIPTION
# [CDAP-20512] fix plugins not updating when toggling runs

## Description
Previously properties nodes were not updated when toggling runs, so the UI shows the unchanged config

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20512](https://cdap.atlassian.net/browse/CDAP-20512)

## Test Plan
add additional e2e test


https://user-images.githubusercontent.com/98125204/228968971-d2f744b5-be91-40ea-860e-8346abbc6ad7.mov






[CDAP-20512]: https://cdap.atlassian.net/browse/CDAP-20512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20512]: https://cdap.atlassian.net/browse/CDAP-20512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ