### PR TITLE
Add support for multiple pipelines push and pull in SCM tab

### DIFF
--- a/app/cdap/api/longRunningOperation.ts
+++ b/app/cdap/api/longRunningOperation.ts
@@ -18,15 +18,23 @@ import DataSourceConfigurer from 'services/datasource/DataSourceConfigurer';
 import { apiCreator } from 'services/resource-helper';
 
 const dataSrc = DataSourceConfigurer.getInstance();
-const basePath = '/namespaces/:namespace/repository';
+const basePath = '/namespaces/:namespace/operations';
+const PUSH_FILTER = encodeURIComponent('TYPE=PUSH_APPS');
+const PULL_FILTER = encodeURIComponent('TYPE=PULL_APPS');
 
-export const SourceControlApi = {
-  push: apiCreator(dataSrc, 'POST', 'REQUEST', `${basePath}/apps/:appId/push`),
-  pull: apiCreator(dataSrc, 'POST', 'REQUEST', `${basePath}/apps/:appId/pull`),
-  pushMultiple: apiCreator(dataSrc, 'POST', 'REQUEST', `${basePath}/apps/push`),
-  pullMultiple: apiCreator(dataSrc, 'POST', 'REQUEST', `${basePath}/apps/pull`),
-  list: apiCreator(dataSrc, 'GET', 'REQUEST', `${basePath}/apps`),
-  setConfig: apiCreator(dataSrc, 'PUT', 'REQUEST', basePath),
-  getConfig: apiCreator(dataSrc, 'GET', 'REQUEST', basePath),
-  deleteConfig: apiCreator(dataSrc, 'DELETE', 'REQUEST', basePath),
+export const LongRunningOperationApi = {
+  getLatestPush: apiCreator(
+    dataSrc,
+    'GET',
+    'REQUEST',
+    `${basePath}/?pageSize=1&filter=${PUSH_FILTER}`
+  ),
+  getLatestPull: apiCreator(
+    dataSrc,
+    'GET',
+    'REQUEST',
+    `${basePath}/?pageSize=1&filter=${PULL_FILTER}`
+  ),
+  pollOperation: apiCreator(dataSrc, 'GET', 'POLL', `${basePath}/:operationId`),
+  stopOperation: apiCreator(dataSrc, 'POST', 'REQUEST', `${basePath}/:operationId/stop`),
 };

--- a/app/cdap/components/SourceControlManagement/LocalPipelineListView/CommitModal.tsx
+++ b/app/cdap/components/SourceControlManagement/LocalPipelineListView/CommitModal.tsx
@@ -34,6 +34,7 @@ interface ICommitModalProps {
   loadingMessage?: string;
   pipelineName?: string;
   updateFileHash?: (fileHash: string) => void;
+  enableMultiplePush?: boolean;
 }
 
 export const CommitModal = ({
@@ -43,6 +44,7 @@ export const CommitModal = ({
   loadingMessage = null,
   pipelineName,
   updateFileHash,
+  enableMultiplePush = false,
 }: ICommitModalProps) => {
   const [commitMessage, setCommitMessage] = useState(null);
   const [pushError, setPushError] = useState(null);
@@ -108,11 +110,18 @@ export const CommitModal = ({
     handlePipelinePush();
   };
 
+  const getPushSuccessMessage = () => {
+    if (enableMultiplePush) {
+      return T.translate(`${PREFIX}.pushSuccessMulti`);
+    }
+    return T.translate(`${PREFIX}.pushSuccess`, { pipelineName });
+  };
+
   return (
     <>
       <Alert
         showAlert={pushStatus !== null}
-        message={pushError || T.translate(`${PREFIX}.pushSuccess`, { pipelineName })}
+        message={pushError || getPushSuccessMessage()}
         type={getAlertTypeFromStatus(pushStatus)}
         onClose={resetPushErrorAndSuccess}
       />

--- a/app/cdap/components/SourceControlManagement/LocalPipelineListView/PipelineTable.tsx
+++ b/app/cdap/components/SourceControlManagement/LocalPipelineListView/PipelineTable.tsx
@@ -38,6 +38,7 @@ interface IRepositoryPipelineTableProps {
   selectedPipelines: string[];
   showFailedOnly: boolean;
   enableMultipleSelection?: boolean;
+  disabled?: boolean;
 }
 
 export const LocalPipelineTable = ({
@@ -45,10 +46,15 @@ export const LocalPipelineTable = ({
   selectedPipelines,
   showFailedOnly,
   enableMultipleSelection = false,
+  disabled = false,
 }: IRepositoryPipelineTableProps) => {
   const isSelected = (name: string) => selectedPipelines.indexOf(name) !== -1;
 
   const handleSelectAllClick = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (disabled) {
+      return;
+    }
+
     if (event.target.checked) {
       const allSelected = localPipelines.map((pipeline) => pipeline.name);
       setSelectedPipelines(allSelected);
@@ -58,6 +64,10 @@ export const LocalPipelineTable = ({
   };
 
   const handleClick = (event: React.MouseEvent, name: string) => {
+    if (disabled) {
+      return;
+    }
+
     if (enableMultipleSelection) {
       handleMultipleSelection(name);
       return;
@@ -101,6 +111,7 @@ export const LocalPipelineTable = ({
                   }
                   checked={selectedPipelines.length === localPipelines.length}
                   onChange={handleSelectAllClick}
+                  disabled={disabled}
                 />
               )}
             </TableCell>
@@ -131,9 +142,10 @@ export const LocalPipelineTable = ({
                 selected={isPipelineSelected}
                 onClick={(e) => handleClick(e, pipeline.name)}
                 data-testid={`local-${pipeline.name}`}
+                disabled={disabled}
               >
                 <TableCell padding="checkbox">
-                  <Checkbox color="primary" checked={isPipelineSelected} />
+                  <Checkbox color="primary" checked={isPipelineSelected} disabled={disabled} />
                 </TableCell>
                 <StatusCell
                   data-testid={

--- a/app/cdap/components/SourceControlManagement/LocalPipelineListView/index.tsx
+++ b/app/cdap/components/SourceControlManagement/LocalPipelineListView/index.tsx
@@ -15,18 +15,23 @@
  */
 
 import PrimaryContainedButton from 'components/shared/Buttons/PrimaryContainedButton';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { getCurrentNamespace } from 'services/NamespaceStore';
+import Alert from '@material-ui/lab/Alert';
+import AlertTitle from '@material-ui/lab/AlertTitle';
 import {
   countPushFailedPipelines,
+  fetchLatestOperation,
   getNamespacePipelineList,
+  pushMultipleSelectedPipelines,
   pushSelectedPipelines,
   reset,
   resetPushStatus,
   setLoadingMessage,
   setLocalPipelines,
   setNameFilter,
+  stopOperation,
   toggleCommitModal,
   toggleShowFailedOnly,
 } from '../store/ActionCreator';
@@ -38,12 +43,29 @@ import cloneDeep from 'lodash/cloneDeep';
 import PrimaryTextButton from 'components/shared/Buttons/PrimaryTextButton';
 import { LocalPipelineTable } from './PipelineTable';
 import { useOnUnmount } from 'services/react/customHooks/useOnUnmount';
-import { FailStatusDiv, PipelineListContainer, StyledSelectionStatusDiv } from '../styles';
-import { IListResponse } from '../types';
+import {
+  AlertErrorView,
+  FailStatusDiv,
+  PipelineListContainer,
+  StyledSelectionStatusDiv,
+} from '../styles';
+import { IListResponse, IOperationMetaResponse, IOperationRun } from '../types';
+import { useFeatureFlagDefaultFalse } from 'services/react/customHooks/useFeatureFlag';
+import {
+  getOperationRunMessage,
+  getOperationStartTime,
+  getOperationStatusType,
+  parseOperationResource,
+} from '../helpers';
+import Button from '@material-ui/core/Button';
+import { OperationStatus } from '../OperationStatus';
+import ExpandLess from '@material-ui/icons/ExpandLess';
+import ExpandMore from '@material-ui/icons/ExpandMore';
 
 const PREFIX = 'features.SourceControlManagement.push';
 
 export const LocalPipelineListView = () => {
+  const [viewErrorExpanded, setViewErrorExpanded] = useState(false);
   const {
     ready,
     localPipelines,
@@ -54,6 +76,13 @@ export const LocalPipelineListView = () => {
     showFailedOnly,
   } = useSelector(({ push }) => push);
 
+  const { running: isAnOperationRunning, operation } = useSelector(
+    ({ operationRun }) => operationRun
+  );
+
+  const multiPushEnabled = useFeatureFlagDefaultFalse(
+    'source.control.management.multi.app.enabled'
+  );
   const pushFailedCount = countPushFailedPipelines();
 
   useEffect(() => {
@@ -61,6 +90,12 @@ export const LocalPipelineListView = () => {
       getNamespacePipelineList(getCurrentNamespace(), nameFilter);
     }
   }, [ready]);
+
+  useEffect(() => {
+    if (multiPushEnabled) {
+      fetchLatestOperation(getCurrentNamespace());
+    }
+  }, []);
 
   useOnUnmount(() => reset());
 
@@ -71,6 +106,31 @@ export const LocalPipelineListView = () => {
       commitMessage,
     };
     toggleCommitModal();
+    if (multiPushEnabled) {
+      pushMultipleSelectedPipelines(
+        getCurrentNamespace(),
+        selectedPipelines,
+        payload,
+        setLoadingMessage
+      ).subscribe({
+        next(res: IOperationMetaResponse) {
+          const resources = res.resources.map(parseOperationResource);
+          const resourceNames = resources.map(({ name }) => name);
+          pushedPipelines.forEach((pipeline) => {
+            if (resourceNames.includes(pipeline.name)) {
+              pipeline.status = res.status;
+            }
+          });
+          setLocalPipelines(pushedPipelines);
+        },
+        complete() {
+          setLoadingMessage(null);
+        },
+      });
+
+      return;
+    }
+
     pushSelectedPipelines(
       getCurrentNamespace(),
       selectedPipelines,
@@ -100,11 +160,13 @@ export const LocalPipelineListView = () => {
             localPipelines={localPipelines}
             selectedPipelines={selectedPipelines}
             showFailedOnly={showFailedOnly}
+            enableMultipleSelection={multiPushEnabled}
+            disabled={isAnOperationRunning}
           />
           <PrimaryContainedButton
             onClick={toggleCommitModal}
             size="large"
-            disabled={!selectedPipelines.length}
+            disabled={isAnOperationRunning || !selectedPipelines.length}
             data-testid="remote-push-button"
           >
             {T.translate(`${PREFIX}.pushButton`)}
@@ -115,9 +177,54 @@ export const LocalPipelineListView = () => {
     return <div>{T.translate(`${PREFIX}.emptyPipelineListMessage`, { query: nameFilter })}</div>;
   };
 
+  const getOperationAction = () => {
+    if (!operation.done) {
+      return (
+        <Button
+          color="inherit"
+          size="small"
+          onClick={stopOperation(getCurrentNamespace(), operation)}
+        >
+          {T.translate(`${PREFIX}.stopOperation`)}
+        </Button>
+      );
+    }
+
+    if (operation.status === OperationStatus.FAILED) {
+      return (
+        <Button
+          color="inherit"
+          size="small"
+          onClick={() => setViewErrorExpanded((isExpanded) => !isExpanded)}
+        >
+          {viewErrorExpanded ? <ExpandLess /> : <ExpandMore />}
+        </Button>
+      );
+    }
+
+    return undefined;
+  };
+
   return (
     <PipelineListContainer>
       <SearchBox nameFilter={nameFilter} setNameFilter={setNameFilter} />
+      {operation && (
+        <Alert
+          variant="filled"
+          severity={getOperationStatusType(operation)}
+          action={getOperationAction()}
+        >
+          <AlertTitle>{getOperationRunMessage(operation)}</AlertTitle>
+          {getOperationStartTime(operation)}
+          {operation.status === OperationStatus.FAILED && viewErrorExpanded && (
+            <AlertErrorView>
+              Operation ID: {operation.id}
+              <br />
+              Error: {operation.error.message}
+            </AlertErrorView>
+          )}
+        </Alert>
+      )}
       {selectedPipelines.length > 0 && (
         <StyledSelectionStatusDiv>
           <div>
@@ -126,7 +233,7 @@ export const LocalPipelineListView = () => {
               total: localPipelines.length,
             })}
           </div>
-          {pushFailedCount > 0 && (
+          {!multiPushEnabled && pushFailedCount > 0 && (
             <>
               <FailStatusDiv>
                 {pushFailedCount === 1
@@ -142,6 +249,9 @@ export const LocalPipelineListView = () => {
               </PrimaryTextButton>
             </>
           )}
+          {multiPushEnabled && pushFailedCount > 0 && (
+            <FailStatusDiv>{T.translate(`${PREFIX}.pipelinesPushedFailMulti`)}</FailStatusDiv>
+          )}
         </StyledSelectionStatusDiv>
       )}
       {ready ? LocalPipelineTableComp() : <LoadingSVGCentered />}
@@ -150,6 +260,7 @@ export const LocalPipelineListView = () => {
         onToggle={toggleCommitModal}
         onSubmit={onPushSubmit}
         loadingMessage={loadingMessage}
+        enableMultiplePush={multiPushEnabled}
       />
     </PipelineListContainer>
   );

--- a/app/cdap/components/SourceControlManagement/OperationStatus.ts
+++ b/app/cdap/components/SourceControlManagement/OperationStatus.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+export enum OperationStatus {
+  PENDING = 'PENDING',
+  STARTING = 'STARTING',
+  RUNNING = 'RUNNING',
+  STOPPING = 'STOPPING',
+  SUCCEEDED = 'SUCCEEDED',
+  FAILED = 'FAILED',
+  KILLED = 'KILLED',
+}

--- a/app/cdap/components/SourceControlManagement/OperationType.ts
+++ b/app/cdap/components/SourceControlManagement/OperationType.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+export enum OperationType {
+  PUSH_APPS = 'PUSH_APPS',
+  PULL_APPS = 'PULL_APPS',
+}

--- a/app/cdap/components/SourceControlManagement/SearchBox.tsx
+++ b/app/cdap/components/SourceControlManagement/SearchBox.tsx
@@ -32,7 +32,7 @@ const StyledTextField = styled(TextField)`
 `;
 
 const StyledDiv = styled.div`
-  margin: 12px 12px;
+  margin: 12px 0px;
 `;
 
 interface ISearchBoxProps {

--- a/app/cdap/components/SourceControlManagement/helpers.ts
+++ b/app/cdap/components/SourceControlManagement/helpers.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import moment from 'moment';
+import { OperationStatus } from './OperationStatus';
+import { OperationType } from './OperationType';
+import { IResource, IOperationResource, IOperationRun, ITimeInstant } from './types';
+import T from 'i18n-react';
+
+const PREFIX = 'features.SourceControlManagement';
+
+export const parseOperationResource = (resource: IOperationResource): IResource => {
+  const { resourceUri } = resource;
+  const [resourceType, resourceId] = resourceUri.split(':');
+  const [namespace, name, version] = resourceId.split('.');
+  return {
+    resourceType,
+    namespace,
+    name,
+    version,
+  };
+};
+
+export const getOperationRunMessage = (operation: IOperationRun) => {
+  const n = operation.metadata?.resources?.length || '';
+
+  if (n === 1) {
+    return getOperationRunMessageSingular(operation);
+  }
+
+  if (operation.status === OperationStatus.SUCCEEDED) {
+    if (operation.type === OperationType.PUSH_APPS) {
+      return T.translate(`${PREFIX}.push.pushSuccessMulti`, { n });
+    }
+    if (operation.type === OperationType.PULL_APPS) {
+      return T.translate(`${PREFIX}.pull.pullSuccessMulti`, { n });
+    }
+    return T.translate(`${PREFIX}.syncSuccessMulti`);
+  }
+
+  if (operation.status === OperationStatus.FAILED || operation.status === OperationStatus.KILLED) {
+    if (operation.type === OperationType.PUSH_APPS) {
+      return T.translate(`${PREFIX}.push.pushFailureMulti`, { n });
+    }
+    if (operation.type === OperationType.PULL_APPS) {
+      return T.translate(`${PREFIX}.pull.pullFailureMulti`, { n });
+    }
+    return T.translate(`${PREFIX}.syncFailreMulti`);
+  }
+
+  if (operation.type === OperationType.PUSH_APPS) {
+    return T.translate(`${PREFIX}.push.pushAppMessageMulti`, { n });
+  }
+  if (operation.type === OperationType.PULL_APPS) {
+    return T.translate(`${PREFIX}.pull.pullAppMessageMulti`, { n });
+  }
+  return T.translate(`${PREFIX}.syncAppMessageMulti`);
+};
+
+export const getOperationStatusType = (operation: IOperationRun) => {
+  if (!operation || !operation.done) {
+    return 'info';
+  }
+
+  if (operation.status === OperationStatus.SUCCEEDED) {
+    return 'success';
+  }
+
+  if (operation.status === OperationStatus.FAILED || operation.status === OperationStatus.KILLED) {
+    return 'error';
+  }
+
+  return 'info';
+};
+
+export const getOperationRunMessageSingular = (operation: IOperationRun) => {
+  if (operation.status === OperationStatus.SUCCEEDED) {
+    if (operation.type === OperationType.PUSH_APPS) {
+      return T.translate(`${PREFIX}.push.pipelinePushedSuccess`);
+    }
+    if (operation.type === OperationType.PULL_APPS) {
+      return T.translate(`${PREFIX}.pull.pipelinePulledSuccess`);
+    }
+    return T.translate(`${PREFIX}.pipelineSyncedSuccess`);
+  }
+
+  if (operation.status === OperationStatus.FAILED || operation.status === OperationStatus.KILLED) {
+    if (operation.type === OperationType.PUSH_APPS) {
+      return T.translate(`${PREFIX}.push.pipelinePushedFail`);
+    }
+    if (operation.type === OperationType.PULL_APPS) {
+      return T.translate(`${PREFIX}.pull.pipelinePulledFail`);
+    }
+    return T.translate(`${PREFIX}.pipelineSyncedFail`);
+  }
+
+  if (operation.type === OperationType.PUSH_APPS) {
+    return T.translate(`${PREFIX}.push.pipelinePushMessage`);
+  }
+  if (operation.type === OperationType.PULL_APPS) {
+    return T.translate(`${PREFIX}.pull.pipelinePullMessage`);
+  }
+  return T.translate(`${PREFIX}.pipelineSyncMessage`);
+};
+
+export const compareTimeInstant = (t1: ITimeInstant, t2: ITimeInstant): number => {
+  return t1.seconds - t2.seconds || t1.nanos - t2.nanos;
+};
+
+export const getOperationStartTime = (operation: IOperationRun): string => {
+  return moment(operation.metadata?.createTime.seconds * 1000).format('DD-MM-YYYY HH:mm:ss A');
+};

--- a/app/cdap/components/SourceControlManagement/index.tsx
+++ b/app/cdap/components/SourceControlManagement/index.tsx
@@ -24,6 +24,7 @@ import styled from 'styled-components';
 import T from 'i18n-react';
 import { RemotePipelineListView } from './RemotePipelineListView';
 import { getCurrentNamespace } from 'services/NamespaceStore';
+import { FeatureProvider } from 'services/react/providers/featureFlagProvider';
 
 const PREFIX = 'features.SourceControlManagement';
 
@@ -64,9 +65,11 @@ const SourceControlManagementSyncView = () => {
           <Tab data-testid="remote-pipeline-tab" label={T.translate(`${PREFIX}.pull.tab`)} />
         </Tabs>
       </StyledDiv>
-      <StyledDiv>
-        {tabIndex === 0 ? <LocalPipelineListView /> : <RemotePipelineListView />}
-      </StyledDiv>
+      <FeatureProvider>
+        <StyledDiv>
+          {tabIndex === 0 ? <LocalPipelineListView /> : <RemotePipelineListView />}
+        </StyledDiv>
+      </FeatureProvider>
     </Provider>
   );
 };

--- a/app/cdap/components/SourceControlManagement/store/index.ts
+++ b/app/cdap/components/SourceControlManagement/store/index.ts
@@ -17,7 +17,8 @@
 import { combineReducers, createStore, Store as StoreInterface } from 'redux';
 import { composeEnhancers } from 'services/helpers';
 import { IAction } from 'services/redux-helpers';
-import { IRepositoryPipeline } from '../types';
+import { IOperationRun, IRepositoryPipeline } from '../types';
+import { act } from 'react-dom/test-utils';
 
 interface IPushViewState {
   ready: boolean;
@@ -39,9 +40,15 @@ interface IPullViewState {
   pullViewErrorMsg: string;
 }
 
+interface IOperationRunState {
+  running: boolean;
+  operation?: IOperationRun;
+}
+
 interface IStore {
   push: IPushViewState;
   pull: IPullViewState;
+  operationRun: IOperationRunState;
 }
 
 export const PushToGitActions = {
@@ -66,6 +73,11 @@ export const PullFromGitActions = {
   setPullViewErrorMsg: 'REMOTE_PIPELINES_SET_ERROR_MSG',
 };
 
+export const OperationRunActions = {
+  setLatestOperation: 'SET_RUNNING_OPERATION',
+  unsetLatestOperation: 'UNSET_RUNNING_OPERATION',
+};
+
 const defaultPushViewState: IPushViewState = {
   ready: false,
   localPipelines: [],
@@ -84,6 +96,10 @@ const defaultPullViewState: IPullViewState = {
   loadingMessage: null,
   showFailedOnly: false,
   pullViewErrorMsg: '',
+};
+
+const defaultOperationRunState: IOperationRunState = {
+  running: false,
 };
 
 const push = (state = defaultPushViewState, action: IAction) => {
@@ -178,14 +194,35 @@ const pull = (state = defaultPullViewState, action: IAction) => {
   }
 };
 
+const operationRun = (
+  state: IOperationRunState = defaultOperationRunState,
+  action: IAction
+): IOperationRunState => {
+  switch (action.type) {
+    case OperationRunActions.setLatestOperation:
+      return {
+        running: !action.payload?.done,
+        operation: action.payload,
+      };
+    case OperationRunActions.unsetLatestOperation:
+      return {
+        running: false,
+      };
+    default:
+      return state;
+  }
+};
+
 const SourceControlManagementSyncStore: StoreInterface<IStore> = createStore(
   combineReducers({
     push,
     pull,
+    operationRun,
   }),
   {
     push: defaultPushViewState,
     pull: defaultPullViewState,
+    operationRun: defaultOperationRunState,
   },
   composeEnhancers('SourceControlManagementSyncStore')()
 );

--- a/app/cdap/components/SourceControlManagement/styles.ts
+++ b/app/cdap/components/SourceControlManagement/styles.ts
@@ -20,6 +20,7 @@ import Popover from 'components/shared/Popover';
 
 export const TableBox = styled(TableContainer)`
   box-shadow: 0 1px 2px 0 rgb(0 0 0 / 20%);
+  margin-top: 10px;
   margin-bottom: 30px;
   max-height: calc(80vh - 200px);
   min-height: calc(80vh - 300px);
@@ -41,6 +42,10 @@ export const StyledPopover = styled(Popover)`
 `;
 
 export const StyledTableRow = styled(TableRow)`
+  .MuiTableCell-body {
+    ${(props) => (props.disabled ? `color: ${props.theme.palette.grey[300]};` : '')}
+  }
+
   &&.Mui-selected {
     background-color: ${(props) => props.theme.palette.blue[500]};
   }
@@ -72,4 +77,8 @@ export const StyledSelectionStatusDiv = styled.div`
 
 export const FailStatusDiv = styled.div`
   color: #d15668;
+`;
+
+export const AlertErrorView = styled.p`
+  margin: 1rem 0;
 `;

--- a/app/cdap/components/SourceControlManagement/types.ts
+++ b/app/cdap/components/SourceControlManagement/types.ts
@@ -16,12 +16,48 @@
 
 import { IArtifactObj } from 'components/PipelineContextMenu/PipelineTypes';
 import { SUPPORT } from 'components/StatusButton/constants';
+import { OperationType } from './OperationType';
+import { OperationStatus } from './OperationStatus';
 
 export interface IRepositoryPipeline {
   name: string;
   fileHash: string;
   error: string;
   status: SUPPORT;
+}
+
+export interface IOperationResource {
+  resourceUri: string;
+}
+
+export interface ITimeInstant {
+  seconds: number;
+  nanos: number;
+}
+
+export interface IOperationMeta {
+  resources: IOperationResource[];
+  createTime?: ITimeInstant;
+  endTime?: ITimeInstant;
+}
+
+export interface IOperationError {
+  message?: string;
+  details?: IOperationResourceScopedError[];
+}
+
+export interface IOperationResourceScopedError {
+  resourceUri: string;
+  message?: string;
+}
+
+export interface IOperationRun {
+  id: string;
+  type: OperationType;
+  done: boolean;
+  status: OperationStatus;
+  metadata?: IOperationMeta;
+  error?: IOperationError;
 }
 
 export interface IPushResponse {
@@ -51,4 +87,17 @@ export interface IListResponse {
   name: string;
   message: string;
   fileHash?: string;
+}
+
+export interface IOperationMetaResponse {
+  status: SUPPORT;
+  resources?: IOperationResource[];
+  message: string;
+}
+
+export interface IResource {
+  resourceType: string;
+  namespace: string;
+  name: string;
+  version: string;
 }

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -3226,32 +3226,51 @@ features:
           _: "{context} required fields are missing"
     info: Source control management allows you to connect namespace with the repository of your source control system repository to efficiently manage development process of the deployed pipelines.
     linkButton: Link Repository
+    syncAppMessageMulti: Syncing pipelines with the remote repository now...
+    syncSuccessMulti: Successfully synced {n} pipelines with the remote repository.
+    syncFailureMulti: Failed to sync {n} pipelines with the remote repository.
+    pipelineSyncMessage: Syncing 1 pipeline with the remote repository
+    pipelineSyncedSuccess: Successfully synced 1 pipeline with the remote repository
+    pipelineSyncedFail: Failed to sync 1 pipeline with the remote repository
     pull:
       emptyPipelineListMessage: There are no pipelines in the remote repository or no pipelines matching the search query "{query}"
       modalTitle: Pull pipeline from remote repository
-      pipelinePulledFail: "Failed to pull 1 pipeline"
+      pipelinePulledFail: "Failed to pull 1 pipeline from the remote repository"
+      pipelinePulledSuccess: Successfully pulled 1 pipeline from the remote repository
+      pipelinePullMessage: Pulling 1 pipeline from the remote repository
       pipelinesListedFail: "Failed to list remote pipelines"
       pipelinesPulledFail: "Failed to pull {count} pipelines"
       pipelinesSelected: "{selected} of {total} pipelines selected"
       pullAppMessage: Pulling {appId} from remote repository now...
+      pullAppMessageMulti: Pulling {n} pipelines from the remote repository now...
       pullButton: Pull to namespace
       pullChipTooltip: Click to pull the latest from Git
       pullSuccess: Pipeline {pipelineName} updated
+      pullSuccessMulti: Successfully pulled {n} pipelines from the remote repository.
+      pullFailureMulti: Failed to pull {n} pipelines from the remote repository.
       tab: Remote pipelines
       upToDate: Pipeline is already up to date.
+      stopOperation: STOP
     push:
       commitPlaceHolder: Write commit message here
       commitTitle: Enter Commit Message
       emptyCommitMessage: Commit Message cannot be empty.
       emptyPipelineListMessage: There are no pipelines in current namespace or no pipelines matching the search query "{query}"
-      pipelinePushedFail: "Failed to push 1 pipeline"
+      pipelinePushedFail: "Failed to push 1 pipeline to the remote repository"
+      pipelinePushedSuccess: Successfully pushed 1 pipeline to the remote repository
+      pipelinePushMessage: Pushing 1 pipeline to the remote repository
       pipelinesPushedFail: "Failed to push {count} pipelines"
+      pipelinesPushedFailMulti: Failed to push the pipelines
       pipelinesSelected: "{selected} of {total} pipelines selected"
       pushAppMessage: Pushing {appId} to remote repository now...
+      pushAppMessageMulti: Pushing {n} pipelines to the remote repository now...
       pushButton: Push to remote
       pushSuccess: Successfully pushed pipeline {pipelineName}
+      pushSuccessMulti: Successfully pushed {n} pipelines to the remote repository.
+      pushFailureMulti: Failed to push {n} pipelines to the remote repository.
       searchLabel: Search by batch pipeline name
       tab: Local pipelines
+      stopOperation: STOP
     table:
       connected: Connected
       pipelineName: Pipeline name


### PR DESCRIPTION
# SCM multiple pipelines push and pull

## Description
This PR adds support for pushing and pulling multiple pipelines in the SCM tab in the NamespaceAdmin page.

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20873](https://cdap.atlassian.net/browse/CDAP-20873)

## Test Plan
TODO: Add e2e tests

## Screenshots
<img width="1512" alt="Screenshot 2023-11-20 at 14 46 54" src="https://github.com/cdapio/cdap-ui/assets/4161531/89666f55-2a78-439f-af07-806545526bd6">
<img width="1512" alt="Screenshot 2023-11-20 at 14 47 10" src="https://github.com/cdapio/cdap-ui/assets/4161531/cb145c65-6c95-45cc-8018-3acb20bc6ec6">
<img width="1512" alt="Screenshot 2023-11-20 at 14 48 10" src="https://github.com/cdapio/cdap-ui/assets/4161531/95917c5c-ca25-4ff0-97c8-7ae297a9f477">
<img width="1512" alt="Screenshot 2023-11-20 at 14 48 21" src="https://github.com/cdapio/cdap-ui/assets/4161531/11d800a1-b05c-4b5d-a2b5-d0041fb8fa66">




[CDAP-20873]: https://cdap.atlassian.net/browse/CDAP-20873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ