### PR TITLE
[CDAP-20775] disable upgradeInsecureRequests

### DIFF
--- a/server/express.js
+++ b/server/express.js
@@ -184,6 +184,7 @@ function makeApp(authAddress, cdapConfig, uiSettings) {
             objectSrc: [`'none'`],
             workerSrc: [`'self' blob:`],
             reportUri: `https://csp.withgoogle.com/csp/cdap`,
+            upgradeInsecureRequests: null,
           },
         },
         hsts: cdapConfig["hsts.enabled"] === 'true' && hstsSettings,


### PR DESCRIPTION
# [CDAP-20775] disable upgradeInsecureRequests

## Description
The helmet.js library defaults this value to true, causing request issues with HDF

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20775](https://cdap.atlassian.net/browse/CDAP-20775)

## Test Plan
verified the setting disappears after making the change




[CDAP-20775]: https://cdap.atlassian.net/browse/CDAP-20775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20775]: https://cdap.atlassian.net/browse/CDAP-20775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ