### PR TITLE
[CDAP-20728] Fix connection diff list item alignment

### DIFF
--- a/app/cdap/components/PipelineDiff/DiffList/DiffListItem.tsx
+++ b/app/cdap/components/PipelineDiff/DiffList/DiffListItem.tsx
@@ -16,7 +16,7 @@
 import React from 'react';
 
 import ListItem from '@material-ui/core/ListItem';
-import ListItemIcon from '@material-ui/core/ListItemIcon';
+import MuiListItemIcon from '@material-ui/core/ListItemIcon';
 import MuiListItemText from '@material-ui/core/ListItemText';
 import IconButton from '@material-ui/core/IconButton';
 
@@ -45,6 +45,12 @@ const CustomIconImg = styled.img`
 
 const ListItemText = styled(MuiListItemText)`
   flex: 1;
+`;
+
+const ListItemIcon = styled(MuiListItemIcon)`
+  min-width: 18px;
+  margin-left: 5px;
+  margin-right: 5px;
 `;
 interface IPluginDiffListItemProps {
   nodeName: string;
@@ -109,9 +115,6 @@ export const ConnectionDiffListItem = ({
         )}
       </ListItemIcon>
       <ListItemText primary={fromNodeName} />
-      <IconButton size="small">
-        <DiffIcon diffType={diffType} />
-      </IconButton>
       <ListItemIcon>
         {toCustomIconSrc ? (
           <CustomIconImgContainer>
@@ -122,6 +125,9 @@ export const ConnectionDiffListItem = ({
         )}
       </ListItemIcon>
       <ListItemText primary={toNodeName} />
+      <IconButton edge="end" size="small">
+        <DiffIcon diffType={diffType} />
+      </IconButton>
     </ListItem>
   );
 };

--- a/app/cdap/components/PipelineDiff/DiffList/DiffListItem.tsx
+++ b/app/cdap/components/PipelineDiff/DiffList/DiffListItem.tsx
@@ -17,7 +17,7 @@ import React from 'react';
 
 import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
-import ListItemText from '@material-ui/core/ListItemText';
+import MuiListItemText from '@material-ui/core/ListItemText';
 import IconButton from '@material-ui/core/IconButton';
 
 import styled from 'styled-components';
@@ -43,6 +43,9 @@ const CustomIconImg = styled.img`
   height: 100%;
 `;
 
+const ListItemText = styled(MuiListItemText)`
+  flex: 1;
+`;
 interface IPluginDiffListItemProps {
   nodeName: string;
   customIconSrc?: string;


### PR DESCRIPTION
# [CDAP-20728](https://cdap.atlassian.net/browse/CDAP-20728) Fix connection diff list item alignment

## Description
- Adjusted flex-basis property of the plugin names in the list item so that they have equal size.
- Moved the diff icon to the very right of connection diff list item.
## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20728](https://cdap.atlassian.net/browse/CDAP-20728)

## Screenshots
Before: 
![Screenshot 2023-07-13 5 38 04 PM](https://github.com/cdapio/cdap-ui/assets/47050442/aaf836f8-45b1-4ef3-b30f-4c942c50c1a8)

After:

![image](https://github.com/cdapio/cdap-ui/assets/47050442/10dad7b4-7749-4d29-a93a-9f0f7d6b9c49)


[CDAP-20728]: https://cdap.atlassian.net/browse/CDAP-20728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20728]: https://cdap.atlassian.net/browse/CDAP-20728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ