### PR TITLE
[CDAP-20821] remove extra feature prefix from namespaced service accounts

### DIFF
--- a/app/cdap/components/CaskWizards/AddNamespace/index.js
+++ b/app/cdap/components/CaskWizards/AddNamespace/index.js
@@ -126,7 +126,7 @@ export default class AddNamespaceWizard extends Component {
 
   isNamespacedServiceAccountsEnabled() {
     return (
-      window.CDAP_CONFIG.featureFlags['feature.namespaced.service.accounts.enabled'] === 'true'
+      window.CDAP_CONFIG.featureFlags['namespaced.service.accounts.enabled'] === 'true'
     );
   }
 

--- a/app/cdap/components/NamespaceAdmin/AdminTabs.tsx
+++ b/app/cdap/components/NamespaceAdmin/AdminTabs.tsx
@@ -75,7 +75,7 @@ export const AdminTabs = () => {
     'source.control.management.git.enabled'
   );
   const namespacedServiceAccountsEnabled = useFeatureFlagDefaultFalse(
-    'feature.namespaced.service.accounts.enabled'
+    'namespaced.service.accounts.enabled'
   );
 
   return (


### PR DESCRIPTION
# TITLE

## Description
Summary of changes
Removes the extra `feature` prefix from `namespaced.service.accounts` feature flag as done similarly in source control management feature: https://github.com/cdapio/cdap-ui/blob/f4e3bccad5901df2bd1934f2c18ffae31fba9250/app/cdap/components/NamespaceAdmin/AdminTabs.tsx#L75

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20821](https://cdap.atlassian.net/browse/CDAP-20821)

## Test Plan

## Screenshots




[CDAP-20821]: https://cdap.atlassian.net/browse/CDAP-20821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ