### PR TITLE
fix the flaky e2e tests in the scm feature

### DIFF
--- a/src/e2e-test/features/source.control.management.sync.apps.feature
+++ b/src/e2e-test/features/source.control.management.sync.apps.feature
@@ -16,24 +16,22 @@
 
 @Integration_Tests
 Feature: Source Control Management - Pulling and pushing applications
+  Background:
+    When Open Source Control Management Page
+    Then Delete the repo config
+    Then Initialize the repository config
 
   @SOURCE_CONTROL_MANAGEMENT_TEST
   Scenario: Should successfully push a pipeline to git from pipeline list page
-    When Open Source Control Management Page
-    When Initialize the repository config
     When Deploy and test pipeline "test_pipeline2_fll_airport" with pipeline JSON file "fll_airport_pipeline2.json"
     Then Click push button in Actions dropdown
     Then Commit changes with message "upload pipeline to Git"
     Then Banner is shown with message "Successfully pushed pipeline test_pipeline2_fll_airport"
     Then Clean up pipeline "test_pipeline2_fll_airport" which is created for testing
-    When Open Source Control Management Page
-    Then Delete the repo config
 
   @SOURCE_CONTROL_MANAGEMENT_TEST
   Scenario: Remote pipeline tab loads pipelines from git
     # Setup
-    When Open Source Control Management Page
-    When Initialize the repository config
     When Deploy and test pipeline "test_pipeline2_fll_airport" with pipeline JSON file "fll_airport_pipeline2.json"
     # Test push from SCM sync page
     When Open Source Control Sync Page
@@ -51,15 +49,10 @@ Feature: Source Control Management - Pulling and pushing applications
     Then Pull success indicator is shown for pipeline "test_pipeline2_fll_airport"
     # Clean up
     Then Clean up pipeline "test_pipeline2_fll_airport" which is created for testing
-    When Open Source Control Management Page
-    Then Delete the repo config
 
   @PIPELINE_EDIT_TEST
   @SOURCE_CONTROL_MANAGEMENT_TEST
   Scenario: Edit a simple pipeline and restore a version from git
-    # Setup Repo config
-    When Open Source Control Management Page
-    When Initialize the repository config
     When Deploy and test pipeline "pipeline_edit_test" with pipeline JSON file "logs_generator.json"
     # Push version 1 of the pipeline to git.
     Then Click push button in Actions dropdown
@@ -77,5 +70,3 @@ Feature: Source Control Management - Pulling and pushing applications
     Then History should show 3 entries
     # Clean up.
     Then Clean up pipeline "pipeline_edit_test" which is created for testing
-    When Open Source Control Management Page
-    Then Delete the repo config

--- a/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/SourceControlManagement.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/SourceControlManagement.java
@@ -26,6 +26,7 @@ import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import org.junit.Assert;
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
 /**
@@ -99,7 +100,16 @@ public class SourceControlManagement {
 
   @Then("Delete the repo config")
   public void deleteTheRepoConfig() {
-    ElementHelper.clickOnElement(Helper.locateElementByTestId("actions-popover"));
+    // This first step tries to find and open the action popover for the repository
+    // config (the only row in the table). If this step fails with a NoSuchElementException,
+    // then it means that the repo config is not present in the page.
+    // In this case, we can skip the rest of the steps, as we do not have a repo config to delete.
+    try {
+      ElementHelper.clickOnElement(Helper.locateElementByTestId("actions-popover"));
+    } catch (NoSuchElementException e) {
+      return;
+    }
+
     ElementHelper.clickOnElement(Helper.locateElementByTestId("Delete-on-popover"));
     ElementHelper.clickOnElement(Helper.locateElementByTestId("Delete"));
   }


### PR DESCRIPTION
# [CDAP-20898] Fix flaky e2e tests in SCM

## Description

The steps for deleting and initializing the scm repository config for each of the e2e test scenario fails sometimes. This happens because of unchecked attempts to initialize / delete the repository config.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20898](https://cdap.atlassian.net/browse/CDAP-20898)

## Test Plan
NA

## Screenshots
NA


[CDAP-20898]: https://cdap.atlassian.net/browse/CDAP-20898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20898]: https://cdap.atlassian.net/browse/CDAP-20898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ