### PR TITLE
[CDAP-20725] Reposition diff indicator on plugin diff node

### DIFF
--- a/app/cdap/components/PipelineDiff/DiffCanvas/PluginNode.tsx
+++ b/app/cdap/components/PipelineDiff/DiffCanvas/PluginNode.tsx
@@ -23,9 +23,10 @@ import { getPluginDiffColors } from '../util/helpers';
 import { DiffIcon } from '../DiffIcon';
 
 const NodeRoot = styled.div`
+  position: relative;
   height: 110px;
   width: 200px;
-  border: 3px solid ${({ color }) => color};
+  border: 2px solid ${({ color }) => color};
   border-radius: 5px;
   background: white;
   display: flex;
@@ -55,6 +56,7 @@ const IconRoot = styled.div`
 const TitleContainer = styled.div`
   flex-grow: 1;
   padding-top: 10px;
+  min-width: 0;
 `;
 
 const TitleLabel = styled.label`
@@ -63,6 +65,7 @@ const TitleLabel = styled.label`
   font-size: 14px;
   text-overflow: ellipsis;
   overflow: hidden;
+  white-space: nowrap;
 `;
 
 const SubtitleLabel = styled(TitleLabel)`
@@ -70,12 +73,11 @@ const SubtitleLabel = styled(TitleLabel)`
   color: ${({ color }) => color};
 `;
 
-const DiffIconContainer = styled.div`
-  display: flex;
-  flex-grow: 1;
-  justify-content: flex-end;
-  align-items: flex-end;
-  padding: 0 10px 10px 10px;
+const DiffIconRoot = styled(DiffIcon)`
+  position: absolute;
+  top: 0;
+  right: 0;
+  transform: translate(50%, -50%);
 `;
 
 const HandleRoot = styled(Handle)`
@@ -123,9 +125,7 @@ export const DefaultPluginNode = ({
           <SubtitleLabel color={primaryLight}>{data.plugin.artifact.version}</SubtitleLabel>
         </TitleContainer>
       </HeaderRoot>
-      <DiffIconContainer>
-        {diffIndicator && <DiffIcon diffType={diffIndicator} fontSize="large" />}
-      </DiffIconContainer>
+      {diffIndicator && <DiffIconRoot diffType={diffIndicator} fontSize="large" />}
       <HandleRoot type="target" position={Position.Left} />
       <HandleRoot type="source" id="source_right" position={Position.Right} />
       {children}

--- a/app/cdap/components/PipelineDiff/DiffIcon.tsx
+++ b/app/cdap/components/PipelineDiff/DiffIcon.tsx
@@ -14,23 +14,47 @@
  * the License.
  */
 import React, { ComponentProps } from 'react';
-import EditIcon from '@material-ui/icons/Edit';
-import AddBoxOutlinedIcon from '@material-ui/icons/AddBoxOutlined';
-import IndeterminateCheckBoxOutlinedIcon from '@material-ui/icons/IndeterminateCheckBoxOutlined';
+import AddIcon from '@material-ui/icons/Add';
+import RemoveIcon from '@material-ui/icons/Remove';
+import { SvgIcon } from '@material-ui/core';
 import { DiffIndicator } from './types';
 import { getPluginDiffColors } from './util/helpers';
-import { SvgIcon } from '@material-ui/core';
+import styled from 'styled-components';
+
+const DiffIconContainer = styled(SvgIcon)`
+  border: 2px solid ${({ color }) => color};
+  border-radius: 3px;
+  background-color: white;
+  line-height: 1;
+`;
+
+const ModifiedIcon = styled.circle`
+  fill: ${({ color }) => color};
+`;
 
 type IconProps = ComponentProps<typeof SvgIcon>;
 interface IDiffIconProps extends Omit<IconProps, 'color'> {
   diffType: DiffIndicator;
+  className?: string;
 }
-export function DiffIcon({ diffType, style, ...props }: IDiffIconProps) {
+export function DiffIcon({ diffType, className, ...props }: IDiffIconProps) {
   const color = getPluginDiffColors(diffType).primary;
   if (diffType === DiffIndicator.ADDED) {
-    return <AddBoxOutlinedIcon style={{ color, ...style }} {...props} />;
+    return (
+      <DiffIconContainer color={color} className={className}>
+        <AddIcon style={{ color }} {...props} />
+      </DiffIconContainer>
+    );
   } else if (diffType === DiffIndicator.DELETED) {
-    return <IndeterminateCheckBoxOutlinedIcon style={{ color, ...style }} {...props} />;
+    return (
+      <DiffIconContainer color={color} className={className}>
+        <RemoveIcon style={{ color }} {...props} />
+      </DiffIconContainer>
+    );
   }
-  return <EditIcon style={{ color, ...style }} {...props} />;
+  return (
+    <DiffIconContainer color={color} className={className}>
+      <ModifiedIcon cx={'50%'} cy={'50%'} r={'4'} color={color} {...props} />
+    </DiffIconContainer>
+  );
 }

--- a/app/cdap/components/PipelineDiff/DiffList/DiffListItem.tsx
+++ b/app/cdap/components/PipelineDiff/DiffList/DiffListItem.tsx
@@ -107,7 +107,7 @@ export const ConnectionDiffListItem = ({
       </ListItemIcon>
       <ListItemText primary={fromNodeName} />
       <IconButton size="small">
-        <DiffIcon diffType={diffType} />
+        <DiffIcon diffType={diffType} fontSize="small" />
       </IconButton>
       <ListItemIcon>
         {toCustomIconSrc ? (

--- a/app/cdap/components/PipelineDiff/DiffList/index.tsx
+++ b/app/cdap/components/PipelineDiff/DiffList/index.tsx
@@ -35,6 +35,7 @@ const DiffListRoot = styled(Paper)`
   &.MuiPaper-root {
     height: 100%;
     width: 400px;
+    min-width: 400px;
   }
 `;
 


### PR DESCRIPTION
# [CDAP-20725](https://cdap.atlassian.net/browse/CDAP-20725) Reposition diff indicator on plugin diff node

## Description
The current position of the difference indicator (+, - and pen icons) look more like they are clickable buttons than just indicators. This PR relocates the indicator to the top right corner of the node, and changes the modification indicator from a pen to a filled circle. 

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [x] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20725](https://cdap.atlassian.net/browse/CDAP-20725)

## Screenshots
Current:

![image](https://github.com/cdapio/cdap-ui/assets/47050442/f719e7c2-b7be-41cc-a872-72b43966c3e0)

Updated:

![Screenshot 2023-07-12 11 43 43 AM](https://github.com/cdapio/cdap-ui/assets/47050442/fb74147b-59fa-4abc-8bb7-94e51b0a0515)



[CDAP-20725]: https://cdap.atlassian.net/browse/CDAP-20725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20725]: https://cdap.atlassian.net/browse/CDAP-20725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ