### PR TITLE
[CDAP-20639] change default state only when lcm disabled

### DIFF
--- a/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ResourcesTabContent/DriverResources.js
+++ b/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ResourcesTabContent/DriverResources.js
@@ -50,10 +50,6 @@ const mapDispatchToProps = (dispatch) => {
   );
   return {
     onVirtualCoresChange: (e) => {
-      dispatch({
-        type: PipelineConfigurationsActions.SET_DRIVER_VIRTUAL_CORES,
-        payload: { virtualCores: e.target.value },
-      });
       if (lifecycleManagementEditEnabled) {
         const { runtimeArgs } = PipelineConfigurationsStore.getState();
         const newRunTimePairs = getUpdatedRuntimeArgsPair(
@@ -65,13 +61,15 @@ const mapDispatchToProps = (dispatch) => {
           type: PipelineConfigurationsActions.SET_RUNTIME_ARGS,
           payload: { runtimeArgs: { pairs: newRunTimePairs } },
         });
+      } else {
+        // modify the default state if LCM is not enabled
+        dispatch({
+          type: PipelineConfigurationsActions.SET_DRIVER_VIRTUAL_CORES,
+          payload: { virtualCores: e.target.value },
+        });
       }
     },
     onMemoryMBChange: (e) => {
-      dispatch({
-        type: PipelineConfigurationsActions.SET_DRIVER_MEMORY_MB,
-        payload: { memoryMB: e.target.value },
-      });
       if (lifecycleManagementEditEnabled) {
         const { runtimeArgs } = PipelineConfigurationsStore.getState();
         const newRunTimePairs = getUpdatedRuntimeArgsPair(
@@ -82,6 +80,12 @@ const mapDispatchToProps = (dispatch) => {
         dispatch({
           type: PipelineConfigurationsActions.SET_RUNTIME_ARGS,
           payload: { runtimeArgs: { pairs: newRunTimePairs } },
+        });
+      } else {
+        // modify the default state if LCM is not enabled
+        dispatch({
+          type: PipelineConfigurationsActions.SET_DRIVER_MEMORY_MB,
+          payload: { memoryMB: e.target.value },
         });
       }
     },

--- a/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ResourcesTabContent/ExecutorResources.js
+++ b/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ResourcesTabContent/ExecutorResources.js
@@ -53,10 +53,6 @@ const mapDispatchToProps = (dispatch) => {
   );
   return {
     onVirtualCoresChange: (e) => {
-      dispatch({
-        type: PipelineConfigurationsActions.SET_MEMORY_VIRTUAL_CORES,
-        payload: { virtualCores: e.target.value },
-      });
       if (lifecycleManagementEditEnabled) {
         const { runtimeArgs } = PipelineConfigurationsStore.getState();
         const newRunTimePairs = getUpdatedRuntimeArgsPair(
@@ -68,13 +64,15 @@ const mapDispatchToProps = (dispatch) => {
           type: PipelineConfigurationsActions.SET_RUNTIME_ARGS,
           payload: { runtimeArgs: { pairs: newRunTimePairs } },
         });
+      } else {
+        // modify the default state if LCM is not enabled
+        dispatch({
+          type: PipelineConfigurationsActions.SET_MEMORY_VIRTUAL_CORES,
+          payload: { virtualCores: e.target.value },
+        });
       }
     },
     onMemoryMBChange: (e) => {
-      dispatch({
-        type: PipelineConfigurationsActions.SET_MEMORY_MB,
-        payload: { memoryMB: e.target.value },
-      });
       if (lifecycleManagementEditEnabled) {
         const { runtimeArgs } = PipelineConfigurationsStore.getState();
         const newRunTimePairs = getUpdatedRuntimeArgsPair(
@@ -85,6 +83,12 @@ const mapDispatchToProps = (dispatch) => {
         dispatch({
           type: PipelineConfigurationsActions.SET_RUNTIME_ARGS,
           payload: { runtimeArgs: { pairs: newRunTimePairs } },
+        });
+      } else {
+        // modify the default state if LCM is not enabled
+        dispatch({
+          type: PipelineConfigurationsActions.SET_MEMORY_MB,
+          payload: { memoryMB: e.target.value },
         });
       }
     },


### PR DESCRIPTION
# [CDAP-20639] change default state only when lcm disabled

## Description
To improve that when users delete driver and executor resources config from runtime arguments, the config tab will fallback to default state without refreshing the page

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [x] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20639](https://cdap.atlassian.net/browse/CDAP-20639)




[CDAP-20639]: https://cdap.atlassian.net/browse/CDAP-20639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20639]: https://cdap.atlassian.net/browse/CDAP-20639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ