### PR TITLE
[CDAP-20656] Give proper versionid to batchappdetail call

### DIFF
--- a/app/cdap/components/EntityListView/JustAddedSection/index.js
+++ b/app/cdap/components/EntityListView/JustAddedSection/index.js
@@ -163,6 +163,7 @@ export default class JustAddedSection extends Component {
       .map((app) => {
         return {
           appId: app.id,
+          version: app.appVersion,
         };
       });
 

--- a/app/cdap/components/EntityListView/ListView/index.js
+++ b/app/cdap/components/EntityListView/ListView/index.js
@@ -66,6 +66,7 @@ export default class HomeListView extends Component {
       .map((app) => {
         return {
           appId: app.id,
+          version: app.appVersion,
         };
       });
 

--- a/app/cdap/services/metadata-parser/index.js
+++ b/app/cdap/services/metadata-parser/index.js
@@ -112,9 +112,17 @@ function createApplicationObj(entityObj) {
     id: entityObj.entity.details.application,
     type: entityObj.entity.type.toLowerCase(),
     metadata: entityObj,
+    // this is artifact version, not app version
     version,
     icon,
     isHydrator: entityIsPipeline(entityObj),
+    appVersion:
+      entityObj.metadata.properties &&
+      Array.isArray(entityObj.metadata.properties)
+        ? entityObj.metadata.properties.find(
+            (property) => property.name == "version"
+          ).value
+        : null,
   };
 }
 


### PR DESCRIPTION
# [CDAP-20656] Give proper versionid to batchappdetail call

## Description
Added a new field `appVersion` in the application entity object, we get this value from the metadata/search properties. Then we supply it to the batchAppDetail call

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20656](https://cdap.atlassian.net/browse/CDAP-20656)

## Screenshots
<img width="663" alt="image" src="https://github.com/cdapio/cdap-ui/assets/98125204/736d5bc8-5a4a-4003-81ae-2070327ff147">




[CDAP-20656]: https://cdap.atlassian.net/browse/CDAP-20656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20656]: https://cdap.atlassian.net/browse/CDAP-20656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ