### PR TITLE
Add data-testid for operational stats e2e test

### DIFF
--- a/app/cdap/components/Administration/AdminManagementTabContent/PlatformsDetails/Genericdetails.js
+++ b/app/cdap/components/Administration/AdminManagementTabContent/PlatformsDetails/Genericdetails.js
@@ -30,7 +30,7 @@ export default function GenericDetails({ details, className }) {
         .filter((detail) => ['name', 'url', 'version', 'logs'].indexOf(detail) === -1)
         .map((detail, i) => {
           return (
-            <div key={i}>
+            <div key={i} data-testid={`generic-details-${detail}`}>
               <strong>{capitalize(detail)}</strong>
               <RenderObjectAsTable obj={details[detail]} />
             </div>

--- a/app/cdap/components/Administration/AdminTabSwitch/index.tsx
+++ b/app/cdap/components/Administration/AdminTabSwitch/index.tsx
@@ -94,7 +94,7 @@ export default class AdminTabSwitch extends React.PureComponent<IAdminTabSwitchP
   public renderUptimeVersion() {
     return (
       <span className="uptime-version-container">
-        <span>
+        <span data-testid="system-uptime-container" data-uptime={this.props.uptime}>
           {this.props.uptime
             ? T.translate(`${PREFIX}.uptimeLabel`, {
                 time: humanReadableDuration(Math.ceil(this.props.uptime / 1000)),

--- a/app/cdap/components/shared/RenderObjectAsTable/index.js
+++ b/app/cdap/components/shared/RenderObjectAsTable/index.js
@@ -26,7 +26,7 @@ const RenderObjectAsTable = ({ obj }) => {
           return (
             <tr key={i}>
               <td>{node}</td>
-              <td>{obj[node]}</td>
+              <td data-testid={node}>{obj[node]}</td>
             </tr>
           );
         })}


### PR DESCRIPTION
# Add testids for operational stats e2e test

## Description

Adds testids to generic-details component and tables contained within it (in page administration/management) 

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [x] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [Jira issue #](fill-in.org)

## Test Plan

NA

## Screenshots

NA
