### PR TITLE
[CDAP-20569] add featureflag eval in plugin property filter

### DIFF
--- a/app/cdap/components/shared/ConfigurationGroup/utilities/DynamicPluginFilters.ts
+++ b/app/cdap/components/shared/ConfigurationGroup/utilities/DynamicPluginFilters.ts
@@ -99,8 +99,14 @@ export function evaluateFilter(
     return true;
   }
 
+  // convert string 'true' to boolean
+  const featureFlags = { ...window?.CDAP_CONFIG?.featureFlags };
+  for (const key in featureFlags) {
+    featureFlags[key] = featureFlags[key] === 'true';
+  }
   const typedPropertyValues = {
     ...getTypedPropertyValues(propertyValues, propertiesFromBackend),
+    featureFlags,
   };
 
   // Some upgrade scenarios leave useConnection as null,

--- a/app/cdap/components/shared/ConfigurationGroup/utilities/__tests__/DynamicPluginFilters.test.ts
+++ b/app/cdap/components/shared/ConfigurationGroup/utilities/__tests__/DynamicPluginFilters.test.ts
@@ -147,6 +147,13 @@ const pluginProperties = {
     required: false,
     type: 'string',
   },
+  property18: {
+    name: 'property18',
+    description: 'property18',
+    macroSupported: true,
+    required: false,
+    type: 'string',
+  },
   outputProperty: {
     name: 'outputProperty',
     description: 'description of outputProperty',
@@ -458,6 +465,17 @@ const widgetJson: IWidgetJson = {
         },
       ],
     },
+    {
+      name: 'Filter for feature flag',
+      condition: {
+        expression: 'featureFlags["some.feature"] == true',
+      },
+      show: [
+        {
+          name: 'property18',
+        },
+      ],
+    },
   ],
 };
 
@@ -731,6 +749,28 @@ describe('Unit tests for Dynamic Plugin Filters', () => {
       const newProperties = getPropertieObj(filteredConfigurationGroups);
       const newproperty13 = newProperties.property13;
       expect(newproperty13.show).toBe(true);
+    });
+  });
+
+  describe('Test filter on feature flag', () => {
+    it('Should show property when feature flag is on', () => {
+      window.CDAP_CONFIG = {
+        featureFlags: {
+          'some.feature': 'true',
+        },
+      };
+      const { filteredConfigurationGroups } = getFilteredConfigurationGroups();
+      const properties = getPropertieObj(filteredConfigurationGroups);
+      const property18 = properties.property18;
+      expect(property18.show).toBe(true);
+      delete window.CDAP_CONFIG.featureFlags;
+    });
+
+    it('Should hide property when feature flag is off', () => {
+      const { filteredConfigurationGroups } = getFilteredConfigurationGroups();
+      const properties = getPropertieObj(filteredConfigurationGroups);
+      const property18 = properties.property18;
+      expect(property18.show).toBe(false);
     });
   });
 });


### PR DESCRIPTION
# [CDAP-20569] add featureflag eval in plugin property filter

## Description
This adds the featureFlags object from window.CDAP_CONFIG to the evaluation group for plugins
![image](https://user-images.githubusercontent.com/98125204/231891833-517e87f0-2170-4a6b-88bf-d9eb443826b3.png)
So in order to show/hide properties for plugins, the syntax in the widget json should be
```
{
      "name": "foo",
      "condition": {
        "expression": "featureFlags['some.feature'] == true"
      },
      "show": [
        {
          "type": "property",
          "name": "bar"
        }
      ]
    },
```

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20569](https://cdap.atlassian.net/browse/CDAP-20569)

## Test Plan
Jest cannot access the window object, may need to write e2e tests




[CDAP-20569]: https://cdap.atlassian.net/browse/CDAP-20569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20569]: https://cdap.atlassian.net/browse/CDAP-20569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ