### PR TITLE
Changes in command help content for service account create dialog

### DIFF
--- a/app/cdap/components/NamespaceAdmin/ServiceAccounts/EditConfirmDialog.tsx
+++ b/app/cdap/components/NamespaceAdmin/ServiceAccounts/EditConfirmDialog.tsx
@@ -31,6 +31,7 @@ interface IEditConfirmDialogProps {
   isShow: boolean;
   closeFn: () => void;
   namespaceIdentity: string;
+  k8snamespace?: string;
 }
 
 const StyledTextField = styled(TextField)`
@@ -65,15 +66,19 @@ const getGcloudCommand = ({
   tenantProjectId = '${TENANT_PROJECT_ID}',
   identity = '${IDENTITY}',
   gsaEmail = '${GSA_EMAIL}',
+  gsaProjectId = '${GSA_PROJECT_ID}',
+  k8snamespace = 'default',
 }): string =>
-  `gcloud iam service-accounts add-iam-policy-binding --role roles/iam.workloadIdentityUser --member "serviceAccount:${tenantProjectId}.svc.id.goog[default/${identity}]" ${gsaEmail}`;
+  `gcloud iam service-accounts add-iam-policy-binding --role roles/iam.workloadIdentityUser --member "serviceAccount:${tenantProjectId}.svc.id.goog[${k8snamespace}/${identity}]" ${gsaEmail} --project ${gsaProjectId}`;
 
 export const EditConfirmDialog = ({
   selectedServiceAcccount,
   isShow,
   closeFn,
   namespaceIdentity,
+  k8snamespace,
 }: IEditConfirmDialogProps) => {
+  const namespacedCreationHookEnabled = window.CDAP_CONFIG.cdap.namespaceCreationHookEnabled;
   const [serviceAccountInputValue, setServiceAccountInputValue] = useState<string>(
     selectedServiceAcccount
   );
@@ -88,6 +93,7 @@ export const EditConfirmDialog = ({
   const gcloudCommandParams = {
     identity: namespaceIdentity || undefined,
     gsaEmail: serviceAccountInputValue || undefined,
+    k8snamespace: (namespacedCreationHookEnabled && k8snamespace) || undefined,
   };
 
   const copyableExtendedMessage =

--- a/app/cdap/components/NamespaceAdmin/ServiceAccounts/index.tsx
+++ b/app/cdap/components/NamespaceAdmin/ServiceAccounts/index.tsx
@@ -36,7 +36,7 @@ const SubTitleBox = styled(Box)`
   margin-bottom: 15px;
 `;
 
-const ServiceAccountsView = ({ serviceAccounts, namespaceIdentity }) => {
+const ServiceAccountsView = ({ serviceAccounts, namespaceIdentity, k8snamespace }) => {
   const [showPopover, setShowPopover] = useState(false);
   const [selectedServiceAcccount, setSelectedServiceAcccount] = useState<string>('');
   const [isSaveDialogOpen, setSaveDialogOpen] = useState(false);
@@ -125,6 +125,7 @@ const ServiceAccountsView = ({ serviceAccounts, namespaceIdentity }) => {
           isShow={isSaveDialogOpen}
           closeFn={closeSaveDialog}
           namespaceIdentity={namespaceIdentity}
+          k8snamespace={k8snamespace}
         ></EditConfirmDialog>
       )}
     </div>
@@ -135,6 +136,7 @@ const mapStateToProps = (state) => {
   return {
     serviceAccounts: state.serviceAccounts,
     namespaceIdentity: state.identity,
+    k8snamespace: state.k8snamespace,
   };
 };
 

--- a/app/cdap/components/NamespaceAdmin/store/ActionCreator.ts
+++ b/app/cdap/components/NamespaceAdmin/store/ActionCreator.ts
@@ -48,6 +48,7 @@ export function getNamespaceDetail(namespace) {
         exploreAsPrincipal: res.config['explore.as.principal'],
         schedulerQueueName: res.config['scheduler.queue.name'],
         identity: res.identity,
+        k8snamespace: res.config['k8s.namespace'],
       },
     });
   });

--- a/app/cdap/components/NamespaceAdmin/store/index.ts
+++ b/app/cdap/components/NamespaceAdmin/store/index.ts
@@ -94,6 +94,7 @@ interface INamespaceAdmin {
   sourceControlManagementConfig: ISourceControlManagementConfig;
   serviceAccounts: IServiceAccount[];
   identity: string;
+  k8snamespace: string;
 }
 
 type INamespaceAdminState = Partial<INamespaceAdmin>;
@@ -113,6 +114,7 @@ const defaultInitialState: Partial<INamespaceAdminState> = {
   sourceControlManagementConfig: null,
   serviceAccounts: [],
   identity: null,
+  k8snamespace: null,
 };
 
 const namespaceAdmin: Reducer<INamespaceAdminState> = (state = defaultInitialState, action) => {


### PR DESCRIPTION
# Changes in command help content for service account create dialog

## Description
Minor Changes in command help content that is shown for service account create dialog. 
* Added `--project` parameters
* Showing k8snamespaces when available and also when `namespaces.creation.hook.enabled` true

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20880](https://cdap.atlassian.net/browse/CDAP-20880)
[CDAP-20878](https://cdap.atlassian.net/browse/CDAP-20878)
## Test Plan

## Screenshots
<img width="652" alt="image" src="https://github.com/cdapio/cdap-ui/assets/107839049/23d9735a-b094-451e-bcde-087a5d9cb91c">




[CDAP-20880]: https://cdap.atlassian.net/browse/CDAP-20880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20878]: https://cdap.atlassian.net/browse/CDAP-20878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ