### PR TITLE
fix(CDAP-20605): SCM UI should not be calling validation before listing pipelines

### DIFF
--- a/app/cdap/components/NamespaceAdmin/SourceControlManagement/index.tsx
+++ b/app/cdap/components/NamespaceAdmin/SourceControlManagement/index.tsx
@@ -31,7 +31,7 @@ import { ISourceControlManagementConfig } from './types';
 import SourceControlManagementForm from './SourceControlManagementForm';
 import PrimaryTextButton from 'components/shared/Buttons/PrimaryTextButton';
 import { getCurrentNamespace } from 'services/NamespaceStore';
-import { validateSourceControlManagement } from '../store/ActionCreator';
+import { getSourceControlManagement } from '../store/ActionCreator';
 import Alert from 'components/shared/Alert';
 import ButtonLoadingHoc from 'components/shared/Buttons/ButtonLoadingHoc';
 
@@ -75,7 +75,7 @@ export const SourceControlManagement = () => {
   const validateConfigAndRedirect = () => {
     setLoading(true);
     const namespace = getCurrentNamespace();
-    validateSourceControlManagement(namespace).subscribe(
+    getSourceControlManagement(namespace).subscribe(
       () => {
         window.location.href = `/ns/${namespace}/scm/sync`;
       },

--- a/app/cdap/components/NamespaceAdmin/store/ActionCreator.ts
+++ b/app/cdap/components/NamespaceAdmin/store/ActionCreator.ts
@@ -277,23 +277,6 @@ export const addOrValidateSourceControlManagementForm = (
   ).map(() => getAndSetSourceControlManagement(namespace));
 };
 
-// This validation function directly reads config from api and validate
-export const validateSourceControlManagement = (namespace) => {
-  return getSourceControlManagement(namespace).pipe(
-    switchMap((res: any) => {
-      const [config, token] = res;
-      config.auth.token = token;
-      return MyNamespaceApi.setSourceControlManagement(
-        { namespace },
-        getBodyForSubmit(config, true)
-      );
-    }),
-    catchError((err) => {
-      throw err;
-    })
-  );
-};
-
 export const deleteSourceControlManagement = (
   namespace,
   formState: ISourceControlManagementConfig

--- a/app/cdap/components/ResourceCenterEntity/ResourceCenterPipelineEntity.tsx
+++ b/app/cdap/components/ResourceCenterEntity/ResourceCenterPipelineEntity.tsx
@@ -26,7 +26,7 @@ import IconSVG from 'components/shared/IconSVG';
 import PrimaryOutlinedButton from 'components/shared/Buttons/PrimaryOutlinedButton';
 import { defaultState, PullPipelineWizard, reducer } from './PullPipelineWizard';
 import PrimaryContainedButton from 'components/shared/Buttons/PrimaryContainedButton';
-import { validateSourceControlManagement } from 'components/NamespaceAdmin/store/ActionCreator';
+import { getSourceControlManagement } from 'components/NamespaceAdmin/store/ActionCreator';
 import ButtonLoadingHoc from 'components/shared/Buttons/ButtonLoadingHoc';
 import { useFeatureFlagDefaultFalse } from 'services/react/customHooks/useFeatureFlag';
 import { getHydratorUrl } from 'services/UiUtils/UrlGenerator';
@@ -113,7 +113,7 @@ export default function ResourceCenterPipelineEntity({
 
   const pullPipelineBtnHandler = () => {
     dispatch({ type: 'SET_LOADING', payload: { loading: true } });
-    validateSourceControlManagement(namespace).subscribe(
+    getSourceControlManagement(namespace).subscribe(
       () => {
         dispatch({ type: 'TOGGLE_MODAL' });
       },


### PR DESCRIPTION
fix(CDAP-20605): SCM UI should not be calling validation before listing pipelines

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20605](https://cdap.atlassian.net/browse/CDAP-20605)





[CDAP-20605]: https://cdap.atlassian.net/browse/CDAP-20605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ