### PR TITLE
[CDAP-20738] Fix pushdown not exported

### DIFF
--- a/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ConfigModelessActionButtons/index.tsx
+++ b/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ConfigModelessActionButtons/index.tsx
@@ -87,12 +87,10 @@ export const ConfigModelessActionButtons = ({ ...props }: IConfigModelessActionB
 
   const saveAndAction = (actionFn) => {
     setSaveLoading(true);
-    let observable;
-    if (lifecycleManagementEditEnabled) {
-      observable = updatePreferences();
-    } else {
-      observable = Observable.forkJoin(updatePipeline(), updatePreferences());
-    }
+    const observable = Observable.forkJoin(
+      updatePipeline(lifecycleManagementEditEnabled),
+      updatePreferences()
+    );
     observable.subscribe(
       () => {
         actionFn();

--- a/app/cdap/components/PipelineConfigurations/ConfigurationsContent/PushdownTabContent.tsx
+++ b/app/cdap/components/PipelineConfigurations/ConfigurationsContent/PushdownTabContent.tsx
@@ -26,35 +26,17 @@ import {
   convertKeyValuePairsToMap,
   convertMapToKeyValuePairs,
   flattenObj,
-  unflatternStringToObj,
+  getPushdownObjectFromRuntimeArgs,
+  isPushdownEnabled,
 } from 'services/helpers';
 import { useFeatureFlagDefaultFalse } from 'services/react/customHooks/useFeatureFlag';
 
 const getPushdownEnabledValue = (state) => {
-  const pushdownEnabledKeyValuePair = state.runtimeArgs.pairs.find(
-    (pair) => pair.key === GENERATED_RUNTIMEARGS.PIPELINE_PUSHDOWN_ENABLED
-  );
-  return pushdownEnabledKeyValuePair
-    ? pushdownEnabledKeyValuePair.value === 'true'
-    : state.pushdownEnabled;
+  return isPushdownEnabled(state.runtimeArgs) || state.pushdownEnabled;
 };
 
 const getTransformationPushdownValue = (state) => {
-  if (state.transformationPushdown) {
-    return state.transformationPushdown;
-  }
-  const transformationPushdownKeyValuePair = state.runtimeArgs.pairs.filter((pair) =>
-    pair.key.startsWith(GENERATED_RUNTIMEARGS.PIPELINE_TRANSFORMATION_PUSHDOWN_PREFIX)
-  );
-  const pushdownObject = {};
-  transformationPushdownKeyValuePair.forEach((pair) => {
-    // unflattern the runtimeargs key and put it in pushdown object
-    const trimmedKey = pair.key.substring(
-      GENERATED_RUNTIMEARGS.PIPELINE_TRANSFORMATION_PUSHDOWN_PREFIX.length
-    );
-    unflatternStringToObj(pushdownObject, trimmedKey, pair.value);
-  });
-  return pushdownObject;
+  return getPushdownObjectFromRuntimeArgs(state.runtimeArgs) || state.transformationPushdown;
 };
 
 export default function PushdownTabContent({}) {

--- a/app/cdap/components/PipelineConfigurations/Store/ActionCreator.js
+++ b/app/cdap/components/PipelineConfigurations/Store/ActionCreator.js
@@ -44,6 +44,7 @@ import uniqBy from 'lodash/uniqBy';
 import cloneDeep from 'lodash/cloneDeep';
 import { CLOUD } from 'services/global-constants';
 import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
 import { map } from 'rxjs/operators';
 
 // Filter certain preferences from being shown in the run time arguments
@@ -150,7 +151,7 @@ const updatePreferences = () => {
   );
 };
 
-const updatePipeline = () => {
+const updatePipeline = (lifecycleManagementEditEnabled = true) => {
   let detailStoreState = PipelineDetailStore.getState();
   let { name, description, artifact, principal } = detailStoreState;
   let { stages, connections, comments } = detailStoreState.config;
@@ -223,6 +224,14 @@ const updatePipeline = () => {
     config = { ...commonConfig, ...realtimeOnlyConfig };
   } else if (artifact.name === GLOBALS.eltSqlPipeline) {
     config = { ...commonConfig, ...sqlOnlyConfig };
+  }
+
+  if (lifecycleManagementEditEnabled) {
+    PipelineDetailStore.dispatch({
+      type: PipelineDetailActions.SET_CONFIG,
+      payload: { config },
+    });
+    return of({});
   }
 
   let publishObservable = MyPipelineApi.publish(

--- a/app/cdap/services/helpers.js
+++ b/app/cdap/services/helpers.js
@@ -31,6 +31,7 @@ import isArray from 'lodash/isArray';
 // We don't use webpack alias here because this is used in Footer which is used in login app
 // And for login 'components/Lab/..' aliases to components folder inside login app.
 import experimentsList from '../components/Lab/experiment-list.tsx';
+import { GENERATED_RUNTIMEARGS } from './global-constants.js';
 /*
   Purpose: Query a json object or an array of json objects
   Return: Returns undefined if property is not defined(never set) and
@@ -897,6 +898,38 @@ const PIPELINE_ARTIFACTS = [
   'cdap-data-streams',
 ];
 
+/**
+ * 
+ * @param {object} runtimeArgs 
+ * @returns a pushdown config object generated from runtimeArgs
+ */
+const getPushdownObjectFromRuntimeArgs = (runtimeArgs) => {
+  const transformationPushdownKeyValuePair = runtimeArgs.pairs.filter((pair) =>
+    pair.key.startsWith(GENERATED_RUNTIMEARGS.PIPELINE_TRANSFORMATION_PUSHDOWN_PREFIX)
+  );
+  const pushdownObject = {};
+  transformationPushdownKeyValuePair.forEach((pair) => {
+    // unflattern the runtimeargs key and put it in pushdown object
+    const trimmedKey = pair.key.substring(
+      GENERATED_RUNTIMEARGS.PIPELINE_TRANSFORMATION_PUSHDOWN_PREFIX.length
+    );
+    unflatternStringToObj(pushdownObject, trimmedKey, pair.value);
+  });
+  return pushdownObject
+}
+
+/**
+ * 
+ * @param {object} runtimeArgs 
+ * @returns a boolean value if pushdown enabled
+ */
+const isPushdownEnabled = (runtimeArgs) => {
+  const pushdownEnabledKeyValuePair = runtimeArgs.pairs.find(
+    (pair) => pair.key === GENERATED_RUNTIMEARGS.PIPELINE_PUSHDOWN_ENABLED
+  );
+  return pushdownEnabledKeyValuePair ? pushdownEnabledKeyValuePair.value === 'true' : false
+}
+
 export {
   openLinkInNewTab,
   objectQuery,
@@ -959,5 +992,7 @@ export {
   unflatternStringToObj,
   arrayOfStringsMatchTargetPrefix,
   PIPELINE_ARTIFACTS,
-  BATCH_PIPELINE_TYPE
+  BATCH_PIPELINE_TYPE,
+  getPushdownObjectFromRuntimeArgs,
+  isPushdownEnabled
 };


### PR DESCRIPTION
# [CDAP-20738] Fix pushdown not exported

## Description
Pushdown was not exported because in 6.9 we do not redeploy the pipeline when changing configurations. So PipelineDetailStore was not able to get pushdown config. The fix is to manually fetching pushdown config from runtimeArgs if they exist.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20738](https://cdap.atlassian.net/browse/CDAP-20738)

## Test Plan
Manually tested





[CDAP-20738]: https://cdap.atlassian.net/browse/CDAP-20738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20738]: https://cdap.atlassian.net/browse/CDAP-20738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ