### PR TITLE
[CDAP-20527] (fix) Fix dataproc profile missing default value

### DIFF
--- a/app/cdap/components/PipelineDetails/ProfilesListView/ProfileCustomizePopover/ProfileCustomizeContent/index.js
+++ b/app/cdap/components/PipelineDetails/ProfilesListView/ProfileCustomizePopover/ProfileCustomizeContent/index.js
@@ -204,7 +204,10 @@ export default class ProfileCustomizeContent extends PureComponent {
                   }
                   return {
                     ...property,
-                    value: this.latestValues[property.name],
+                    value:
+                      this.latestValues[property.name] ||
+                      this.props.customizations[property.name] ||
+                      property['widget-attributes'].default,
                   };
                 });
               return (


### PR DESCRIPTION
# [CDAP-20527] (fix) Fix dataproc profile missing default value

## Description
I believe the issue is the system dataproc profile only returns a small fraction of properties so that it fails to render some default value
<img width="984" alt="image" src="https://user-images.githubusercontent.com/98125204/234164137-25852d9b-0b07-46aa-9fa0-bd692f1ccb60.png">
This pr's solution is to fill in some default values for missing properties with the `provisioner` endpoint. 

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20527](https://cdap.atlassian.net/browse/CDAP-20527)

## Test Plan
verified locally 
<img width="382" alt="image" src="https://user-images.githubusercontent.com/98125204/234335328-8f5f368e-f253-45f1-8afa-15633b26f872.png">
<img width="389" alt="image" src="https://user-images.githubusercontent.com/98125204/234335494-0e3f4824-aba3-4767-bfb2-bdd5180c9917.png">





[CDAP-20527]: https://cdap.atlassian.net/browse/CDAP-20527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20527]: https://cdap.atlassian.net/browse/CDAP-20527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ