### PR TITLE
[fix] add quotes in rounding mode

### DIFF
--- a/app/cdap/components/DataPrep/Directives/ChangeDataType/DecimalOptions.tsx
+++ b/app/cdap/components/DataPrep/Directives/ChangeDataType/DecimalOptions.tsx
@@ -131,7 +131,7 @@ export const DecimalOptions = ({ onApply, onCancel }: ISubmenuProps): JSX.Elemen
 
   function applyDirective() {
     const option = 'decimal';
-    const extraArgs = scale !== '' ? `${scale} ${rounding || 'HALF_EVEN'}` : '';
+    const extraArgs = scale !== '' ? `${scale} '${rounding || 'HALF_EVEN'}'` : '';
     return onApply(option, extraArgs);
   }
 

--- a/app/cdap/components/DataPrep/Directives/ChangeDataType/__test__/DecimalOptions.test.tsx
+++ b/app/cdap/components/DataPrep/Directives/ChangeDataType/__test__/DecimalOptions.test.tsx
@@ -99,7 +99,7 @@ describe('DecimalOptions component', () => {
     expect(onApply.mock.calls).toHaveLength(1);
     expect(onApply.mock.calls[0]).toHaveLength(2);
     expect(onApply.mock.calls[0][0]).toBe('decimal');
-    expect(onApply.mock.calls[0][1]).toBe('4 FLOOR');
+    expect(onApply.mock.calls[0][1]).toBe("4 'FLOOR'");
   });
 
   it('should default rouding mode to HALF_EVEN if scale is specified and rounding mode is not specified', () => {
@@ -110,7 +110,7 @@ describe('DecimalOptions component', () => {
     expect(onApply.mock.calls).toHaveLength(1);
     expect(onApply.mock.calls[0]).toHaveLength(2);
     expect(onApply.mock.calls[0][0]).toBe('decimal');
-    expect(onApply.mock.calls[0][1]).toBe('2 HALF_EVEN');
+    expect(onApply.mock.calls[0][1]).toBe("2 'HALF_EVEN'");
   });
 
   it('should not add any extra args if scale is not specified', () => {


### PR DESCRIPTION
# Add quotes in rounding mode

## Description
The set-type directive takes the rounding mode for decimal datatype as a string. Currently it's being passed as an identifier. This PR adds quotes around the rounding mode value to fix it.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [Jira issue #20552](https://cdap.atlassian.net/browse/CDAP-20552)

## Test Plan

To be tested manually.

## Screenshots


![Screenshot 2023-04-10 at 12 45 43 PM](https://user-images.githubusercontent.com/4161531/230848413-a5c5222e-4249-4eef-a5b7-d10562878e80.png)
