### PR TITLE
Redirect to namespace admin UI to add service account to created namespace

### DIFF
--- a/app/cdap/components/CaskWizards/AddNamespace/index.js
+++ b/app/cdap/components/CaskWizards/AddNamespace/index.js
@@ -112,7 +112,6 @@ export default class AddNamespaceWizard extends Component {
       namespaceId: newNamespaceId,
     });
     let buttonLabel = T.translate(`${PREFIX}.callToAction`, { namespaceId: newNamespaceId });
-    let linkLabel = T.translate('features.Wizard.GoToHomePage');
     this.setState({
       successInfo: {
         message,
@@ -120,13 +119,42 @@ export default class AddNamespaceWizard extends Component {
         buttonUrl: window.getAbsUIUrl({
           namespaceId: newNamespaceId,
         }),
-        linkLabel,
-        linkUrl: `${window.getAbsUIUrl({
-          namespaceId: currentNamespaceId,
-        })}/control`,
+        links: this.getLinks(newNamespaceId, currentNamespaceId),
       },
     });
   }
+
+  isNamespacedServiceAccountsEnabled() {
+    return (
+      window.CDAP_CONFIG.featureFlags['feature.namespaced.service.accounts.enabled'] === 'true'
+    );
+  }
+
+  getLinks(newNamespaceId, currentNamespaceId) {
+    let links = [];
+    if (this.isNamespacedServiceAccountsEnabled()) {
+      links.push({
+        linkLabel: T.translate(`${PREFIX}.callToActionAddServiceAccounts`, {
+          namespaceId: newNamespaceId,
+        }),
+        linkUrl: `${window.getAbsUIUrl({
+          namespaceId: newNamespaceId,
+        })}/details/serviceaccounts`,
+      });
+    }
+    links.push(this.getHomePageLinkObject(currentNamespaceId));
+    return links;
+  }
+
+  getHomePageLinkObject(currentNamespaceId) {
+    return {
+      linkLabel: T.translate('features.Wizard.GoToHomePage'),
+      linkUrl: `${window.getAbsUIUrl({
+        namespaceId: currentNamespaceId,
+      })}/control`,
+    };
+  }
+
   render() {
     return (
       <div>

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -3321,6 +3321,7 @@ features:
     title: Warning
   Wizard:
     Add-Namespace:
+      callToActionAddServiceAccounts: Add service account to '{namespaceId}'
       callToAction:
         primary: Switch to '{namespaceId}'
       headerlabel: Add namespace


### PR DESCRIPTION
# Redirect to namespace admin UI to add service account to newly created namespace

## Description
Once after successful namespace creation. 
* Check for the `'feature.namespaced.service.accounts.enabled'` feature flag and show one more link on the finish wizard page. 
* This link will redirect to namespace admin -> Service accounts tab UI to associate\add service account to newly created namespace.

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20821](https://cdap.atlassian.net/browse/CDAP-20821)

## Test Plan

## Screenshots
<img width="400" alt="image" src="https://github.com/cdapio/cdap-ui/assets/107839049/6c76ee84-2123-4136-8809-8b3b258ceeea">


[CDAP-20821]: https://cdap.atlassian.net/browse/CDAP-20821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ