### PR TITLE
 [CDAP-19380] Pipeline Alert UI: Adjust button resize behavior

### DIFF
--- a/app/cdap/components/PostRunActions/WizardNav/WizardSelectActionStep/index.tsx
+++ b/app/cdap/components/PostRunActions/WizardNav/WizardSelectActionStep/index.tsx
@@ -24,7 +24,6 @@ export interface IWizardSelectActionStepProps {
 }
 
 const ActionButton = styled.button`
-  flex-grow: 1;
   box-shadow: 1px 4px 7px -5px rgb(0 0 0 / 65%);
   border: 1px solid #ddd;
   margin: 10px;
@@ -32,7 +31,7 @@ const ActionButton = styled.button`
 
 const ActionsList = styled.div`
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   flex-flow: wrap;
   margin: 10px 0;
 `;


### PR DESCRIPTION
## Description
Due to the flex-grow property, last few buttons would span the whole window width in smaller viewport sizes. Removed the flex-grow property and adjusted the justify-content to center the buttons.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-19380](https://cdap.atlassian.net/browse/CDAP-19380)

## Screenshots
![Smaller Window](https://github.com/cdapio/cdap-ui/assets/47050442/818179bb-8a44-4d3b-a915-037bf9fecb5f)
![Full Screen Window](https://github.com/cdapio/cdap-ui/assets/47050442/f8dc0bdb-2865-460c-8914-119433a207eb)



[CDAP-19380]: https://cdap.atlassian.net/browse/CDAP-19380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ