### PR TITLE
chore(6.9.1): bump e2e sandbox version to 6.9.1

### DIFF
--- a/sandboxjs/sandbox_version.json
+++ b/sandboxjs/sandbox_version.json
@@ -1,4 +1,4 @@
 {
-  "release": "v6.9.0-SNAPSHOT",
-  "version": "6.9.0-SNAPSHOT"
+  "release": "v6.9.1-SNAPSHOT",
+  "version": "6.9.1-SNAPSHOT"
 }


### PR DESCRIPTION
chore: bump e2e sandbox version to 6.9.1