### PR TITLE
Update entity top panel styles

### DIFF
--- a/app/cdap/components/EntityTopPanel/EntityBreadCrumb.tsx
+++ b/app/cdap/components/EntityTopPanel/EntityBreadCrumb.tsx
@@ -18,13 +18,20 @@ import * as React from 'react';
 import makeStyle from '@material-ui/core/styles/makeStyles';
 import { Theme } from '@material-ui/core';
 import { Link } from 'react-router-dom';
+import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
+import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 
 const useStyle = makeStyle<Theme>((theme) => {
   return {
     root: {
-      alignSelf: 'center',
+      alignSelf: 'stretch',
+      display: 'flex',
+      alignItems: 'stretch',
     },
     linkContainer: {
+      height: '100%',
+      display: 'inline-flex',
+      alignItems: 'center',
       color: 'rgba(0, 0, 0, 0.6)',
       cursor: 'pointer',
       '& :hover': {
@@ -35,7 +42,15 @@ const useStyle = makeStyle<Theme>((theme) => {
       marginRight: '5px',
     },
     divider: {
+      height: '100%',
       margin: '0 10px',
+      display: 'inline-flex',
+      alignItems: 'center',
+    },
+    backDivider: {
+      height: '100%',
+      margin: '0 10px',
+      borderRight: '1px #cccccc solid',
     },
   };
 });
@@ -71,9 +86,16 @@ export function EntityBreadCrumb({
   return (
     <div className={classes.root}>
       <Tag to={breadCrumbAnchorLink} onClick={onClickHandler} className={classes.linkContainer}>
+        {historyBack && <ChevronLeftIcon fontSize="inherit" />}
         <span>{breadCrumbAnchorLabel}</span>
       </Tag>
-      <span className={classes.divider}> {'>'} </span>
+      {historyBack ? (
+        <span className={classes.backDivider} />
+      ) : (
+        <span className={classes.divider}>
+          <ChevronRightIcon fontSize="inherit" />
+        </span>
+      )}
     </div>
   );
 }

--- a/app/cdap/components/EntityTopPanel/EntityTitle.tsx
+++ b/app/cdap/components/EntityTopPanel/EntityTitle.tsx
@@ -36,6 +36,7 @@ const useStyle = makeStyle<Theme, { multiline: boolean }>((theme) => {
     },
     entityTypeText: {
       verticalAlign: 'middle',
+      marginLeft: '5px',
     },
   };
 });

--- a/app/cdap/components/FieldLevelLineage/v2/TopPanel/index.tsx
+++ b/app/cdap/components/FieldLevelLineage/v2/TopPanel/index.tsx
@@ -23,12 +23,16 @@ import T from 'i18n-react';
 const styles = (theme) => {
   return {
     root: {
-      height: 60,
       background: theme.palette.white[50],
       display: 'grid',
-      gridTemplateColumns: 'auto 342px',
+      gridTemplateColumns: 'auto 190px',
+      marginBottom: '10px',
+      padding: '5px 0',
     },
     picker: {
+      height: '100%',
+      display: 'flex',
+      alignItems: 'center',
       marginTop: '2px',
     },
   };


### PR DESCRIPTION
# Update EntityTopPanel styles 

## Description
Minor UI updates for EntityTopPanel component.
+ update the spacing between the breadcrumb segments
+ use chevron icons instead of '>' for breadcrumb divider 

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [x] General Improvement
- [ ] Cherry Pick

## Links
Jira: [Jira #20529](https://cdap.atlassian.net/browse/CDAP-20529)

## Test Plan
Manually verified

## Screenshots
#### Before
![Screenshot 2023-04-03 at 1 51 56 PM](https://user-images.githubusercontent.com/4161531/229453761-f2a052ba-8e27-4ec9-806f-1915d73796ea.png)
![Screenshot 2023-04-03 at 1 52 18 PM](https://user-images.githubusercontent.com/4161531/229453775-50d56471-a6c5-4ea1-9742-5528e36cfcb1.png)

#### After
![Screenshot 2023-04-03 at 1 50 55 PM](https://user-images.githubusercontent.com/4161531/229453853-63b0f09c-5bed-4a91-a426-0bdca7f44587.png)
![Screenshot 2023-04-03 at 1 51 22 PM](https://user-images.githubusercontent.com/4161531/229453862-68752283-3094-4e38-8379-86c92aeb7779.png)



