### PR TITLE
[CDAP-20546] (fix) replicator deployed list is not showing connection 'from/to'

### DIFF
--- a/app/cdap/components/Replicator/List/Deployed/index.tsx
+++ b/app/cdap/components/Replicator/List/Deployed/index.tsx
@@ -95,6 +95,7 @@ const DeployedView: React.FC<WithStyles<typeof styles>> = ({ classes }) => {
       const batchDetailBody = list.map((replicator) => {
         return {
           appId: replicator.name,
+          version: replicator.version,
         };
       });
 


### PR DESCRIPTION
# [CDAP-20546] (fix) replicator deployed list is not showing connection 'from/to'

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20546](https://cdap.atlassian.net/browse/CDAP-20546)

## Screenshots
![image](https://user-images.githubusercontent.com/98125204/230502746-b105db98-ff1f-420c-8adb-432f28dd93e6.png)




[CDAP-20546]: https://cdap.atlassian.net/browse/CDAP-20546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20546]: https://cdap.atlassian.net/browse/CDAP-20546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ