### PR TITLE
Minor UI improvements in service accounts UI (namespace isolation feature)

### DIFF
--- a/app/cdap/components/CaskWizards/AddNamespace/index.js
+++ b/app/cdap/components/CaskWizards/AddNamespace/index.js
@@ -125,9 +125,7 @@ export default class AddNamespaceWizard extends Component {
   }
 
   isNamespacedServiceAccountsEnabled() {
-    return (
-      window.CDAP_CONFIG.featureFlags['namespaced.service.accounts.enabled'] === 'true'
-    );
+    return window.CDAP_CONFIG.featureFlags['namespaced.service.accounts.enabled'] === 'true';
   }
 
   getLinks(newNamespaceId, currentNamespaceId) {

--- a/app/cdap/components/NamespaceAdmin/ServiceAccounts/EditConfirmDialog.tsx
+++ b/app/cdap/components/NamespaceAdmin/ServiceAccounts/EditConfirmDialog.tsx
@@ -66,10 +66,7 @@ const getGcloudCommand = ({
   identity = '${IDENTITY}',
   gsaEmail = '${GSA_EMAIL}',
 }): string =>
-  `gcloud iam service-accounts add-iam-policy-binding 
-      --role roles/iam.workloadIdentityUser 
-     --member "serviceAccount:${tenantProjectId}.svc.id.goog[default/${identity}]"
-     ${gsaEmail}`;
+  `gcloud iam service-accounts add-iam-policy-binding --role roles/iam.workloadIdentityUser --member "serviceAccount:${tenantProjectId}.svc.id.goog[default/${identity}]" ${gsaEmail}`;
 
 export const EditConfirmDialog = ({
   selectedServiceAcccount,
@@ -124,6 +121,12 @@ export const EditConfirmDialog = ({
     }
   };
 
+  const showHelp = () => {
+    setSaveStatus(SeverityType.INFO);
+    setSaveStatusMsg(T.translate(`${PREFIX}.helpTitle`));
+    setSaveStatusDetails(T.translate(`${PREFIX}.helpContent`).toString());
+  };
+
   const getEditDialogContent = () => {
     return (
       <StyledTextField
@@ -136,6 +139,10 @@ export const EditConfirmDialog = ({
         color="primary"
         onChange={(ev) => {
           setServiceAccountInputValue(ev.target.value);
+          // this check is to show help again when user changes the input after getting error.
+          if (saveStatus !== SeverityType.INFO) {
+            showHelp();
+          }
         }}
       />
     );


### PR DESCRIPTION
# Minor fixes in the service accounts UI. 

## Description
* Showing help when user changes the input. 
* Removed formatting for the gCloud command, so that it will work when we copy and paste.

## PR Type
- [x] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20864](https://cdap.atlassian.net/browse/CDAP-20864)

## Test Plan

## Screenshots




[CDAP-20864]: https://cdap.atlassian.net/browse/CDAP-20864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ