### PR TITLE
[CDAP-20744] Add support for any nested modification difference to diff table

### DIFF
--- a/app/cdap/components/PipelineDiff/DiffInfo/DiffInfoTable.tsx
+++ b/app/cdap/components/PipelineDiff/DiffInfo/DiffInfoTable.tsx
@@ -23,8 +23,166 @@ import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
 import TableContainer from '@material-ui/core/TableContainer';
-import { DiffIndicator, IPipelineStage } from '../types';
+import { Diff, ChangedArray, DiffIndicator, IPipelineStage, ChangedObject } from '../types';
 import { ADDED_REGEX, DELETED_REGEX, I18N_PREFIX } from '../constants';
+
+function _flattenObject<T>(obj: T, name: string = '') {
+  if (typeof obj !== 'object' && name === '') {
+    return obj;
+  }
+  if (typeof obj !== 'object') {
+    return { [name]: obj };
+  }
+
+  const flatObj: Record<string, any> = {};
+  Object.keys(obj).forEach((keyName) => {
+    const newKeyName = name !== '' ? `${name}.${keyName}` : keyName;
+    Object.assign(flatObj, _flattenObject(obj[keyName], newKeyName));
+  });
+  return flatObj;
+}
+
+function _getModifiedArrayDiffRows<T extends any[]>(diff: ChangedArray<T>, name: string = '') {
+  const namePrefix = name !== '' ? `${name}.` : '';
+  return [].concat(
+    ...diff.map((item, index) => {
+      if (item[0] === ' ') {
+        return [];
+      }
+      if (item[0] !== DiffIndicator.MODIFIED) {
+        const flatDiffItem = _flattenObject(item[1], `${namePrefix}${index}`);
+        return Object.keys(flatDiffItem).map((name) => ({
+          name,
+          oldValue: item[0] === DiffIndicator.DELETED ? flatDiffItem[name] : '-',
+          newValue: item[0] === DiffIndicator.ADDED ? flatDiffItem[name] : '-',
+        }));
+      }
+      return _getModifiedDiffRows(item[1], `${namePrefix}${index}`);
+    })
+  );
+}
+
+function _getModifiedObjectDiffRows<T>(diff: ChangedObject<T>, name: string = '') {
+  if (typeof diff.__new === 'object' && typeof diff.__old === 'object') {
+    return [
+      {
+        name,
+        oldValue: JSON.stringify(diff.__old, null, 2),
+        newValue: JSON.stringify(diff.__new, null, 2),
+      },
+    ];
+  }
+  if (typeof diff.__old === 'object') {
+    const flatOld = _flattenObject(diff.__old, name);
+    const oldEntries = Object.keys(flatOld).map((name) => ({
+      name,
+      oldValue: flatOld[name],
+      newValue: '-',
+    }));
+    return [
+      {
+        name,
+        oldValue: '-',
+        newValue: diff.__new,
+      },
+      ...oldEntries,
+    ];
+  }
+  if (typeof diff.__new === 'object') {
+    const flatNew = _flattenObject(diff.__new, name);
+    const newEntries = Object.keys(flatNew).map((name) => ({
+      name,
+      oldValue: '-',
+      newValue: flatNew[name],
+    }));
+    return [
+      {
+        name,
+        oldValue: diff.__old,
+        newValue: '-',
+      },
+      ...newEntries,
+    ];
+  }
+  return [
+    {
+      name,
+      oldValue: diff.__old,
+      newValue: diff.__new,
+    },
+  ];
+}
+
+function _getModifiedPropertyDiffRows<T>(diff: Diff<T>, name: string = '') {
+  const namePrefix = name !== '' ? `${name}.` : '';
+  return [].concat(
+    ...Object.keys(diff).map((keyName) => {
+      if (keyName.match(ADDED_REGEX)) {
+        const name = `${namePrefix}${keyName.replace(ADDED_REGEX, '')}`;
+        if (typeof diff[keyName] === 'object') {
+          const flatAdded = _flattenObject(diff[keyName], name);
+          return Object.keys(flatAdded).map((name) => ({
+            name,
+            oldValue: '-',
+            newValue: flatAdded[name],
+          }));
+        }
+        return [
+          {
+            name,
+            oldValue: '-',
+            newValue: diff[keyName],
+          },
+        ];
+      }
+      if (keyName.match(DELETED_REGEX)) {
+        const name = `${namePrefix}${keyName.replace(DELETED_REGEX, '')}`;
+        if (typeof diff[keyName] === 'object') {
+          const flatDeleted = _flattenObject(diff[keyName], name);
+          return Object.keys(flatDeleted).map((name) => ({
+            name,
+            oldValue: flatDeleted[name],
+            newValue: '-',
+          }));
+        }
+        return [
+          {
+            name,
+            oldValue: diff[keyName],
+            newValue: '-',
+          },
+        ];
+      }
+      return _getModifiedDiffRows(diff[keyName], `${namePrefix}${keyName}`);
+    })
+  );
+}
+
+function _getModifiedDiffRows<T>(diff: Diff<T>, name: string = '') {
+  // An array in difference setting is represented as in `DiffArray` type. For that reason
+  // if an element of the array is different, every element needs to be checked and
+  // handled accordingly
+  if (Array.isArray(diff)) {
+    return _getModifiedArrayDiffRows(diff, name);
+  }
+  // If the object has changed types (like from an object to a string) or its primitive value
+  // has changed, its diff will be of type `ChangedObject`.
+  if (typeof diff === 'object' && '__old' in diff && '__new' in diff) {
+    return _getModifiedObjectDiffRows(diff, name);
+  }
+
+  // If function call reaches to this point, the diff object has a property
+  // that has been added, deleted or modified.
+  return _getModifiedPropertyDiffRows(diff, name);
+}
+
+function getDiffRows(diffIndicator: DiffIndicator, diff: Diff<IPipelineStage>) {
+  if (diffIndicator === DiffIndicator.DELETED || diffIndicator === DiffIndicator.ADDED) {
+    const flatDiff = _flattenObject(diff);
+    return Object.keys(flatDiff).map((name) => ({ name, value: flatDiff[name] as string }));
+  }
+  return _getModifiedDiffRows(diff);
+}
 
 const DiffInfoTableContainer = styled(TableContainer)`
   flex-grow: 1;
@@ -32,47 +190,13 @@ const DiffInfoTableContainer = styled(TableContainer)`
   width: 100%;
 `;
 
-function getEntryData(diffIndicator: DiffIndicator, propertyName: string, propertyValue) {
-  if (diffIndicator === DiffIndicator.DELETED || diffIndicator === DiffIndicator.ADDED) {
-    return { name: propertyName, value: propertyValue as string };
-  }
-
-  if (typeof propertyValue === 'string' && propertyName.match(ADDED_REGEX)) {
-    return {
-      name: propertyName.replace(ADDED_REGEX, ''),
-      oldValue: '-',
-      newValue: propertyValue,
-    };
-  }
-
-  if (typeof propertyValue === 'string' && propertyName.match(DELETED_REGEX)) {
-    return {
-      name: propertyName.replace(DELETED_REGEX, ''),
-      oldValue: propertyValue,
-      newValue: '-',
-    };
-  }
-
-  if (typeof propertyValue === 'string') {
-    return {
-      name: propertyName,
-      oldValue: '-',
-      newValue: '-',
-    };
-  }
-
-  return {
-    name: propertyName,
-    oldValue: propertyValue.__old,
-    newValue: propertyValue.__new,
-  };
-}
-
 interface IDiffInfoTableProps {
   diffIndicator: DiffIndicator;
-  pluginProperties: IPipelineStage['plugin']['properties'] | undefined;
+  diff: Diff<IPipelineStage>;
 }
-export const DiffInfoTable = ({ diffIndicator, pluginProperties }: IDiffInfoTableProps) => {
+
+export const DiffInfoTable = ({ diffIndicator, diff }: IDiffInfoTableProps) => {
+  const diffRows = getDiffRows(diffIndicator, diff);
   return (
     <DiffInfoTableContainer>
       <Table stickyHeader size="small">
@@ -89,26 +213,25 @@ export const DiffInfoTable = ({ diffIndicator, pluginProperties }: IDiffInfoTabl
             )}
           </TableRow>
         </TableHead>
-        {Object.keys(pluginProperties ?? {}).map((property) => {
-          const entryData = getEntryData(diffIndicator, property, pluginProperties[property]);
+        {diffRows.map((row) => {
           if (diffIndicator === DiffIndicator.MODIFIED) {
             return (
-              <TableRow key={`properties.${property}`}>
+              <TableRow key={row.name}>
                 <TableCell component="th" scope="row">
-                  properties.{entryData.name}
+                  {row.name}
                 </TableCell>
-                <TableCell align="right">{entryData.oldValue}</TableCell>
-                <TableCell align="right">{entryData.newValue}</TableCell>
+                <TableCell align="right">{row.oldValue}</TableCell>
+                <TableCell align="right">{row.newValue}</TableCell>
               </TableRow>
             );
           }
           return (
-            <TableRow key={`properties.${property}`}>
+            <TableRow key={row.name}>
               <TableCell component="th" scope="row">
-                properties.{entryData.name}
+                {row.name}
               </TableCell>
               <TableCell style={{ overflowWrap: 'anywhere' }} align="right">
-                {entryData.value}
+                {row.value}
               </TableCell>
             </TableRow>
           );

--- a/app/cdap/components/PipelineDiff/DiffInfo/index.tsx
+++ b/app/cdap/components/PipelineDiff/DiffInfo/index.tsx
@@ -57,10 +57,7 @@ export const DiffInfo = ({ openDiffItem, diffMap, availablePluginsMap }: IDiffIn
         )}
         iconName={getPluginIcon(getPluginNameFromStageDiffKey(openDiffItem))}
       />
-      <DiffInfoTable
-        diffIndicator={diffMap.stages[openDiffItem].diffIndicator}
-        pluginProperties={diff.plugin?.properties}
-      />
+      <DiffInfoTable diffIndicator={diffMap.stages[openDiffItem].diffIndicator} diff={diff} />
     </DiffInfoContainer>
   );
 };

--- a/app/cdap/components/PipelineDiff/store/diffSlice.ts
+++ b/app/cdap/components/PipelineDiff/store/diffSlice.ts
@@ -67,6 +67,7 @@ const diffSlice = createSlice({
     ) {
       state.topPipelineConfig = action.payload.topPipelineConfig;
       state.bottomPipelineConfig = action.payload.bottomPipelineConfig;
+      // @ts-ignore TODO: fix type issue
       state.diffMap = action.payload.diffMap;
       state.availablePluginsMap = action.payload.availablePluginsMap;
       state.isLoading = false;

--- a/app/cdap/components/PipelineDiff/types.ts
+++ b/app/cdap/components/PipelineDiff/types.ts
@@ -14,14 +14,25 @@
  * the License.
  */
 import { Edge, Node } from 'reactflow';
-export type DeepPartial<T> = {
-  [P in keyof T]?: DeepPartial<T[P]>;
+
+export type ChangedArray<T extends any[]> = Array<
+  [' '] | ['+' | '-', T[number]] | ['~', Diff<T[number]>]
+>;
+export interface ChangedObject<T> {
+  __old: T;
+  __new: T;
+}
+export type ChangedProperty<T> = {
+  [P in keyof T]?: Diff<T[P]>;
 };
+
+export type Diff<T> = T extends [] ? ChangedArray<T> : ChangedObject<T> | ChangedProperty<T>;
 export interface IPipelineConnection {
   from: string;
   to: string;
 }
 export interface IPipelineStage {
+  [prop: string]: any;
   id: string;
   name: string;
   plugin: {
@@ -56,11 +67,11 @@ export interface IStageDiffItem {
   diffIndicator: DiffIndicator;
   stage1: IPipelineStage;
   stage2: IPipelineStage;
-  diff: DeepPartial<IPipelineStage>;
+  diff: ChangedProperty<IPipelineStage>;
 }
 export interface IConnectionDiffItem {
   diffIndicator: DiffIndicator;
-  diff: DeepPartial<IPipelineConnection>;
+  diff: ChangedProperty<IPipelineConnection>;
   from: IPipelineStage;
   to: IPipelineStage;
 }

--- a/app/cdap/components/shared/AppHeader/AppToolBar/AppToolbar.tsx
+++ b/app/cdap/components/shared/AppHeader/AppToolBar/AppToolbar.tsx
@@ -99,7 +99,7 @@ class AppToolbar extends React.PureComponent<IAppToolbarProps, IAppToolbarState>
             featureUrl={`/ns/${namespace}/reports`}
             onClick={() => this.eventEmitter.emit(globalEvents.CLOSEMARKET)}
           />
-          <HubButton />
+          {/* <HubButton /> */}
           <ToolBarFeatureLink
             featureFlag={true}
             featureName={Theme.featureNames.systemAdmin}


### PR DESCRIPTION
# [CDAP-20744](https://cdap.atlassian.net/browse/CDAP-20744) Add support for any nested modification difference to diff table

## Description
Currently, the diff info table only shows diff in the `plugin.properties`, and assumes every value in this object is a string. Addition of object diffs and displaying every diff item will provide a more verbose and complete information to the user.

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [x] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20744](https://cdap.atlassian.net/browse/CDAP-20744) 


## Screenshots
before
![Screenshot 2023-07-28 3 19 37 PM](https://github.com/cdapio/cdap-ui/assets/47050442/1bd2cb0c-0d6e-4552-bf26-aa210df3fbb5)

after
![Screenshot 2023-07-28 3 20 37 PM](https://github.com/cdapio/cdap-ui/assets/47050442/42a9535a-5e85-4bde-a44f-019677d95cfb)




[CDAP-20744]: https://cdap.atlassian.net/browse/CDAP-20744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20744]: https://cdap.atlassian.net/browse/CDAP-20744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ