### PR TITLE
Add new tab for Service accounts in Namespace admin UI 

### DIFF
--- a/app/cdap/api/serviceaccounts.js
+++ b/app/cdap/api/serviceaccounts.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import DataSourceConfigurer from 'services/datasource/DataSourceConfigurer';
+import { apiCreator } from 'services/resource-helper';
+
+const dataSrc = DataSourceConfigurer.getInstance();
+const basePath = '/namespaces/:namespace/credentials';
+const identityBasePath = `${basePath}/workloadIdentity`;
+
+export const ServiceAccountsApi = {
+  getServiceAccount: apiCreator(dataSrc, 'GET', 'REQUEST', `${identityBasePath}`),
+  createWorkloadIdentity: apiCreator(dataSrc, 'PUT', 'REQUEST', `${identityBasePath}`),
+  validateWorkloadIdentity: apiCreator(dataSrc, 'POST', 'REQUEST', `${identityBasePath}/validate`),
+  getWorkloadIdentity: apiCreator(dataSrc, 'GET', 'REQUEST', `${identityBasePath}`),
+  deleteWorkloadIdentity: apiCreator(dataSrc, 'DELETE', 'REQUEST', `${identityBasePath}`),
+};

--- a/app/cdap/components/NamespaceAdmin/AdminTabs.tsx
+++ b/app/cdap/components/NamespaceAdmin/AdminTabs.tsx
@@ -29,6 +29,7 @@ import Tab from '@material-ui/core/Tab';
 import TabContext from '@material-ui/lab/TabContext';
 import styled from 'styled-components';
 import { useLocation } from 'react-router';
+import ServiceAccounts from './ServiceAccounts';
 
 const StyledTabs = styled(Tabs)`
   border-bottom: 1px solid #e8e8e8;
@@ -73,6 +74,9 @@ export const AdminTabs = () => {
   const sourceControlManagementEnabled = useFeatureFlagDefaultFalse(
     'source.control.management.git.enabled'
   );
+  const namespacedServiceAccountsEnabled = useFeatureFlagDefaultFalse(
+    'feature.namespaced.service.accounts.enabled'
+  );
 
   return (
     <>
@@ -91,6 +95,13 @@ export const AdminTabs = () => {
               value={`${baseNSPath}/connections`}
             />
             <LinkTab label="Drivers" to={`${baseNSPath}/drivers`} value={`${baseNSPath}/drivers`} />
+            {namespacedServiceAccountsEnabled && (
+              <LinkTab
+                label="Service Accounts"
+                to={`${baseNSPath}/serviceaccounts`}
+                value={`${baseNSPath}/serviceaccounts`}
+              />
+            )}
             {sourceControlManagementEnabled && (
               <LinkTab
                 label="Source Control Management"
@@ -108,6 +119,9 @@ export const AdminTabs = () => {
           <Route exact path={`${basepath}/connections`} component={Connections} />
           <Route exact path={`${basepath}/drivers`} component={Drivers} />
           <Route exact path={`${basepath}/scm`} component={SourceControlManagement} />
+          {namespacedServiceAccountsEnabled && (
+            <Route exact path={`${basepath}/serviceaccounts`} component={ServiceAccounts} />
+          )}
         </Switch>
       </div>
     </>

--- a/app/cdap/components/NamespaceAdmin/ServiceAccounts/DeleteConfirmDialog.tsx
+++ b/app/cdap/components/NamespaceAdmin/ServiceAccounts/DeleteConfirmDialog.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { ReactNode, useState } from 'react';
+import T from 'i18n-react';
+import { ConfirmDialog, SeverityType, IExtendedMessage } from 'components/shared/ConfirmDialog';
+import { deleteServiceAccount } from 'components/NamespaceAdmin/store/ActionCreator';
+
+const PREFIX = 'features.ServiceAccounts';
+
+interface IDeleteConfirmDialogProps {
+  selectedServiceAcccount: string;
+  isShow: boolean;
+  closeFn: () => void;
+}
+
+export const DeleteConfirmDialog = ({
+  selectedServiceAcccount,
+  isShow,
+  closeFn,
+}: IDeleteConfirmDialogProps) => {
+  const [deleteErrorMsg, setDeleteErrorMsg] = useState<string | ReactNode>(null);
+  const [extendedErrorMsg, setExtendedErrorMsg] = useState<IExtendedMessage | string>(null);
+
+  const deleteHanlder = () => {
+    deleteServiceAccount().subscribe(closeFn, (err) => {
+      setDeleteErrorMsg(T.translate(`${PREFIX}.failedToDelete`));
+      if (err.response) {
+        setExtendedErrorMsg({ response: err.response });
+      }
+    });
+  };
+
+  return (
+    <ConfirmDialog
+      headerTitle={T.translate(`${PREFIX}.deleteTitle`)}
+      confirmationElem={T.translate(`${PREFIX}.deleteConfirmation`, {
+        serviceaccount: selectedServiceAcccount,
+      })}
+      cancelButtonText={T.translate(`${PREFIX}.cancelButtonText`)}
+      confirmButtonText={T.translate(`${PREFIX}.deleteButtonText`)}
+      confirmFn={deleteHanlder}
+      cancelFn={closeFn}
+      isOpen={isShow}
+      severity={SeverityType.ERROR}
+      statusMessage={deleteErrorMsg}
+      extendedMessage={extendedErrorMsg}
+    ></ConfirmDialog>
+  );
+};

--- a/app/cdap/components/NamespaceAdmin/ServiceAccounts/EditConfirmDialog.tsx
+++ b/app/cdap/components/NamespaceAdmin/ServiceAccounts/EditConfirmDialog.tsx
@@ -1,0 +1,160 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { ReactNode, useState } from 'react';
+import T from 'i18n-react';
+import styled from 'styled-components';
+import TextField from '@material-ui/core/TextField';
+import { ConfirmDialog, SeverityType, IExtendedMessage } from 'components/shared/ConfirmDialog';
+import {
+  validateServiceAccount,
+  addServiceAccount,
+} from 'components/NamespaceAdmin/store/ActionCreator';
+
+const PREFIX = 'features.ServiceAccounts';
+
+interface IEditConfirmDialogProps {
+  selectedServiceAcccount: string;
+  isShow: boolean;
+  closeFn: () => void;
+  namespaceIdentity: string;
+}
+
+const StyledTextField = styled(TextField)`
+  & .MuiInputLabel-shrink {
+    font-size: 17px;
+  }
+  & .MuiOutlinedInput-notchedOutline {
+    font-size: 16px;
+    border-color: #80868b;
+  }
+  & .MuiFormHelperText-root {
+    margin-left: 0px;
+    font-size: 12px;
+  }
+`;
+
+/**
+ * Generates the gcloud cli command to add an IAM policy binding. If any of the
+ * parameters for the command is not provided when the command is generated, then
+ * the user should be able to provide them as environment variables in their shell.
+ *
+ * @param  tenantProjectId string, defaults to "${TENANT_PROJECT_ID}" so it can be
+ *         provided as the environment variable TENANT_PROJECT_ID when
+ *         the command is run
+ * @param  identity string, defaults to "${IDENTITY}" so that it can be provided as the
+ *         environment variable IDENTITY when the command is run
+ * @param  gsaEmail string, defaults to "${GSA_EMAIL}" so that it can be provided as the
+ *         environment variable GSA_EMAIL when the command is run
+ * @return string, the gcloud cli command to run
+ */
+const getGcloudCommand = ({
+  tenantProjectId = '${TENANT_PROJECT_ID}',
+  identity = '${IDENTITY}',
+  gsaEmail = '${GSA_EMAIL}',
+}): string =>
+  `gcloud iam service-accounts add-iam-policy-binding 
+      --role roles/iam.workloadIdentityUser 
+     --member "serviceAccount:${tenantProjectId}.svc.id.goog[default/${identity}]"
+     ${gsaEmail}`;
+
+export const EditConfirmDialog = ({
+  selectedServiceAcccount,
+  isShow,
+  closeFn,
+  namespaceIdentity,
+}: IEditConfirmDialogProps) => {
+  const [serviceAccountInputValue, setServiceAccountInputValue] = useState<string>(
+    selectedServiceAcccount
+  );
+  const [saveStatusMsg, setSaveStatusMsg] = useState<string | ReactNode>(
+    T.translate(`${PREFIX}.helpTitle`)
+  );
+  const [saveStatusDetails, setSaveStatusDetails] = useState<IExtendedMessage | string>(
+    T.translate(`${PREFIX}.helpContent`).toString()
+  );
+  const [saveStatus, setSaveStatus] = useState<SeverityType>(SeverityType.INFO);
+
+  const gcloudCommandParams = {
+    identity: namespaceIdentity || undefined,
+    gsaEmail: serviceAccountInputValue || undefined,
+  };
+
+  const copyableExtendedMessage =
+    saveStatus === SeverityType.INFO ? getGcloudCommand(gcloudCommandParams) : null;
+
+  // validates and then saves
+  const handleSave = () => {
+    const reqObj = { identity: namespaceIdentity, serviceAccount: serviceAccountInputValue };
+    validateServiceAccount(reqObj).subscribe(
+      (res) => {
+        // validation success, so proceed for save
+        addServiceAccount(reqObj).subscribe(closeFn, (err) => {
+          // save failed
+          showErrorMessage('failedToSave', err);
+        });
+      },
+      (validationError) => {
+        // validation failed
+        showErrorMessage('failedToValidate', validationError);
+      }
+    );
+  };
+
+  const showErrorMessage = (failedStage, errorObj) => {
+    setSaveStatus(SeverityType.ERROR);
+    setSaveStatusMsg(T.translate(`${PREFIX}.${failedStage}`));
+    if (errorObj.response) {
+      setSaveStatusDetails({
+        response: errorObj.response,
+      });
+    }
+  };
+
+  const getEditDialogContent = () => {
+    return (
+      <StyledTextField
+        label={T.translate(`${PREFIX}.editInputLabel`)}
+        defaultValue={serviceAccountInputValue}
+        helperText={T.translate(`${PREFIX}.inputHelperText`)}
+        variant="outlined"
+        margin="dense"
+        fullWidth
+        color="primary"
+        onChange={(ev) => {
+          setServiceAccountInputValue(ev.target.value);
+        }}
+      />
+    );
+  };
+
+  return (
+    <ConfirmDialog
+      headerTitle={T.translate(`${PREFIX}.serviceAccount`)}
+      confirmationElem={getEditDialogContent()}
+      cancelButtonText={T.translate('commons.cancel')}
+      confirmButtonText={T.translate('commons.save')}
+      confirmFn={handleSave}
+      cancelFn={closeFn}
+      disableAction={!serviceAccountInputValue}
+      isOpen={isShow}
+      severity={saveStatus}
+      statusMessage={saveStatusMsg}
+      extendedMessage={saveStatusDetails}
+      copyableExtendedMessage={copyableExtendedMessage}
+    ></ConfirmDialog>
+  );
+};

--- a/app/cdap/components/NamespaceAdmin/ServiceAccounts/index.tsx
+++ b/app/cdap/components/NamespaceAdmin/ServiceAccounts/index.tsx
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { useState } from 'react';
+import { connect } from 'react-redux';
+
+import Table from 'components/shared/Table';
+import TableHeader from 'components/shared/Table/TableHeader';
+import TableRow from 'components/shared/Table/TableRow';
+import TableCell from 'components/shared/Table/TableCell';
+import TableBody from 'components/shared/Table/TableBody';
+import Button from '@material-ui/core/Button';
+import ActionsPopover, { IAction } from 'components/shared/ActionsPopover';
+import T from 'i18n-react';
+import Box from '@material-ui/core/Box';
+import styled from 'styled-components';
+import { DeleteConfirmDialog } from './DeleteConfirmDialog';
+import { EditConfirmDialog } from './EditConfirmDialog';
+
+const PREFIX = 'features.ServiceAccounts';
+
+const SubTitleBox = styled(Box)`
+  margin-bottom: 15px;
+`;
+
+const ServiceAccountsView = ({ serviceAccounts, namespaceIdentity }) => {
+  const [showPopover, setShowPopover] = useState(false);
+  const [selectedServiceAcccount, setSelectedServiceAcccount] = useState<string>('');
+  const [isSaveDialogOpen, setSaveDialogOpen] = useState(false);
+  const [isDeleteDialogOpen, setDeleteDialogOpen] = useState(false);
+
+  const showAddDialog = () => {
+    setSaveDialogOpen(true);
+    setSelectedServiceAcccount(null);
+  };
+
+  const showSaveDialog = (serviceAccount) => {
+    setSelectedServiceAcccount(serviceAccount);
+    setSaveDialogOpen(true);
+    setShowPopover(false);
+  };
+
+  const closeSaveDialog = () => {
+    setSaveDialogOpen(false);
+  };
+
+  const showDeleteConfirmation = (serviceAccount) => {
+    setSelectedServiceAcccount(serviceAccount);
+    setShowPopover(false);
+    setDeleteDialogOpen(true);
+  };
+
+  const closeDeleteConfirmation = () => {
+    setDeleteDialogOpen(false);
+  };
+
+  return (
+    <div>
+      {(!serviceAccounts || !serviceAccounts.length) && (
+        <SubTitleBox>
+          <Button variant="contained" color="primary" onClick={showAddDialog}>
+            {T.translate(`${PREFIX}.addServiceAccount`)}
+          </Button>
+        </SubTitleBox>
+      )}
+      <Table columnTemplate="1fr 100px">
+        <TableHeader>
+          <TableRow>
+            <TableCell>{T.translate(`${PREFIX}.serviceAccount`)}</TableCell>
+            <TableCell />
+          </TableRow>
+        </TableHeader>
+
+        <TableBody>
+          {serviceAccounts &&
+            serviceAccounts.map((serviceAccount) => {
+              const actions: IAction[] = [
+                {
+                  label: T.translate('commons.edit'),
+                  actionFn: () => showSaveDialog(serviceAccount.serviceAccount),
+                },
+                {
+                  label: 'separator',
+                },
+                {
+                  label: T.translate('commons.delete'),
+                  actionFn: () => showDeleteConfirmation(serviceAccount.serviceAccount),
+                },
+              ];
+
+              return (
+                <TableRow key={`${serviceAccount.serviceAccount}`}>
+                  <TableCell>{serviceAccount.serviceAccount}</TableCell>
+                  <TableCell>
+                    <ActionsPopover actions={actions} showPopover={showPopover} />
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+        </TableBody>
+      </Table>
+      {isDeleteDialogOpen && (
+        <DeleteConfirmDialog
+          selectedServiceAcccount={selectedServiceAcccount}
+          isShow={isDeleteDialogOpen}
+          closeFn={closeDeleteConfirmation}
+        ></DeleteConfirmDialog>
+      )}
+      {isSaveDialogOpen && (
+        <EditConfirmDialog
+          selectedServiceAcccount={selectedServiceAcccount}
+          isShow={isSaveDialogOpen}
+          closeFn={closeSaveDialog}
+          namespaceIdentity={namespaceIdentity}
+        ></EditConfirmDialog>
+      )}
+    </div>
+  );
+};
+
+const mapStateToProps = (state) => {
+  return {
+    serviceAccounts: state.serviceAccounts,
+    namespaceIdentity: state.identity,
+  };
+};
+
+const ServiceAccounts = connect(mapStateToProps)(ServiceAccountsView);
+export default ServiceAccounts;

--- a/app/cdap/components/NamespaceAdmin/index.tsx
+++ b/app/cdap/components/NamespaceAdmin/index.tsx
@@ -24,6 +24,7 @@ import {
   getDrivers,
   getConnections,
   getAndSetSourceControlManagement,
+  getServiceAccounts,
 } from 'components/NamespaceAdmin/store/ActionCreator';
 import { Provider } from 'react-redux';
 import Store from 'components/NamespaceAdmin/store';
@@ -60,6 +61,7 @@ const NamespaceAdmin = () => {
     getConnections(namespace);
     getProfiles(namespace);
     getAndSetSourceControlManagement(namespace);
+    getServiceAccounts(namespace);
 
     eventEmitter.on(globalEvents.NSPREFERENCESSAVED, getPreferences);
     eventEmitter.on(globalEvents.ARTIFACTUPLOAD, getDrivers);

--- a/app/cdap/components/NamespaceAdmin/store/index.ts
+++ b/app/cdap/components/NamespaceAdmin/store/index.ts
@@ -26,6 +26,7 @@ export const NamespaceAdminActions = {
   setPreferences: 'SET_PREFERENCES',
   setDrivers: 'SET_DRIVERS',
   setConnections: 'SET_CONNECTIONS',
+  setServiceAccounts: 'SET_SERVICE_ACCOUNTS',
   setSourceControlManagementConfig: 'SET_SOURCE_CONTROL_MANAGEMENT_CONFIG',
   reset: 'NAMESPACE_ADMIN_RESET',
 };
@@ -61,6 +62,11 @@ interface IPlugin {
   type: string;
 }
 
+interface IServiceAccount {
+  identity: string;
+  serviceAccount: string;
+}
+
 // TODO: this should probably be under the Connections component
 export interface IConnection {
   connectionType: string;
@@ -86,6 +92,8 @@ interface INamespaceAdmin {
   drivers: IDriver[];
   connections: IConnection[];
   sourceControlManagementConfig: ISourceControlManagementConfig;
+  serviceAccounts: IServiceAccount[];
+  identity: string;
 }
 
 type INamespaceAdminState = Partial<INamespaceAdmin>;
@@ -103,6 +111,8 @@ const defaultInitialState: Partial<INamespaceAdminState> = {
   drivers: [],
   connections: [],
   sourceControlManagementConfig: null,
+  serviceAccounts: [],
+  identity: null,
 };
 
 const namespaceAdmin: Reducer<INamespaceAdminState> = (state = defaultInitialState, action) => {
@@ -146,6 +156,11 @@ const namespaceAdmin: Reducer<INamespaceAdminState> = (state = defaultInitialSta
       return {
         ...state,
         sourceControlManagementConfig: action.payload.sourceControlManagementConfig,
+      };
+    case NamespaceAdminActions.setServiceAccounts:
+      return {
+        ...state,
+        serviceAccounts: action.payload.serviceAccounts,
       };
     case NamespaceAdminActions.reset:
       return {

--- a/app/cdap/components/shared/ConfirmDialog/Status.tsx
+++ b/app/cdap/components/shared/ConfirmDialog/Status.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { ReactNode, useState } from 'react';
+
+import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@material-ui/icons/KeyboardArrowUp';
+import T from 'i18n-react';
+import IconButton from '@material-ui/core/IconButton';
+import { StyledBox, StyledAlert, CopyContentBox } from './styles';
+import { copyToClipBoard } from 'services/Clipboard';
+import FileCopyOutlinedIcon from '@material-ui/icons/FileCopyOutlined';
+import { IExtendedMessage, SeverityType } from './index';
+
+interface IStatusProps {
+  severity?: SeverityType;
+  statusMessage?: string | ReactNode;
+  extendedMessage?: IExtendedMessage | string;
+  copyableExtendedMessage?: string | ReactNode;
+}
+
+export const Status = ({
+  severity,
+  statusMessage,
+  extendedMessage,
+  copyableExtendedMessage,
+}: IStatusProps) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const handleToggleExtendedMessage = () => {
+    setIsExpanded(!isExpanded);
+  };
+
+  return (
+    <StyledAlert severity={severity}>
+      {statusMessage}
+      {(extendedMessage || copyableExtendedMessage) && (
+        <>
+          <IconButton
+            size="small"
+            onClick={handleToggleExtendedMessage}
+            color="inherit"
+            title={
+              isExpanded
+                ? T.translate('commons.hideDetails').toString()
+                : T.translate('commons.showDetails').toString()
+            }
+          >
+            {isExpanded ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+          </IconButton>
+          {isExpanded && (
+            <StyledBox>
+              {typeof extendedMessage === 'string' ? (
+                <div>{extendedMessage}</div>
+              ) : (
+                <pre>{extendedMessage.response}</pre>
+              )}
+              {copyableExtendedMessage && (
+                <CopyContentBox>
+                  <IconButton
+                    onClick={() => copyToClipBoard(copyableExtendedMessage)}
+                    size="small"
+                    style={{ float: 'right' }}
+                    title={T.translate('commons.copyToClipboard').toString()}
+                  >
+                    <FileCopyOutlinedIcon />
+                  </IconButton>
+                  <pre>{copyableExtendedMessage}</pre>
+                </CopyContentBox>
+              )}
+            </StyledBox>
+          )}
+        </>
+      )}
+    </StyledAlert>
+  );
+};

--- a/app/cdap/components/shared/ConfirmDialog/index.tsx
+++ b/app/cdap/components/shared/ConfirmDialog/index.tsx
@@ -15,24 +15,23 @@
  */
 
 import React, { ReactElement, ReactNode, useEffect, useState } from 'react';
-import isObject from 'lodash/isObject';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogActions from '@material-ui/core/DialogActions';
-import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
-import KeyboardArrowUpIcon from '@material-ui/icons/KeyboardArrowUp';
 
-import IconButton from '@material-ui/core/IconButton';
-import { StyledBox, StyledDialog, StyledAlert, CopyContentBox } from './styles';
+import { StyledDialog } from './styles';
 import PrimaryTextButton from 'components/shared/Buttons/PrimaryTextButton';
-import { copyToClipBoard } from 'services/Clipboard';
-import FileCopyOutlinedIcon from '@material-ui/icons/FileCopyOutlined';
+import { Status } from './Status';
 
 export enum SeverityType {
   SUCCESS = 'success',
   INFO = 'info',
   WARNING = 'warning',
   ERROR = 'error',
+}
+
+export interface IExtendedMessage {
+  response: string;
 }
 
 interface IConfirmDialogProps {
@@ -46,7 +45,7 @@ interface IConfirmDialogProps {
   confirmationText?: string | ReactNode;
   severity?: SeverityType;
   statusMessage?: string | ReactNode;
-  extendedMessage?: { response: string };
+  extendedMessage?: IExtendedMessage | string;
   disableAction?: boolean;
   copyableExtendedMessage?: string | ReactNode;
 }
@@ -66,70 +65,18 @@ export const ConfirmDialog = ({
   disableAction,
   copyableExtendedMessage,
 }: IConfirmDialogProps) => {
-  const [isExpanded, setIsExpanded] = useState(false);
-
-  useEffect(() => {
-    setIsExpanded(false);
-  }, [statusMessage]);
-
-  const showStatusMessage = () => {
-    if (statusMessage) {
-      return (
-        <StyledAlert severity={severity}>
-          {statusMessage}
-          {getExtendedMessage()}
-        </StyledAlert>
-      );
-    }
-  };
-
-  const handleToggleExtendedMessage = () => {
-    setIsExpanded(!isExpanded);
-  };
-
-  const getExtendedMessage = () => {
-    if (extendedMessage || copyableExtendedMessage) {
-      return (
-        <>
-          <IconButton
-            size="small"
-            onClick={handleToggleExtendedMessage}
-            color="inherit"
-            title={isExpanded ? 'Hide details' : 'Show details'}
-          >
-            {isExpanded ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
-          </IconButton>
-          {isExpanded && (
-            <StyledBox>
-              {isObject(extendedMessage) ? (
-                <pre>{extendedMessage.response}</pre>
-              ) : (
-                <div>{extendedMessage}</div>
-              )}
-              {copyableExtendedMessage && (
-                <CopyContentBox>
-                  <IconButton
-                    onClick={() => copyToClipBoard(copyableExtendedMessage)}
-                    size="small"
-                    style={{ float: 'right' }}
-                    title="Copy to clipboard"
-                  >
-                    <FileCopyOutlinedIcon />
-                  </IconButton>
-                  <pre>{copyableExtendedMessage}</pre>
-                </CopyContentBox>
-              )}
-            </StyledBox>
-          )}
-        </>
-      );
-    }
-  };
-
   return (
     <StyledDialog open={isOpen} fullWidth>
       <DialogTitle>{headerTitle}</DialogTitle>
-      {showStatusMessage()}
+      {statusMessage && (
+        <Status
+          severity={severity}
+          statusMessage={statusMessage}
+          extendedMessage={extendedMessage}
+          copyableExtendedMessage={copyableExtendedMessage}
+          key={statusMessage.toString()}
+        ></Status>
+      )}
       <DialogContent>
         {confirmationText}
         {confirmationElem}

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -5,6 +5,7 @@ commons:
   apply: Apply
   as: as
   back: Back
+  cancel: Cancel
   learnMore: Learn More
   gotIt: Ok, Got it.
   cookieBanner: This application uses cookies from Google to deliver and enhance the quality of its services and to analyze traffic.
@@ -13,6 +14,7 @@ commons:
   clickhere: click here
   close: Close
   connectionSuccess: Successfully connected.
+  copyToClipboard: Copy to clipboard
   delete: Delete
   deprecated: Deprecated
   descriptionLabel: Description
@@ -96,6 +98,7 @@ commons:
   pipelines: Pipelines
   requiredFieldMissingMsg: Required field cannot be empty
   resource-center: Add entity
+  save: Save
   schemaLabel: Schema
   scope: Scope
   secondsShortLabel: secs
@@ -107,6 +110,7 @@ commons:
   then: Then
   tracker: Cask Tracker
   typeLabel: Type
+  validate: Validate
   when: When
   wrangler: Cask Wrangler
   yesLabel: Yes
@@ -3168,6 +3172,22 @@ features:
       symbolName: Symbol name
   ServiceEnableUtility:
     serviceNotFound: Cannot find {artifactName} artifact
+  ServiceAccounts:
+    addServiceAccount: Add service account
+    delete: Delete
+    deleteButtonText: Delete
+    cancelButtonText: Cancel
+    deleteConfirmation: Clicking Delete will remove *_{serviceaccount}_* from the default namespace. Are you sure you want to remove the service account?
+    deleteTitle: Delete service account
+    edit: Edit
+    editInputLabel: Pipeline design service account
+    failedToDelete: Unable to delete service account
+    failedToValidate: Service account validation failed
+    failedToSave: Failed to save the service account changes
+    helpTitle: Provided Google Service Accounts (GSA) will be leveraged as workload identity, more details on gcloud commands help ... 
+    helpContent: "Users for Kubernetes Service Account(KSA) internally to enhance security and access control in the namespace to perform pipeline design-time operations (pipeline preview, Wrangler, pipeline validation). You need to grant Workload Identity User permission to the KSA which can be done using the gcloud command : "
+    inputHelperText: Provide details of the service account for authorization
+    serviceAccount : Service account
   SourceControlManagement:
     configModal:
       auth:


### PR DESCRIPTION
# Add new tab for Service accounts in Namespace admin UI 

## Description
Add new tab for Service accounts in Namespace admin UI 

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20821](https://cdap.atlassian.net/browse/CDAP-20821)

## Test Plan

## Screenshots
**Service account's Edit and Delete options in Namespace admin - Service accounts tab**
<img width="500" alt="image" src="https://github.com/cdapio/cdap-ui/assets/107839049/9895fbf1-b834-4731-a25b-8f2c277b652f">

**Add Service account button when no service account is associated with namespace**
<img width="400" alt="image" src="https://github.com/cdapio/cdap-ui/assets/107839049/2402fc39-b21a-4b98-8c8a-2fef16be8d99">

**Edit\Add dialog with help content and copy option for gCloud command**
<img width="600" alt="image" src="https://github.com/cdapio/cdap-ui/assets/107839049/0f23ead4-c963-4bb6-a4c9-b38fca9e1c37">

**Gcloud command with Identity & Service account filled automatically**
<img width="647" alt="image" src="https://github.com/cdapio/cdap-ui/assets/107839049/4058cd44-64cc-4e28-8a0d-d640dec379d6">


**Delete service account dialog**
<img width="600" alt="image" src="https://github.com/cdapio/cdap-ui/assets/107839049/b4bc4087-2cd5-4f3f-a537-9db5d78b47e8">

**Dialog when error occurred**
<img width="600" alt="image" src="https://github.com/cdapio/cdap-ui/assets/107839049/651831f6-f07a-4c8e-8739-9152ba761b54">








[CDAP-20821]: https://cdap.atlassian.net/browse/CDAP-20821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ