### PR TITLE
[CDAP-20746] Fixes navigation from diff list not working on nodes outside canvas 

### DIFF
--- a/app/cdap/components/PipelineDiff/DiffCanvas/PluginConnection.tsx
+++ b/app/cdap/components/PipelineDiff/DiffCanvas/PluginConnection.tsx
@@ -13,36 +13,12 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React, { useEffect } from 'react';
-import {
-  EdgeProps,
-  EdgeLabelRenderer,
-  BaseEdge,
-  getSmoothStepPath,
-  useReactFlow,
-  useStoreApi,
-  Node,
-} from 'reactflow';
+import React from 'react';
+import { EdgeProps, EdgeLabelRenderer, BaseEdge, getSmoothStepPath } from 'reactflow';
 import styled from 'styled-components';
 
-import { DiffIndicator } from '../types';
 import { DiffIcon } from '../DiffIcon';
-import { useAppDispatch, useAppSelector } from '../store/hooks';
-import { actions } from '../store/diffSlice';
-
-function getConnectionBounds(fromNode: Node, toNode: Node) {
-  const x1 = Math.min(fromNode.position.x, toNode.position.x);
-  const y1 = Math.min(fromNode.position.y, toNode.position.y);
-
-  const x2 = Math.max(fromNode.position.x + fromNode.width, toNode.position.x + toNode.width);
-  const y2 = Math.max(fromNode.position.y + fromNode.height, toNode.position.y + toNode.height);
-  return {
-    x: x1,
-    y: y1,
-    width: x2 - x1,
-    height: y2 - y1,
-  };
-}
+import { IPipelineEdgeData } from '../types';
 
 const DiffIconRoot = styled(DiffIcon)`
   position: absolute;
@@ -62,7 +38,7 @@ export const PluginConnection = ({
   targetPosition,
   data,
   ...props
-}: EdgeProps<{ diffIndicator?: DiffIndicator }>) => {
+}: EdgeProps<IPipelineEdgeData>) => {
   const [edgePath, labelX, labelY] = getSmoothStepPath({
     sourceX,
     sourceY,
@@ -71,25 +47,6 @@ export const PluginConnection = ({
     targetY,
     targetPosition,
   });
-  const dispatch = useAppDispatch();
-  const { fitBounds } = useReactFlow();
-  const store = useStoreApi();
-  const { nodeInternals } = store.getState();
-  const fromNode = nodeInternals.get(source);
-  const toNode = nodeInternals.get(target);
-
-  const focusElement = useAppSelector((state) => {
-    return state.pipelineDiff.focusElement;
-  });
-
-  useEffect(() => {
-    if (focusElement === id) {
-      const bounds = getConnectionBounds(fromNode, toNode);
-      fitBounds(bounds, { duration: 1000 });
-      dispatch(actions.endNavigate());
-    }
-  }, [fromNode, toNode, focusElement]);
-
   return (
     <>
       <BaseEdge path={edgePath} {...props} />

--- a/app/cdap/components/PipelineDiff/DiffCanvas/PluginNode.tsx
+++ b/app/cdap/components/PipelineDiff/DiffCanvas/PluginNode.tsx
@@ -14,16 +14,17 @@
  * the License.
  */
 
-import React, { useEffect } from 'react';
-import { Handle, NodeProps, Position, useReactFlow, useStoreApi } from 'reactflow';
+import React from 'react';
+import { Handle, NodeProps, Position } from 'reactflow';
 import styled from 'styled-components';
 import classnames from 'classnames';
-import { IPipelineNodeData, actions } from '../store/diffSlice';
+import { actions } from '../store/diffSlice';
 import { getPluginDiffColors } from '../util/helpers';
 import { DiffIcon } from '../DiffIcon';
 import Button from '@material-ui/core/Button';
 import { getStageDiffKey } from '../util/diff';
-import { useAppDispatch, useAppSelector } from '../store/hooks';
+import { useAppDispatch } from '../store/hooks';
+import { IPipelineNodeData } from '../types';
 
 const NodeRoot = styled.div`
   background: white;
@@ -130,36 +131,6 @@ export const DefaultPluginNode = ({
   const diffIndicator = data.diffItem?.diffIndicator;
   const { primary, primaryLight } = getPluginDiffColors(diffIndicator);
   const dispatch = useAppDispatch();
-
-  const { fitBounds } = useReactFlow();
-  const store = useStoreApi();
-  const { nodeInternals } = store.getState();
-  const node = nodeInternals.get(id);
-
-  const focusElement = useAppSelector((state) => {
-    return state.pipelineDiff.focusElement;
-  });
-
-  useEffect(() => {
-    if (focusElement && focusElement === data.diffKey) {
-      const cx = node.position.x + node.width / 2;
-      const cy = node.position.y + node.height / 2;
-      // setTimeout allows for navigating after a possible resize occurs
-      // e.g. another window opens that causes the canvas to be smaller
-      setTimeout(() => {
-        fitBounds(
-          {
-            x: cx - node.width,
-            y: cy - node.height,
-            width: node.width * 2,
-            height: node.height * 2,
-          },
-          { duration: 1000 }
-        );
-        dispatch(actions.endNavigate());
-      }, 0);
-    }
-  }, [node, focusElement]);
 
   return (
     <NodeRoot id={id} color={primary}>

--- a/app/cdap/components/PipelineDiff/DiffList/index.tsx
+++ b/app/cdap/components/PipelineDiff/DiffList/index.tsx
@@ -150,7 +150,7 @@ export const DiffList = () => {
                 {...props}
                 onClick={() => {
                   dispatch(actions.showDiffDetails(props.diffKey));
-                  dispatch(actions.startNavigateTo(props.diffKey));
+                  dispatch(actions.startNavigateTo({ type: 'node', name: props.diffKey }));
                 }}
                 key={props.diffKey}
               />
@@ -162,7 +162,9 @@ export const DiffList = () => {
             return (
               <ConnectionDiffListItem
                 {...props}
-                onClick={() => dispatch(actions.startNavigateTo(props.diffKey))}
+                onClick={() =>
+                  dispatch(actions.startNavigateTo({ type: 'edge', name: props.diffKey }))
+                }
                 key={props.diffKey}
               />
             );

--- a/app/cdap/components/PipelineDiff/store/diffSlice.ts
+++ b/app/cdap/components/PipelineDiff/store/diffSlice.ts
@@ -16,21 +16,12 @@
 
 import { createSlice } from '@reduxjs/toolkit';
 import { PayloadAction } from '@reduxjs/toolkit';
-import {
-  AvailablePluginsMap,
-  IPipelineConfig,
-  IPipelineDiffMap,
-  IPipelineStage,
-  IStageDiffItem,
-} from '../types';
+import { AvailablePluginsMap, IPipelineConfig, IPipelineDiffMap } from '../types';
 
-export interface IPipelineNodeData extends IPipelineStage {
-  customIconSrc?: string;
-  iconName: string;
-  diffItem?: IStageDiffItem;
-  diffKey: string;
+interface FocusElement {
+  type: 'node' | 'edge';
+  name: string;
 }
-
 interface IDiffState {
   isLoading: boolean;
   error: any; // TODO: type
@@ -38,7 +29,7 @@ interface IDiffState {
   bottomPipelineConfig: IPipelineConfig | null;
   diffMap: IPipelineDiffMap;
   openDiffItem: string | null;
-  focusElement: string | null;
+  focusElement: FocusElement | null;
   availablePluginsMap: AvailablePluginsMap;
 }
 
@@ -92,7 +83,7 @@ const diffSlice = createSlice({
       state.openDiffItem = null;
       state.focusElement = null;
     },
-    startNavigateTo(state, action: PayloadAction<string>) {
+    startNavigateTo(state, action: PayloadAction<FocusElement>) {
       state.focusElement = action.payload;
     },
     endNavigate(state) {

--- a/app/cdap/components/PipelineDiff/types.ts
+++ b/app/cdap/components/PipelineDiff/types.ts
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
+import { Edge, Node } from 'reactflow';
 export type DeepPartial<T> = {
   [P in keyof T]?: DeepPartial<T[P]>;
 };
@@ -73,3 +73,17 @@ export interface IPipelineDiffMap {
 export type AvailablePluginsMap = any;
 
 export type NodeType = 'alertErrorNode' | 'defaultNode';
+export interface IPipelineNodeData extends IPipelineStage {
+  customIconSrc?: string;
+  iconName: string;
+  diffItem?: IStageDiffItem;
+  diffKey: string;
+}
+// A type helper to distribute each node type into its corresponding node
+export type PipelineNode<U = NodeType> = U extends NodeType ? Node<IPipelineNodeData, U> : never;
+
+export type EdgeType = 'smoothstep' | 'diffEdge';
+export interface IPipelineEdgeData {
+  diffIndicator?: DiffIndicator;
+}
+export type PipelineEdge = Edge<IPipelineEdgeData>;


### PR DESCRIPTION
# [CDAP-20746](https://cdap.atlassian.net/browse/CDAP-20746) Fixes navigation from diff list not working on nodes outside canvas 

## Description
#1078 added the feature where the canvas only renders the visible elements. This caused the nodes and connections that are outside of the canvas to not render, thus not running the navigation logic within them. This PR moves this logic into the Reactflow container. 

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20746](https://cdap.atlassian.net/browse/CDAP-20746)




[CDAP-20746]: https://cdap.atlassian.net/browse/CDAP-20746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20746]: https://cdap.atlassian.net/browse/CDAP-20746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ