### PR TITLE
fix: use Object.keys in the feature flag for loop

### DIFF
--- a/app/cdap/components/shared/ConfigurationGroup/utilities/DynamicPluginFilters.ts
+++ b/app/cdap/components/shared/ConfigurationGroup/utilities/DynamicPluginFilters.ts
@@ -101,7 +101,7 @@ export function evaluateFilter(
 
   // convert string 'true' to boolean
   const featureFlags = { ...window?.CDAP_CONFIG?.featureFlags };
-  for (const key in featureFlags) {
+  for (const key of Object.keys(featureFlags)) {
     featureFlags[key] = featureFlags[key] === 'true';
   }
   const typedPropertyValues = {

--- a/src/e2e-test/features/logviewer.feature
+++ b/src/e2e-test/features/logviewer.feature
@@ -21,7 +21,7 @@ Feature: Logviewer - Validate log viewer functionalities
   Scenario: Deploy and run pipeline till complete
     When Deploy and test pipeline "logs_generator" with timestamp with pipeline JSON file "logs_generator.json"
     Then Run the pipeline
-    Then Deployed pipeline status is "Running"
+    Then Deployed pipeline status is "Running" or "Starting"
 
   @LOGVIEWER_TEST
   Scenario: Log viewer should show

--- a/src/e2e-test/features/logviewer.feature
+++ b/src/e2e-test/features/logviewer.feature
@@ -21,7 +21,7 @@ Feature: Logviewer - Validate log viewer functionalities
   Scenario: Deploy and run pipeline till complete
     When Deploy and test pipeline "logs_generator" with timestamp with pipeline JSON file "logs_generator.json"
     Then Run the pipeline
-    Then Check pipeline is running
+    Then Deployed pipeline status is "Running"
 
   @LOGVIEWER_TEST
   Scenario: Log viewer should show

--- a/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/CommonSteps.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/CommonSteps.java
@@ -22,7 +22,6 @@ import io.cdap.cdap.ui.utils.Constants;
 import io.cdap.cdap.ui.utils.Helper;
 import io.cdap.e2e.pages.actions.CdfPluginPropertiesActions;
 import io.cdap.e2e.pages.actions.CdfStudioActions;
-import io.cdap.e2e.pages.locators.CdfStudioLocators;
 import io.cdap.e2e.utils.ElementHelper;
 import io.cdap.e2e.utils.SeleniumDriver;
 import io.cdap.e2e.utils.WaitHelper;
@@ -175,7 +174,7 @@ public class CommonSteps {
 
   @Then("Close node property")
   public void closeNodeProperty() {
-    ElementHelper.clickOnElement(Helper.locateElementByTestId("close-config-popover"));;
+    ElementHelper.clickOnElement(Helper.locateElementByTestId("close-config-popover"));
   }
 
   @Then("Click on \"Get Schema\" button")
@@ -188,11 +187,10 @@ public class CommonSteps {
     ElementHelper.clickOnElement(Helper.locateElementByTestId("pipeline-run-btn"));
   }
 
-  @Then("Check pipeline is running")
-  public void isPipelineRunning() {
-    WaitHelper.waitForElementToBeDisplayed(
-      Helper.locateElementByCssSelector(Helper.getCssSelectorByDataTestId("Running"))
-    );
+  @Then("Deployed pipeline status is {string}")
+  public void deployedPipelineStatusIsString(String status) {
+    WaitHelper.waitForElementToBePresent(
+      By.cssSelector(Helper.getCssSelectorByDataTestId(status)));
   }
 
   @Then("Export the pipeline")

--- a/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/CommonSteps.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/CommonSteps.java
@@ -193,6 +193,17 @@ public class CommonSteps {
       By.cssSelector(Helper.getCssSelectorByDataTestId(status)));
   }
 
+  @Then("Deployed pipeline status is {string} or {string}")
+  public void deployedPipelineStatusIsStringOrString(String status1, String status2) {
+    boolean status1Present = WaitHelper.waitForElementToBeOptionallyPresent(
+      By.cssSelector(Helper.getCssSelectorByDataTestId(status1)), 60);
+    if (!status1Present) {
+      boolean status2Present = WaitHelper.waitForElementToBeOptionallyPresent(
+        By.cssSelector(Helper.getCssSelectorByDataTestId(status2)), 60);
+      Assert.assertTrue(status2Present);
+    }
+  }
+
   @Then("Export the pipeline")
   public void exportPipeline() {
     ElementHelper.clickOnElement(Helper.locateElementByTestId("pipeline-export-btn"));

--- a/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/PipelineRuntimeMacros.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/PipelineRuntimeMacros.java
@@ -20,7 +20,6 @@ import io.cdap.cdap.ui.utils.Commands;
 import io.cdap.cdap.ui.utils.Constants;
 import io.cdap.cdap.ui.utils.Helper;
 import io.cdap.e2e.utils.ElementHelper;
-import io.cdap.e2e.utils.SeleniumDriver;
 import io.cdap.e2e.utils.WaitHelper;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
@@ -140,12 +139,6 @@ public class PipelineRuntimeMacros {
   @When("Deployed run button is clicked")
   public void deployedRunButtonIsClicked() {
     ElementHelper.clickOnElement(Helper.locateElementByTestId("run-deployed-pipeline-modal-btn"));
-  }
-
-  @Then("Deployed pipeline status is {string}")
-  public void deployedPipelineStatusIsString(String status) {
-    WaitHelper.waitForElementToBePresent(
-      By.cssSelector(Helper.getCssSelectorByDataTestId(status)));
   }
 
   @When("Close the runtime argument dialog")


### PR DESCRIPTION
fix: use Object.keys in the feature flag for loop

fyi: https://stackoverflow.com/questions/40770425/tslint-codelyzer-ng-lint-error-for-in-statements-must-be-filtere

## Description
Summary of changes
](fix: use Object.keys in the feature flag for loop)
## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [x] General Improvement
- [ ] Cherry Pick

<img width="1032" alt="image" src="https://user-images.githubusercontent.com/20428112/233196745-e5db8d03-859b-47b8-8966-b2d1f4861ace.png">


