### PR TITLE
[CDAP-20843] Bug fix for log viewer e2e tests

### DIFF
--- a/src/e2e-test/features/logviewer.feature
+++ b/src/e2e-test/features/logviewer.feature
@@ -17,11 +17,14 @@
 @Integration_Tests
 Feature: Logviewer - Validate log viewer functionalities
 
-  @LOGVIEWER_TEST
-  Scenario: Deploy and run pipeline till complete
+  Background: Deploy and run pipeline
     When Deploy and test pipeline "logs_generator" with timestamp with pipeline JSON file "logs_generator.json"
     Then Run the pipeline
     Then Deployed pipeline status is "Running"
+
+  @LOGVIEWER_TEST
+  Scenario: Deploy and run pipeline till complete
+    Then Deployed pipeline status is "Succeeded"
 
   @LOGVIEWER_TEST
   Scenario: Log viewer should show
@@ -35,6 +38,7 @@ Feature: Logviewer - Validate log viewer functionalities
 
   @LOGVIEWER_TEST
   Scenario: Log level popover should work
+    Then Click on log viewer button
     Then Click on log level toggle
     Then Log level "ERROR" should exist
     Then Log level "WARN" should exist
@@ -50,6 +54,7 @@ Feature: Logviewer - Validate log viewer functionalities
 
   @LOGVIEWER_TEST
   Scenario: Log viewer content should contain correct information
+    Then Click on log viewer button
     Then Log viewer content should contain message "is started by user"
     Then Log viewer content should not contain message "This is a WARN"
     Then Click on advanced logs
@@ -61,12 +66,21 @@ Feature: Logviewer - Validate log viewer functionalities
 
   @LOGVIEWER_TEST
   Scenario: Log viewer should fetch next logs when scroll to bottom
+    Then Click on log viewer button
+    Then Click on advanced logs
+    Then Click on log level toggle
+    Then Click on log level "TRACE"
     Then Scroll up to center
     Then Scroll to latest should be enabled
     Then Debug message should update
 
   @LOGVIEWER_TEST
   Scenario: Log viewer should fetch previous logs when scroll to top
+    Then Deployed pipeline status is "Succeeded"
+    Then Click on log viewer button
+    Then Click on advanced logs
+    Then Click on log level toggle
+    Then Click on log level "TRACE"
     Then Scroll up to center
     Then Click on scroll to latest button
     Then Previous logs should show

--- a/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/Logviewer.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/Logviewer.java
@@ -28,7 +28,9 @@ import io.cucumber.java.en.When;
 import org.junit.Assert;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedCondition;
 
 import java.util.List;
 
@@ -170,6 +172,17 @@ public class Logviewer {
     WebElement element = Helper.locateElementByCssSelector(
       Helper.getCssSelectorByDataTestId("log-viewer-content")
     );
+
+    SeleniumDriver.getWaitDriver().until(new ExpectedCondition<Boolean>() {
+      @Override
+      public Boolean apply(WebDriver driver) {
+        Integer scrollHeight = Integer.valueOf(element.getDomProperty("scrollHeight"));
+        String heightInPixels = element.getCssValue("height");
+        Integer height = Integer.valueOf(heightInPixels.substring(0, heightInPixels.length() - 2));
+
+        return scrollHeight > height + 50;
+      }});
+
     js.executeScript("arguments[0].scrollBy(0, -1500);", element);
     Commands.waitForLoading();
   }

--- a/src/e2e-test/java/io/cdap/cdap/ui/utils/Commands.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/utils/Commands.java
@@ -391,9 +391,11 @@ public class Commands implements CdfHelper {
 
   public static void waitForLoading() {
     if (Helper.isElementExists(Helper.getCssSelectorByDataTestId("loading-indicator"))) {
-      WaitHelper.waitForElementToBeHidden(
-        Helper.locateElementByCssSelector(Helper.getCssSelectorByDataTestId("loading-indicator"))
-      );
+      try {
+        WaitHelper.waitForElementToBeHidden(
+                Helper.locateElementByCssSelector(Helper.getCssSelectorByDataTestId("loading-indicator"))
+        );
+      } catch (Exception e) { }
     }
   }
 }


### PR DESCRIPTION
Bug fix for log viewer e2e test

Modifying test cases such that they run independently. Adding a try c…atch block in waitForLoading function to handle missing element error.


## PR Type
- [x] Bug Fix

## Links
Jira: [CDAP UI E2e test builds are failing with flaky test steps at logviewer verification](https://cdap.atlassian.net/browse/CDAP-20843)

## Screenshots
![image](https://github.com/cdapio/cdap-ui/assets/49074485/d587120e-c302-4a36-8f0e-59d3e2c7b68d)



