### PR TITLE
fix the hydrator multiple connection bug

### DIFF
--- a/app/directives/dag-plus/my-dag-ctrl.js
+++ b/app/directives/dag-plus/my-dag-ctrl.js
@@ -347,6 +347,9 @@ angular.module(PKG.name + '.commons')
       vm.undoStates = DAGPlusPlusNodesStore.getUndoStates();
       vm.redoStates = DAGPlusPlusNodesStore.getRedoStates();
 
+      if (initTimeout) {
+        $timeout.cancel(initTimeout);
+      }
       initTimeout = $timeout(function () {
         initNodes();
         addConnections();


### PR DESCRIPTION
# fix hydrator multiple connection bug

## Description
The customer was observing an inconsistency in the Data Fusion UI as when they load pipelines it shows two arrows indicating an input for the GCS sink plugin, although only one is set.

This was because of a missing clearTimeout call.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20735](https://cdap.atlassian.net/browse/CDAP-20735)

## Test Plan
NA

## Screenshots




[CDAP-20735]: https://cdap.atlassian.net/browse/CDAP-20735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ