### PR TITLE
[CDAP-20729] Add diff colors to nodes in the minimap

### DIFF
--- a/app/cdap/components/PipelineDiff/DiffCanvas/index.tsx
+++ b/app/cdap/components/PipelineDiff/DiffCanvas/index.tsx
@@ -28,6 +28,7 @@ import { DefaultPluginNode, PluginNodeWithAlertError } from './PluginNode';
 import { getReactflowPipelineGraph } from '../util/reactflowGraph';
 import { AvailablePluginsMap, IPipelineConfig, IPipelineDiffMap, NodeType } from '../types';
 import { IPipelineNodeData } from '../store/diffSlice';
+import { getPluginDiffColors } from '../util/helpers';
 
 const nodeTypes: Record<NodeType, ComponentType<NodeProps>> = {
   defaultNode: DefaultPluginNode,
@@ -49,11 +50,19 @@ const DiffCanvas = ({ nodes, connections, backgroundId }: IDiffCanvasProps) => {
       edges={connections}
       nodesConnectable={false}
       nodesDraggable={false}
+      minZoom={-5}
       elementsSelectable={false}
       nodeTypes={nodeTypes}
       fitView
     >
-      {nodes.length > 5 && <MiniMap pannable />}
+      {nodes.length > 5 && (
+        <MiniMap
+          pannable
+          nodeColor={(node: PipelineNode) =>
+            getPluginDiffColors(node.data.diffItem?.diffIndicator).primaryLightest
+          }
+        />
+      )}
       <Controls position="top-right" showInteractive={false} />
       <Background id={backgroundId} />
     </ReactFlow>


### PR DESCRIPTION
# [CDAP-20729](https://cdap.atlassian.net/browse/CDAP-20729) Add diff colors to nodes in the minimap

## Description
Add diff colors to nodes in the minimap.

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20729](https://cdap.atlassian.net/browse/CDAP-20729)

## Screenshots
![Screenshot 2023-07-13 5 32 36 PM](https://github.com/cdapio/cdap-ui/assets/47050442/ba7d5409-6d56-43c8-bd4f-471505098c21)




[CDAP-20725]: https://cdap.atlassian.net/browse/CDAP-20725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20725]: https://cdap.atlassian.net/browse/CDAP-20725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CDAP-20729]: https://cdap.atlassian.net/browse/CDAP-20729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20729]: https://cdap.atlassian.net/browse/CDAP-20729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ