### PR TITLE
[CDAP-20633] improve run level info when latest version has no runs

### DIFF
--- a/app/cdap/api/pipeline.js
+++ b/app/cdap/api/pipeline.js
@@ -23,6 +23,7 @@ const artifactBasePath = `/namespaces/:namespace/artifacts/:artifactName/version
 const statsPath = `${basepath}/workflows/:workflowId/statistics?start=0`;
 const schedulePath = `${basepath}/schedules/:scheduleId`;
 const programPath = `${basepath}/:programType/:programName`;
+const versionedProgramPath = `${basepath}/versions/:versionId/:programType/:programName`;
 const metadataPath = `${basepath}/workflows/:workflowType/runs/:runId/endpoints`;
 const runsCountPath = '/namespaces/:namespace/runcount';
 const batchRunsPath = '/namespaces/:namespace/runs';
@@ -50,6 +51,7 @@ export const MyPipelineApi = {
   getMetadataEndpoints: apiCreator(dataSrc, 'GET', 'REQUEST', metadataPath),
   getRunDetails: apiCreator(dataSrc, 'GET', 'REQUEST', `${programPath}/runs/:runid`),
   getRuns: apiCreator(dataSrc, 'GET', 'REQUEST', `${programPath}/runs`),
+  getVersionedRuns: apiCreator(dataSrc, 'GET', 'REQUEST', `${versionedProgramPath}/runs`),
   pollRuns: apiCreator(dataSrc, 'GET', 'POLL', `${programPath}/runs`),
   getRunsCount: apiCreator(dataSrc, 'POST', 'REQUEST', `${runsCountPath}`),
   pollRunsCount: apiCreator(dataSrc, 'POST', 'POLL', `${runsCountPath}`),

--- a/app/cdap/components/PipelineDetails/RunLevelInfo/CurrentRunIndex.tsx
+++ b/app/cdap/components/PipelineDetails/RunLevelInfo/CurrentRunIndex.tsx
@@ -14,20 +14,36 @@
  * the License.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
+import styled from 'styled-components';
 import IconSVG from 'components/shared/IconSVG';
 import { reverseArrayWithoutMutating, objectQuery } from 'services/helpers';
 import findIndex from 'lodash/findIndex';
 import {
   getAppVersion,
+  getRunsForVersion,
   init,
   setCurrentRunId,
 } from 'components/PipelineDetails/store/ActionCreator';
 import T from 'i18n-react';
 import { getCurrentNamespace } from 'services/NamespaceStore';
+import { getHydratorUrl } from 'services/UiUtils/UrlGenerator';
+import Popover from 'components/shared/Popover';
+import { GLOBALS } from 'services/global-constants';
 
 const PREFIX = 'features.PipelineDetails.RunLevel';
+
+const StyledNoRunsHeader = styled.div`
+  display: flex;
+  > * {
+    padding-left: 5px;
+  }
+`;
+
+const StyledPointerA = styled.a`
+  cursor: pointer;
+`;
 
 const mapStateToProps = (state) => {
   return {
@@ -35,6 +51,9 @@ const mapStateToProps = (state) => {
     runsCount: state.runsCount,
     runs: state.runs,
     currentRun: state.currentRun,
+    versionHasRun: state.versionHasRun,
+    version: state.version,
+    artifactName: state.artifact.name,
   };
 };
 
@@ -43,9 +62,21 @@ interface ICurrentRunIndexProps {
   runsCount: number;
   currentRun: object;
   pipelineName: string;
+  versionHasRun: boolean;
+  version: string;
+  artifactName: string;
 }
 
-const CurrentRunIndex = ({ runs, currentRun, runsCount, pipelineName }: ICurrentRunIndexProps) => {
+const CurrentRunIndex = ({
+  runs,
+  currentRun,
+  runsCount,
+  pipelineName,
+  versionHasRun,
+  version,
+  artifactName,
+}: ICurrentRunIndexProps) => {
+  const namespace = getCurrentNamespace();
   const reversedRuns = reverseArrayWithoutMutating(runs);
   const currentRunIndex = findIndex(reversedRuns, { runid: objectQuery(currentRun, 'runid') });
   // The currentRunIndex is the index in latest 100 runs
@@ -54,6 +85,34 @@ const CurrentRunIndex = ({ runs, currentRun, runsCount, pipelineName }: ICurrent
     currentRunIndex,
     runsCount - (runs.length - currentRunIndex)
   );
+
+  const pipelineLink = getHydratorUrl({
+    stateName: 'hydrator.detail',
+    stateParams: {
+      namespace,
+      pipelineId: pipelineName,
+    },
+  });
+
+  const navigateToLatestRunVersion = (latestRunVersion) => {
+    window.localStorage.setItem('pipelineHistoryVersion', latestRunVersion);
+    window.location.href = pipelineLink;
+  };
+
+  useEffect(() => {
+    const params = {
+      namespace,
+      appId: pipelineName,
+      versionId: version,
+      programType: GLOBALS.programInfo[artifactName].programType,
+      programName: GLOBALS.programInfo[artifactName].programName,
+    };
+    getRunsForVersion(params);
+    const interval = setInterval(() => {
+      getRunsForVersion(params);
+    }, 2000);
+    return () => clearInterval(interval);
+  }, []);
 
   if (!reversedRuns || currentRunIndex === -1) {
     return (
@@ -66,6 +125,32 @@ const CurrentRunIndex = ({ runs, currentRun, runsCount, pipelineName }: ICurrent
           <button disabled>
             <IconSVG name="icon-caret-right" />
           </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!versionHasRun) {
+    return (
+      <div className="run-number-container run-info-container">
+        <StyledNoRunsHeader>
+          <h4 className="run-number">{T.translate(`${PREFIX}.noRuns`)}</h4>
+          <Popover
+            target={() => <IconSVG name="icon-info-circle" />}
+            showOn="Hover"
+            placement="bottom"
+          >
+            {T.translate(`${PREFIX}.noRunsDesc`)}
+          </Popover>
+        </StyledNoRunsHeader>
+        <div className="run-number-switches">
+          <StyledPointerA
+            onClick={() => {
+              navigateToLatestRunVersion(reversedRuns[currentRunIndex].version);
+            }}
+          >
+            {T.translate(`${PREFIX}.goToLatestRun`)}
+          </StyledPointerA>
         </div>
       </div>
     );
@@ -85,7 +170,7 @@ const CurrentRunIndex = ({ runs, currentRun, runsCount, pipelineName }: ICurrent
   const setRunIdAndNavigate = (runid, runIndex) => {
     if (reversedRuns[runIndex].version) {
       getAppVersion({
-        namespace: getCurrentNamespace(),
+        namespace,
         appId: pipelineName,
         version: reversedRuns[runIndex].version,
       }).subscribe(

--- a/app/cdap/components/PipelineDetails/store/ActionCreator.js
+++ b/app/cdap/components/PipelineDetails/store/ActionCreator.js
@@ -185,6 +185,15 @@ const setRuns = (runs) => {
   });
 };
 
+const setVersionHasRun = (versionHasRun) => {
+  PipelineDetailStore.dispatch({
+    type: ACTIONS.SET_VERSION_HAS_RUN,
+    payload: {
+      versionHasRun: versionHasRun,
+    },
+  });
+};
+
 const getRunDetails = ({ namespace, appId, programType, programName, runid }) => {
   return MyPipelineApi.getRunDetails({
     namespace,
@@ -214,6 +223,12 @@ const getRuns = (params) => {
     }
   );
   return runsFetch;
+};
+
+const getRunsForVersion = (params) => {
+  MyPipelineApi.getVersionedRuns(params).subscribe((runs) => {
+    setVersionHasRun(runs.length > 0);
+  });
 };
 
 const pollRunsCount = ({ appId, programType, programName: programId, namespace }) => {
@@ -502,7 +517,9 @@ export {
   setNumRecordsPreview,
   setMaxConcurrentRuns,
   setCurrentRunId,
+  setVersionHasRun,
   getRuns,
+  getRunsForVersion,
   getRunDetails,
   getAppVersion,
   pollRuns,

--- a/app/cdap/components/PipelineDetails/store/index.js
+++ b/app/cdap/components/PipelineDetails/store/index.js
@@ -47,6 +47,7 @@ const ACTIONS = {
 
   // lifecycle management draftid
   SET_EDIT_DRAFT_ID: 'SET_EDIT_DRAFT_ID',
+  SET_VERSION_HAS_RUN: 'SET_VERSION_HAS_RUN',
 
   // Metadata Endpoints Actions
   SET_METADATA_ENDPOINTS: 'SET_METADATA_ENDPOINTS',
@@ -95,6 +96,7 @@ const DEFAULT_PIPELINE_DETAILS = {
   // lcm
   change: {},
   editDraftId: null,
+  versionHasRun: true,
 
   // endpoints for plugin metadata
   metadataEndpoints: [],
@@ -261,6 +263,11 @@ const pipelineDetails = (state = DEFAULT_PIPELINE_DETAILS, action = defaultActio
       return {
         ...state,
         editDraftId: action.payload.draftId,
+      };
+    case ACTIONS.SET_VERSION_HAS_RUN:
+      return {
+        ...state,
+        versionHasRun: action.payload.versionHasRun,
       };
     case ACTIONS.SET_PULL_LOADING:
       return {

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -2480,8 +2480,10 @@ features:
       currentIndex: '({currentRunIndex} of {numRuns})'
       currentRunIndex: 'Run {currentRunIndex} of {numRuns}'
       errors: Errors
+      goToLatestRun: Go to latest run
       logs: Logs
       noRuns: No Runs
+      noRunsDesc: The version you are currently viewing has no runs, click below link to navigate to the version that has the latest run.
       noRuntimeArgsForRun: No runtime arguments available for this run.
       pipelineNeverRun: 'This pipeline has never been run.'
       RunComputeProfile:


### PR DESCRIPTION
# [CDAP-20633] improve run level info when latest version has no runs

## Description
Add additional check to check whether the current version pipeline has any runs. If none, the run level info will show no runs with a link to navigate to the version with the latest run.

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [x] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20633](https://cdap.atlassian.net/browse/CDAP-20633)

## Screenshots
![image](https://github.com/cdapio/cdap-ui/assets/98125204/86120625-307d-41a0-8fa5-7de62291915c)
![image](https://github.com/cdapio/cdap-ui/assets/98125204/3495e2bd-b3b8-4d99-bd59-2ee86110cc95)

https://github.com/cdapio/cdap-ui/assets/98125204/b99410c7-555a-4da9-976d-c3ae98c888c4





[CDAP-20633]: https://cdap.atlassian.net/browse/CDAP-20633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20633]: https://cdap.atlassian.net/browse/CDAP-20633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ