### PR TITLE
Typo correction in  import pipeline modal

### DIFF
--- a/app/hydrator/templates/create/pipeline-upgrade-modal.html
+++ b/app/hydrator/templates/create/pipeline-upgrade-modal.html
@@ -112,7 +112,7 @@
         <div class="row">
           <div class="col-xs-8">
             <div class="error-description">
-              A newer version of this plugin exist.
+              A newer version of the plugin exists
             </div>
 
             <div class="error-suggestion">


### PR DESCRIPTION
# Typo correction in  import pipeline modal

## Description
Typo correction in  import pipeline modal
Fixing the below issue with the suggested correction `A newer version of the plugin exists`
<img width="200" alt="image" src="https://github.com/cdapio/cdap-ui/assets/107839049/169159fe-275f-46b1-91fe-83b966221be3">

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20894](https://cdap.atlassian.net/browse/CDAP-20894)

## Test Plan

## Screenshots




[CDAP-20894]: https://cdap.atlassian.net/browse/CDAP-20894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ