### PR TITLE
[CDAP-20694] Navigation from diff list items to canvas node/edges

### DIFF
--- a/app/cdap/components/PipelineDiff/DiffCanvas/PluginConnection.tsx
+++ b/app/cdap/components/PipelineDiff/DiffCanvas/PluginConnection.tsx
@@ -14,10 +14,24 @@
  * the License.
  */
 import React, { useEffect } from 'react';
-import { EdgeProps, BaseEdge, getSmoothStepPath, useReactFlow, useStoreApi } from 'reactflow';
+import { EdgeProps, BaseEdge, getSmoothStepPath, useReactFlow, useStoreApi, Node } from 'reactflow';
 import { DiffIndicator } from '../types';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { actions } from '../store/diffSlice';
+
+function getConnectionBounds(fromNode: Node, toNode: Node) {
+  const x1 = Math.min(fromNode.position.x, toNode.position.x);
+  const y1 = Math.min(fromNode.position.y, toNode.position.y);
+
+  const x2 = Math.max(fromNode.position.x + fromNode.width, toNode.position.x + toNode.width);
+  const y2 = Math.max(fromNode.position.y + fromNode.height, toNode.position.y + toNode.height);
+  return {
+    x: x1,
+    y: y1,
+    width: x2 - x1,
+    height: y2 - y1,
+  };
+}
 
 export const PluginConnection = ({
   id,
@@ -53,19 +67,9 @@ export const PluginConnection = ({
 
   useEffect(() => {
     if (focusElement === id) {
-      const x1 = Math.min(fromNode.position.x, toNode.position.x);
-      const y1 = Math.min(fromNode.position.y, toNode.position.y);
-
-      const x2 = Math.max(fromNode.position.x + fromNode.width, toNode.position.x + toNode.width);
-      const y2 = Math.max(fromNode.position.y + fromNode.height, toNode.position.y + toNode.height);
-      const bounds = {
-        x: x1,
-        y: y1,
-        width: x2 - x1,
-        height: y2 - y1,
-      };
+      const bounds = getConnectionBounds(fromNode, toNode);
       fitBounds(bounds, { duration: 1000 });
-      dispatch(actions.focused());
+      dispatch(actions.endNavigate());
     }
   }, [fromNode, toNode, focusElement]);
 

--- a/app/cdap/components/PipelineDiff/DiffCanvas/PluginConnection.tsx
+++ b/app/cdap/components/PipelineDiff/DiffCanvas/PluginConnection.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+import React, { useEffect } from 'react';
+import { EdgeProps, BaseEdge, getSmoothStepPath, useReactFlow, useStoreApi } from 'reactflow';
+import { DiffIndicator } from '../types';
+import { useAppDispatch, useAppSelector } from '../store/hooks';
+import { actions } from '../store/diffSlice';
+
+export const PluginConnection = ({
+  id,
+  source,
+  target,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  data,
+  ...props
+}: EdgeProps<{ diffIndicator?: DiffIndicator }>) => {
+  const [edgePath, labelX, labelY] = getSmoothStepPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  });
+  const dispatch = useAppDispatch();
+  const { fitBounds } = useReactFlow();
+  const store = useStoreApi();
+  const { nodeInternals } = store.getState();
+  const fromNode = nodeInternals.get(source);
+  const toNode = nodeInternals.get(target);
+
+  const focusElement = useAppSelector((state) => {
+    return state.pipelineDiff.focusElement;
+  });
+
+  useEffect(() => {
+    if (focusElement === id) {
+      const x1 = Math.min(fromNode.position.x, toNode.position.x);
+      const y1 = Math.min(fromNode.position.y, toNode.position.y);
+
+      const x2 = Math.max(fromNode.position.x + fromNode.width, toNode.position.x + toNode.width);
+      const y2 = Math.max(fromNode.position.y + fromNode.height, toNode.position.y + toNode.height);
+      const bounds = {
+        x: x1,
+        y: y1,
+        width: x2 - x1,
+        height: y2 - y1,
+      };
+      fitBounds(bounds, { duration: 1000 });
+      dispatch(actions.focused());
+    }
+  }, [fromNode, toNode, focusElement]);
+
+  return <BaseEdge path={edgePath} {...props} />;
+};

--- a/app/cdap/components/PipelineDiff/DiffCanvas/PluginNode.tsx
+++ b/app/cdap/components/PipelineDiff/DiffCanvas/PluginNode.tsx
@@ -153,7 +153,7 @@ export const DefaultPluginNode = ({
         },
         { duration: 1000 }
       );
-      dispatch(actions.focused());
+      dispatch(actions.endNavigate());
     }
   }, [node, focusElement]);
 

--- a/app/cdap/components/PipelineDiff/DiffCanvas/PluginNode.tsx
+++ b/app/cdap/components/PipelineDiff/DiffCanvas/PluginNode.tsx
@@ -14,8 +14,8 @@
  * the License.
  */
 
-import React from 'react';
-import { Handle, NodeProps, Position } from 'reactflow';
+import React, { useEffect } from 'react';
+import { Handle, NodeProps, Position, useReactFlow, useStoreApi } from 'reactflow';
 import styled from 'styled-components';
 import classnames from 'classnames';
 import { IPipelineNodeData, actions } from '../store/diffSlice';
@@ -23,7 +23,7 @@ import { getPluginDiffColors } from '../util/helpers';
 import { DiffIcon } from '../DiffIcon';
 import Button from '@material-ui/core/Button';
 import { getStageDiffKey } from '../util/diff';
-import { useAppDispatch } from '../store/hooks';
+import { useAppDispatch, useAppSelector } from '../store/hooks';
 
 const NodeRoot = styled.div`
   background: white;
@@ -130,6 +130,33 @@ export const DefaultPluginNode = ({
   const diffIndicator = data.diffItem?.diffIndicator;
   const { primary, primaryLight } = getPluginDiffColors(diffIndicator);
   const dispatch = useAppDispatch();
+
+  const { fitBounds } = useReactFlow();
+  const store = useStoreApi();
+  const { nodeInternals } = store.getState();
+  const node = nodeInternals.get(id);
+
+  const focusElement = useAppSelector((state) => {
+    return state.pipelineDiff.focusElement;
+  });
+
+  useEffect(() => {
+    if (focusElement && focusElement === data.diffKey) {
+      const cx = node.position.x + node.width / 2;
+      const cy = node.position.y + node.height / 2;
+      fitBounds(
+        {
+          x: cx - node.width,
+          y: cy - node.height,
+          width: node.width * 2,
+          height: node.height * 2,
+        },
+        { duration: 1000 }
+      );
+      dispatch(actions.focused());
+    }
+  }, [node, focusElement]);
+
   return (
     <NodeRoot id={id} color={primary}>
       <HeaderRoot>

--- a/app/cdap/components/PipelineDiff/DiffCanvas/index.tsx
+++ b/app/cdap/components/PipelineDiff/DiffCanvas/index.tsx
@@ -29,12 +29,15 @@ import { getReactflowPipelineGraph } from '../util/reactflowGraph';
 import { AvailablePluginsMap, IPipelineConfig, IPipelineDiffMap, NodeType } from '../types';
 import { IPipelineNodeData } from '../store/diffSlice';
 import { getPluginDiffColors } from '../util/helpers';
+import { PluginConnection } from './PluginConnection';
 
 const nodeTypes: Record<NodeType, ComponentType<NodeProps>> = {
   defaultNode: DefaultPluginNode,
   alertErrorNode: PluginNodeWithAlertError,
 };
-
+const edgeTypes = {
+  diffEdge: PluginConnection,
+};
 // A type helper to distribute each node type into its corresponding node
 type PipelineNode<U = NodeType> = U extends NodeType ? Node<IPipelineNodeData, U> : never;
 
@@ -52,6 +55,7 @@ const DiffCanvas = ({ nodes, connections, backgroundId }: IDiffCanvasProps) => {
       nodesDraggable={false}
       minZoom={-5}
       nodeTypes={nodeTypes}
+      edgeTypes={edgeTypes}
       fitView
     >
       {nodes.length > 5 && (

--- a/app/cdap/components/PipelineDiff/DiffList/index.tsx
+++ b/app/cdap/components/PipelineDiff/DiffList/index.tsx
@@ -72,8 +72,10 @@ export const DiffList = () => {
               customIconSrc={customIconSrc}
               iconName={iconName}
               diffKey={stageKey}
-              // TODO: add navigation to the node on canvas
-              onClick={() => dispatch(actions.showDiffDetails(stageKey))}
+              onClick={() => {
+                dispatch(actions.showDiffDetails(stageKey));
+                dispatch(actions.setFocus(stageKey));
+              }}
               diffType={diffIndicator}
               key={stageKey}
             />
@@ -108,8 +110,7 @@ export const DiffList = () => {
               toCustomIconSrc={toCustomIconSrc}
               toIconName={toIconName}
               diffKey={connectionKey}
-              // TODO: add navigation to the nodes it connects on canvas
-              onClick={() => {}}
+              onClick={() => dispatch(actions.setFocus(connectionKey))}
               diffType={diffMap.connections[connectionKey].diffIndicator}
               key={connectionKey}
             />

--- a/app/cdap/components/PipelineDiff/DiffList/index.tsx
+++ b/app/cdap/components/PipelineDiff/DiffList/index.tsx
@@ -74,7 +74,7 @@ export const DiffList = () => {
               diffKey={stageKey}
               onClick={() => {
                 dispatch(actions.showDiffDetails(stageKey));
-                dispatch(actions.setFocus(stageKey));
+                dispatch(actions.startNavigateTo(stageKey));
               }}
               diffType={diffIndicator}
               key={stageKey}
@@ -110,7 +110,7 @@ export const DiffList = () => {
               toCustomIconSrc={toCustomIconSrc}
               toIconName={toIconName}
               diffKey={connectionKey}
-              onClick={() => dispatch(actions.setFocus(connectionKey))}
+              onClick={() => dispatch(actions.startNavigateTo(connectionKey))}
               diffType={diffMap.connections[connectionKey].diffIndicator}
               key={connectionKey}
             />

--- a/app/cdap/components/PipelineDiff/store/diffSlice.ts
+++ b/app/cdap/components/PipelineDiff/store/diffSlice.ts
@@ -28,6 +28,7 @@ export interface IPipelineNodeData extends IPipelineStage {
   customIconSrc?: string;
   iconName: string;
   diffItem?: IStageDiffItem;
+  diffKey: string;
 }
 
 interface IDiffState {
@@ -39,6 +40,8 @@ interface IDiffState {
 
   diffMap: IPipelineDiffMap;
   openDiffItem: string | null;
+
+  focusElement: string | null;
 
   availablePluginsMap: AvailablePluginsMap;
 }
@@ -55,6 +58,8 @@ const initialState: IDiffState = {
     connections: {},
   },
   openDiffItem: null,
+
+  focusElement: null,
 
   availablePluginsMap: {},
 };
@@ -93,6 +98,13 @@ const diffSlice = createSlice({
     },
     modalClosed(state) {
       state.openDiffItem = null;
+      state.focusElement = null;
+    },
+    setFocus(state, action: PayloadAction<string>) {
+      state.focusElement = action.payload;
+    },
+    focused(state) {
+      state.focusElement = null;
     },
   },
 });

--- a/app/cdap/components/PipelineDiff/store/diffSlice.ts
+++ b/app/cdap/components/PipelineDiff/store/diffSlice.ts
@@ -34,33 +34,25 @@ export interface IPipelineNodeData extends IPipelineStage {
 interface IDiffState {
   isLoading: boolean;
   error: any; // TODO: type
-
   topPipelineConfig: IPipelineConfig | null;
   bottomPipelineConfig: IPipelineConfig | null;
-
   diffMap: IPipelineDiffMap;
   openDiffItem: string | null;
-
   focusElement: string | null;
-
   availablePluginsMap: AvailablePluginsMap;
 }
 
 const initialState: IDiffState = {
   isLoading: false,
   error: null,
-
   topPipelineConfig: null,
   bottomPipelineConfig: null,
-
   diffMap: {
     stages: {},
     connections: {},
   },
   openDiffItem: null,
-
   focusElement: null,
-
   availablePluginsMap: {},
 };
 
@@ -100,10 +92,10 @@ const diffSlice = createSlice({
       state.openDiffItem = null;
       state.focusElement = null;
     },
-    setFocus(state, action: PayloadAction<string>) {
+    startNavigateTo(state, action: PayloadAction<string>) {
       state.focusElement = action.payload;
     },
-    focused(state) {
+    endNavigate(state) {
       state.focusElement = null;
     },
   },

--- a/app/cdap/components/PipelineDiff/util/reactflowGraph.ts
+++ b/app/cdap/components/PipelineDiff/util/reactflowGraph.ts
@@ -57,8 +57,9 @@ export function getReactflowPipelineGraph(
     stageNameToStage[stage.name] = stage;
     const pluginMapKey = getAvailabePluginsMapKeyFromPlugin(stage.plugin);
 
+    const stageDiffKey = getStageDiffKey(stage);
     const type = pluginReactflowNodeType(availablePluginsMap, pluginMapKey);
-    const diffItem = diffMap.stages[getStageDiffKey(stage)];
+    const diffItem = diffMap.stages[stageDiffKey];
 
     return {
       id: stage.name,
@@ -67,6 +68,7 @@ export function getReactflowPipelineGraph(
         customIconSrc: getCustomIconSrc(availablePluginsMap, pluginMapKey),
         iconName: getPluginIcon(stage.plugin.name),
         diffItem,
+        diffKey: stageDiffKey,
       },
       type,
       position: {
@@ -90,10 +92,13 @@ export function getReactflowPipelineGraph(
     const { primaryLight } = getPluginDiffColors(diffIndicator);
     return {
       id: connectionKey,
+      data: {
+        diffIndicator,
+      },
       source: connection.from,
       target: connection.to,
       sourceHandle,
-      type: 'smoothstep',
+      type: diffIndicator ? 'diffEdge' : 'smoothstep',
       isSelectable: true,
       markerEnd: {
         type: MarkerType.ArrowClosed,


### PR DESCRIPTION
# [CDAP-20694](https://cdap.atlassian.net/browse/CDAP-20694) Navigation from diff list items to canvas node/edges

## Description 
- Added a new state to the store indicating the currently focused node/edge
- Added a custom edge type that watches the new state: sets the center of the canvas to the center of the two plugin nodes the edge connects when the state is equal to the connection's diff key
- Plugin nodes watch the new state similar to the new custom edges.

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20694](https://cdap.atlassian.net/browse/CDAP-20694)

## Screenshots
Navigate to the modified node `Parse and Clean`:
![image](https://github.com/cdapio/cdap-ui/assets/47050442/0e562bdf-f23e-4688-94ad-a53e96a1f723)

Navigate to the removed connection from `Parse and Clean` to `Cleanup Errors`:
![image](https://github.com/cdapio/cdap-ui/assets/47050442/cbcdd473-6470-4b93-83f4-63e2c9fe0ed6)






[CDAP-20694]: https://cdap.atlassian.net/browse/CDAP-20694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20694]: https://cdap.atlassian.net/browse/CDAP-20694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ