### PR TITLE
[CDAP-20538] fix stale comments when toggling runs

### DIFF
--- a/app/directives/dag-plus/my-dag-ctrl.js
+++ b/app/directives/dag-plus/my-dag-ctrl.js
@@ -1816,6 +1816,7 @@ angular.module(PKG.name + '.commons')
         conditionNodes = [];
         splitterNodesPorts = {};
         init();
+        vm.initPipelineComments();
       }
     }, true);
   });


### PR DESCRIPTION
# [CDAP-20538] fix stale comments when toggling runs

## Description
Add comments initialization for toggling runs so that the contents change.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20538](https://cdap.atlassian.net/browse/CDAP-20538)





[CDAP-20538]: https://cdap.atlassian.net/browse/CDAP-20538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20538]: https://cdap.atlassian.net/browse/CDAP-20538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ