### PR TITLE
fix(CDAP-20647): Use SCM error message from backend directly

### DIFF
--- a/app/cdap/components/NamespaceAdmin/SourceControlManagement/index.tsx
+++ b/app/cdap/components/NamespaceAdmin/SourceControlManagement/index.tsx
@@ -80,7 +80,7 @@ export const SourceControlManagement = () => {
         window.location.href = `/ns/${namespace}/scm/sync`;
       },
       (err) => {
-        setErrorMessage(T.translate(`${PREFIX}.invalidConfig`, { error: err.message }));
+        setErrorMessage(err.message);
         setLoading(false);
       },
       () => {

--- a/app/cdap/components/ResourceCenterEntity/ResourceCenterPipelineEntity.tsx
+++ b/app/cdap/components/ResourceCenterEntity/ResourceCenterPipelineEntity.tsx
@@ -121,9 +121,7 @@ export default function ResourceCenterPipelineEntity({
         dispatch({
           type: 'SET_ERROR',
           payload: {
-            error: T.translate('features.SourceControlManagement.invalidConfig', {
-              error: err.message,
-            }).toLocaleString(),
+            error: err.message,
           },
         });
         dispatch({ type: 'SET_LOADING', payload: { loading: false } });

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -3200,7 +3200,6 @@ features:
           1: "{context} required field is missing"
           _: "{context} required fields are missing"
     info: Source control management allows you to connect namespace with the repository of your source control system repository to efficiently manage development process of the deployed pipelines.
-    invalidConfig: "{error}. Please validate saved source control management configurations."
     linkButton: Link Repository
     pull:
       emptyPipelineListMessage: There are no pipelines in the remote repository or no pipelines matching the search query "{query}"


### PR DESCRIPTION
Use SCM error message from backend directly

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20647](https://cdap.atlassian.net/browse/CDAP-20647)

## Screenshots
Before:
“The repository configuration of namespace namespace:default is not found.. Please validate saved source control management configurations.” 


After:
<img width="1101" alt="image" src="https://github.com/cdapio/cdap-ui/assets/20428112/f5543071-6a9e-4d3a-b50d-4a277e39822b">






[CDAP-20647]: https://cdap.atlassian.net/browse/CDAP-20647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ