### PR TITLE
Cherry pick help content rephrase in service accounts dialog to release/6.10

### DIFF
--- a/app/cdap/components/shared/ConfirmDialog/styles.ts
+++ b/app/cdap/components/shared/ConfirmDialog/styles.ts
@@ -41,7 +41,7 @@ export const StyledAlert = styled(Alert)`
 export const StyledBox = styled(Box)`
   overflow-y: auto;
   max-height: 14vh;
-  word-break: break-all;
+  word-break: break-word;
 
   & pre {
     word-break: break-word;

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -3185,7 +3185,7 @@ features:
     failedToValidate: Service account validation failed
     failedToSave: Failed to save the service account changes
     helpTitle: Provided Google Service Accounts (GSA) will be leveraged as workload identity, more details on gcloud commands help ... 
-    helpContent: "Users for Kubernetes Service Account(KSA) internally to enhance security and access control in the namespace to perform pipeline design-time operations (pipeline preview, Wrangler, pipeline validation). You need to grant Workload Identity User permission to the KSA which can be done using the gcloud command : "
+    helpContent: "Internal Kubernetes Service Account(KSA) will be leveraged as workload identity users for Google Service Accounts (GSA) to enhance security and access control in the namespace to perform pipeline design-time operations (pipeline preview, Wrangler, pipeline validation) which requires granting Workload Identity User role to the namespace identity kubernetes service account on the IAM service account which can be done using the gcloud command : "
     inputHelperText: Provide details of the service account for authorization
     serviceAccount : Service account
   SourceControlManagement:


### PR DESCRIPTION
# Cherry pick https://github.com/cdapio/cdap-ui/pull/1143 to release/6.10

## Description
Help content rephrase in service accounts modal dialog

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [x] Cherry Pick

## Links
Jira:[CDAP-20878](https://cdap.atlassian.net/browse/CDAP-20878)

## Test Plan

## Screenshots




[CDAP-20878]: https://cdap.atlassian.net/browse/CDAP-20878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ