### PR TITLE
CDAP-20603 Ensure error messages are shown when creating a Wrangler workspace

### DIFF
--- a/app/cdap/components/Connections/Browser/GenericBrowser/index.tsx
+++ b/app/cdap/components/Connections/Browser/GenericBrowser/index.tsx
@@ -170,7 +170,7 @@ export function GenericBrowser({ initialConnectionId, onEntityChange, selectedPa
 
   const onCreateWorkspace = async (entity, parseConfig = {}) => {
     try {
-      createWorkspaceInternal(entity, parseConfig);
+      await createWorkspaceInternal(entity, parseConfig);
     } catch (e) {
       setError(`Failed to create workspace. Error: ${e}`);
       setLoading(false);


### PR DESCRIPTION
# CDAP-20603 Ensure error messages are shown when creating a Wrangler workspace

## Description
An `await` was missing so the `catch` was not being applied

## PR Type
- [X] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20603](https://cdap.atlassian.net/browse/CDAP-20603)

## Test Plan
Manually verify

## Screenshots
N/A



[CDAP-20603]: https://cdap.atlassian.net/browse/CDAP-20603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ