### PR TITLE
[CDAP-20715] Use MUI Accordion instead of custom styling in DiffAccordion 

### DIFF
--- a/app/cdap/components/PipelineDiff/DiffAccordion.tsx
+++ b/app/cdap/components/PipelineDiff/DiffAccordion.tsx
@@ -14,61 +14,73 @@
  * the License.
  */
 
-import React, { MouseEventHandler, PropsWithChildren, useState } from 'react';
-
-import VisibilityIcon from '@material-ui/icons/Visibility';
-import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
+import React, { PropsWithChildren } from 'react';
+import Accordion from '@material-ui/core/Accordion';
+import AccordionSummary from '@material-ui/core/AccordionSummary';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
+import Typography from '@material-ui/core/Typography';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import styled from 'styled-components';
-import { IconButton } from '@material-ui/core';
+import { blue } from '@material-ui/core/colors';
 
-const DiffAccordionTitleBarRoot = styled.div`
+const AccordionRoot = styled(Accordion)`
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  margin: 0;
+  min-height: 0;
   width: 100%;
-  background: lightgray;
-  height: 40px;
-  padding: 0 30px;
+
+  &.Mui-expanded {
+    flex: 1;
+    margin: 0;
+  }
+  .MuiAccordionSummary-content,
+  .MuiAccordionSummary-content.Mui-expanded {
+    margin: 5px 0;
+  }
+  & > .MuiCollapse-root.MuiCollapse-entered {
+    flex: 1;
+    .MuiCollapse-wrapper,
+    .MuiCollapse-wrapperInner,
+    .MuiCollapse-wrapperInner > div {
+      height: 100%;
+    }
+  }
+  .MuiAccordionSummary-expandIcon {
+    padding: 0 10px;
+  }
 `;
-
-interface IDiffAccordionTitleBar {
-  isOpen: boolean;
-  title: string;
-  onClick: MouseEventHandler<HTMLButtonElement>;
-}
-
-const DiffAccordionTitleBar = ({ isOpen, title, onClick }: IDiffAccordionTitleBar) => {
-  return (
-    <DiffAccordionTitleBarRoot>
-      <div style={{ flexGrow: 1 }}>{title}</div>
-      <IconButton onClick={onClick}>
-        {isOpen ? <VisibilityIcon /> : <VisibilityOffIcon />}
-      </IconButton>
-    </DiffAccordionTitleBarRoot>
-  );
-};
-
-const DiffAccordionContent = styled.div`
-  width: 100%;
-  height: 0px;
-  flex-grow: ${(props) => (props.isOpen ? 1 : 0)};
+const AccordionSummaryRoot = styled(AccordionSummary)`
+  &&& {
+    background-color: ${blue[50]};
+    border-bottom: 1px solid rgba(0, 0, 0, 0.125);
+    min-height: 0;
+    width: 100%;
+  }
+`;
+const AccordionDetailsRoot = styled(AccordionDetails)`
+  height: 100%;
+  max-height: 100%;
+  max-width: 100%;
+  padding: 0;
 `;
 
 interface IDiffAccordion {
-  defaultOpen: boolean;
+  defaultExpanded: boolean;
   title: string;
 }
 
-// TODO: CDAP-20715: Use MUI Accordion rather than custom component
 export const DiffAccordion = ({
-  defaultOpen,
+  defaultExpanded,
   children,
   title,
 }: PropsWithChildren<IDiffAccordion>) => {
-  const [isOpen, setIsOpen] = useState(defaultOpen);
   return (
-    <>
-      <DiffAccordionTitleBar title={title} isOpen={isOpen} onClick={() => setIsOpen(!isOpen)} />
-      <DiffAccordionContent isOpen={isOpen}>{children}</DiffAccordionContent>
-    </>
+    <AccordionRoot defaultExpanded={defaultExpanded}>
+      <AccordionSummaryRoot expandIcon={<ExpandMoreIcon />}>
+        <Typography>{title}</Typography>
+      </AccordionSummaryRoot>
+      <AccordionDetailsRoot>{children}</AccordionDetailsRoot>
+    </AccordionRoot>
   );
 };

--- a/app/cdap/components/PipelineDiff/DiffWindow.tsx
+++ b/app/cdap/components/PipelineDiff/DiffWindow.tsx
@@ -23,9 +23,9 @@ import { RootState } from './store';
 import { DiffInfo } from './DiffInfo';
 
 const DiffWindowRoot = styled.div`
-  flex-grow: 1;
   display: flex;
   flex-direction: column;
+  flex-grow: 1;
   height: 100%;
 `;
 
@@ -53,7 +53,7 @@ export const DiffWindow = () => {
   return (
     <DiffWindowRoot>
       {/* TODO: i18n */}
-      <DiffAccordion title={'Old Version'} defaultOpen={true}>
+      <DiffAccordion title={'Old Version'} defaultExpanded={true}>
         {!isLoading && !error && (
           <DiffCanvasWrapper
             config={topPipelineConfig}
@@ -65,7 +65,7 @@ export const DiffWindow = () => {
       </DiffAccordion>
 
       {/* TODO: i18n */}
-      <DiffAccordion title={'Current Version'} defaultOpen={true}>
+      <DiffAccordion title={'Current Version'} defaultExpanded={true}>
         {!isLoading && !error && (
           <DiffCanvasWrapper
             config={bottomPipelineConfig}
@@ -77,7 +77,7 @@ export const DiffWindow = () => {
       </DiffAccordion>
 
       {/* TODO: i18n */}
-      <DiffAccordion title={'Diff'} defaultOpen={false}>
+      <DiffAccordion title={'Diff'} defaultExpanded={false}>
         {!isLoading && !error && (
           <DiffInfo
             diffMap={diffMap}


### PR DESCRIPTION
# [CDAP-20715](https://cdap.atlassian.net/browse/CDAP-20715) Use MUI Accordion instead of custom styling in DiffAccordion 

## Description
Use MUI Accordion instead of custom styling in DiffAccordion

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [x] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20715](https://cdap.atlassian.net/browse/CDAP-20715)

## Screenshots
![image](https://github.com/cdapio/cdap-ui/assets/47050442/aadc909b-c14a-4e28-bb4a-4c400edd9f7b)



[CDAP-20715]: https://cdap.atlassian.net/browse/CDAP-20715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20715]: https://cdap.atlassian.net/browse/CDAP-20715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ