### PR TITLE
[CDAP-20641] remove overwriteConfig runtimearg

### DIFF
--- a/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ConfigModelessActionButtons/index.tsx
+++ b/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ConfigModelessActionButtons/index.tsx
@@ -89,7 +89,7 @@ export const ConfigModelessActionButtons = ({ ...props }: IConfigModelessActionB
     setSaveLoading(true);
     let observable;
     if (lifecycleManagementEditEnabled) {
-      observable = updatePreferences(lifecycleManagementEditEnabled);
+      observable = updatePreferences();
     } else {
       observable = Observable.forkJoin(updatePipeline(), updatePreferences());
     }

--- a/app/cdap/components/PipelineConfigurations/Store/ActionCreator.js
+++ b/app/cdap/components/PipelineConfigurations/Store/ActionCreator.js
@@ -132,7 +132,7 @@ const getMacrosResolvedByPrefs = (resolvedPrefs = {}, macrosMap = {}) => {
   return resolvedMacros;
 };
 
-const updatePreferences = (lifecycleManagementEditEnabled = false) => {
+const updatePreferences = () => {
   const { runtimeArgs } = PipelineConfigurationsStore.getState();
   let filteredRuntimeArgs = cloneDeep(runtimeArgs);
   filteredRuntimeArgs.pairs = filteredRuntimeArgs.pairs.filter(
@@ -140,9 +140,6 @@ const updatePreferences = (lifecycleManagementEditEnabled = false) => {
   );
   let appId = PipelineDetailStore.getState().name;
   let prefObj = convertKeyValuePairsObjToMap(runtimeArgs);
-  if (lifecycleManagementEditEnabled) {
-    prefObj = { ...prefObj, 'app.pipeline.overwriteConfig': 'true' };
-  }
 
   return MyPreferenceApi.setAppPreferences(
     {

--- a/app/cdap/services/global-constants.js
+++ b/app/cdap/services/global-constants.js
@@ -358,7 +358,6 @@ const GENERATED_RUNTIMEARGS = {
   SYSTEM_DRIVER_RESOURCES_CORES: 'task.driver.system.resources.cores',
   SYSTEM_EXECUTOR_RESOURCES_MEMORY: 'task.executor.system.resources.memory',
   SYSTEM_EXECUTOR_RESOURCES_CORES: 'task.executor.system.resources.cores',
-  PIPELINE_CONFIG_OVERWRITE: 'app.pipeline.overwriteConfig',
 }
 
 const SCOPES = {

--- a/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/PipelineEdit.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/PipelineEdit.java
@@ -204,7 +204,6 @@ public class PipelineEdit {
       .map(element -> element.findElement(By.tagName("input")).getAttribute("value"))
       .collect(Collectors.toList());
     Assert.assertTrue(stringKeys.size() == 1);
-    Assert.assertTrue(!stringKeys.contains("app.pipeline.overwriteConfig"));
     Assert.assertTrue(!stringKeys.contains("app.pipeline.instrumentation"));
     ElementHelper.clickOnElement(Helper.locateElementByTestId("pipeline-modeless-close-btn"));
   }
@@ -220,7 +219,6 @@ public class PipelineEdit {
       .map(element -> element.findElement(By.tagName("input")).getAttribute("value"))
       .collect(Collectors.toList());
     Assert.assertTrue(stringKeys.size() > 1);
-    Assert.assertTrue(stringKeys.contains("app.pipeline.overwriteConfig"));
     Assert.assertTrue(stringKeys.contains("app.pipeline.instrumentation"));
     ElementHelper.clickOnElement(Helper.locateElementByTestId("pipeline-modeless-close-btn"));
   }


### PR DESCRIPTION
# [CDAP-20641] remove overwriteConfig runtimearg

## Description
In LCM, we moved pipeline configurations into runtimeargs. However, we require an additional ‘overwriteConfig’ argument to make it work. The UI generates this argument automatically. However, this is inconvenient for users who do not use the UI. We should just use the LCM feature flag

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [x] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20641](https://cdap.atlassian.net/browse/CDAP-20641)




[CDAP-20641]: https://cdap.atlassian.net/browse/CDAP-20641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20641]: https://cdap.atlassian.net/browse/CDAP-20641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ