### PR TITLE
 [CDAP-20737] Add diff icon to edges in canvas

### DIFF
--- a/app/cdap/components/PipelineDiff/DiffCanvas/PluginConnection.tsx
+++ b/app/cdap/components/PipelineDiff/DiffCanvas/PluginConnection.tsx
@@ -14,10 +14,26 @@
  * the License.
  */
 import React, { useEffect } from 'react';
-import { EdgeProps, BaseEdge, getSmoothStepPath, useReactFlow, useStoreApi } from 'reactflow';
+import {
+  EdgeProps,
+  EdgeLabelRenderer,
+  BaseEdge,
+  getSmoothStepPath,
+  useReactFlow,
+  useStoreApi,
+} from 'reactflow';
+import styled from 'styled-components';
+
 import { DiffIndicator } from '../types';
+import { DiffIcon } from '../DiffIcon';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { actions } from '../store/diffSlice';
+
+const DiffIconRoot = styled(DiffIcon)`
+  position: absolute;
+  transform: translate(-50%, -50%)
+    translate(${({ labelX }) => labelX}px, ${({ labelY }) => labelY}px);
+`;
 
 export const PluginConnection = ({
   id,
@@ -69,5 +85,14 @@ export const PluginConnection = ({
     }
   }, [fromNode, toNode, focusElement]);
 
-  return <BaseEdge path={edgePath} {...props} />;
+  return (
+    <>
+      <BaseEdge path={edgePath} {...props} />
+      {data.diffIndicator && (
+        <EdgeLabelRenderer>
+          <DiffIconRoot diffType={data.diffIndicator} labelX={labelX} labelY={labelY} />
+        </EdgeLabelRenderer>
+      )}
+    </>
+  );
 };


### PR DESCRIPTION
# [CDAP-20737](https://cdap.atlassian.net/browse/CDAP-20737) Add diff icon to edges in canvas

## Description
- Added the diff icon as an edge label in reactflow as a way of indicating difference other than colors.

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20737](https://cdap.atlassian.net/browse/CDAP-20737)

## Screenshots
![Screenshot 2023-07-20 12 57 48 PM](https://github.com/cdapio/cdap-ui/assets/47050442/3cb8e587-fdb8-405f-938c-77359536ff42)




[CDAP-20737]: https://cdap.atlassian.net/browse/CDAP-20737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20737]: https://cdap.atlassian.net/browse/CDAP-20737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ