### PR TITLE
[CDAP-20551] (fix) remove spark config from auto gen args

### DIFF
--- a/app/cdap/components/PipelineConfigurations/ConfigurationsContent/EngineConfigTabContent/CustomConfig.js
+++ b/app/cdap/components/PipelineConfigurations/ConfigurationsContent/EngineConfigTabContent/CustomConfig.js
@@ -29,10 +29,11 @@ import { convertKeyValuePairsObjToMap } from 'components/shared/KeyValuePairs/Ke
 import T from 'i18n-react';
 import isEmpty from 'lodash/isEmpty';
 import cloneDeep from 'lodash/cloneDeep';
-import { GENERATED_RUNTIMEARGS } from 'services/global-constants';
 import { useFeatureFlagDefaultFalse } from 'services/react/customHooks/useFeatureFlag';
 
 const PREFIX = 'features.PipelineConfigurations.EngineConfig';
+
+const CUSTOM_SPARK_KEY_PREFIX = 'system.spark.';
 
 const getCustomConfigValue = (customConfigKeyValuePairs, runtimeArgs) => {
   // we want to try getting the custom config from runtimeargs
@@ -41,11 +42,11 @@ const getCustomConfigValue = (customConfigKeyValuePairs, runtimeArgs) => {
     return customConfigKeyValuePairs;
   }
   const customSparkConfigKeyValuePairs = runtimeArgs.pairs.filter((pair) =>
-    pair.key.startsWith(GENERATED_RUNTIMEARGS.CUSTOM_SPARK_KEY_PREFIX)
+    pair.key.startsWith(CUSTOM_SPARK_KEY_PREFIX)
   );
   const customSparkConfigPairs = cloneDeep(customSparkConfigKeyValuePairs);
   customSparkConfigPairs.forEach((pair) => {
-    const trimmedKey = pair.key.substring(GENERATED_RUNTIMEARGS.CUSTOM_SPARK_KEY_PREFIX.length);
+    const trimmedKey = pair.key.substring(CUSTOM_SPARK_KEY_PREFIX.length);
     pair.key = trimmedKey;
   });
   customSparkConfigPairs.push({
@@ -87,13 +88,13 @@ const mapDispatchToCustomConfigKeyValuesProps = (dispatch, ownProps) => {
         // delete previous tranformation pushdown key valur pairs from runtimeargs
         // so that we are not keeping outdated configs in the runtimeargs
         const previousCustomConfigKeyValuePair = runtimeArgs.pairs.filter((pair) =>
-          pair.key.startsWith(GENERATED_RUNTIMEARGS.CUSTOM_SPARK_KEY_PREFIX)
+          pair.key.startsWith(CUSTOM_SPARK_KEY_PREFIX)
         );
         previousCustomConfigKeyValuePair.forEach((pair) => {
           delete runtimeObj[pair.key];
         });
         keyValues.pairs.forEach((pair) => {
-          runtimeObj[GENERATED_RUNTIMEARGS.CUSTOM_SPARK_KEY_PREFIX + pair.key] = String(pair.value);
+          runtimeObj[CUSTOM_SPARK_KEY_PREFIX + pair.key] = String(pair.value);
         });
         const newRunTimePairs = convertMapToKeyValuePairs(runtimeObj);
         dispatch({

--- a/app/cdap/services/global-constants.js
+++ b/app/cdap/services/global-constants.js
@@ -354,7 +354,6 @@ const GENERATED_RUNTIMEARGS = {
   PIPELINE_INSTRUMENTATION: 'app.pipeline.instrumentation',
   PIPELINE_PUSHDOWN_ENABLED: 'app.pipeline.pushdownEnabled',
   PIPELINE_TRANSFORMATION_PUSHDOWN_PREFIX: 'app.pipeline.pushdown.',
-  CUSTOM_SPARK_KEY_PREFIX: 'system.spark.',
   SYSTEM_DRIVER_RESOURCES_MEMORY: 'task.driver.system.resources.memory',
   SYSTEM_DRIVER_RESOURCES_CORES: 'task.driver.system.resources.cores',
   SYSTEM_EXECUTOR_RESOURCES_MEMORY: 'task.executor.system.resources.memory',


### PR DESCRIPTION
# [CDAP-20551] (fix) remove spark config from auto gen args

## Description
Previously for LCM, we set `system.spark.` as an autogenerated runtimeargs, so that when the user enters it, it gets moved into the hidden autogenerated runtimeargs. Since the users will enter these key value pairs quite often, we should not treat them as autogenerated runtimeargs.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20551](https://cdap.atlassian.net/browse/CDAP-20551)





[CDAP-20551]: https://cdap.atlassian.net/browse/CDAP-20551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20551]: https://cdap.atlassian.net/browse/CDAP-20551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ