### PR TITLE
Format and tooltip changes service accounts modal dialog

### DIFF
--- a/app/cdap/components/NamespaceAdmin/ServiceAccounts/EditConfirmDialog.tsx
+++ b/app/cdap/components/NamespaceAdmin/ServiceAccounts/EditConfirmDialog.tsx
@@ -168,6 +168,7 @@ export const EditConfirmDialog = ({
       statusMessage={saveStatusMsg}
       extendedMessage={saveStatusDetails}
       copyableExtendedMessage={copyableExtendedMessage}
+      isExpandedDefault={true}
     ></ConfirmDialog>
   );
 };

--- a/app/cdap/components/shared/ConfirmDialog/Status.tsx
+++ b/app/cdap/components/shared/ConfirmDialog/Status.tsx
@@ -30,6 +30,7 @@ interface IStatusProps {
   statusMessage?: string | ReactNode;
   extendedMessage?: IExtendedMessage | string;
   copyableExtendedMessage?: string | ReactNode;
+  isExpandedDefault?: boolean;
 }
 
 export const Status = ({
@@ -37,8 +38,9 @@ export const Status = ({
   statusMessage,
   extendedMessage,
   copyableExtendedMessage,
+  isExpandedDefault,
 }: IStatusProps) => {
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(isExpandedDefault);
 
   const handleToggleExtendedMessage = () => {
     setIsExpanded(!isExpanded);
@@ -64,7 +66,7 @@ export const Status = ({
           {isExpanded && (
             <StyledBox>
               {typeof extendedMessage === 'string' ? (
-                <div>{extendedMessage}</div>
+                <div dangerouslySetInnerHTML={{ __html: extendedMessage.toString() }}></div>
               ) : (
                 <pre>{extendedMessage.response}</pre>
               )}

--- a/app/cdap/components/shared/ConfirmDialog/index.tsx
+++ b/app/cdap/components/shared/ConfirmDialog/index.tsx
@@ -48,6 +48,7 @@ interface IConfirmDialogProps {
   extendedMessage?: IExtendedMessage | string;
   disableAction?: boolean;
   copyableExtendedMessage?: string | ReactNode;
+  isExpandedDefault?: boolean;
 }
 
 export const ConfirmDialog = ({
@@ -64,6 +65,7 @@ export const ConfirmDialog = ({
   extendedMessage,
   disableAction,
   copyableExtendedMessage,
+  isExpandedDefault,
 }: IConfirmDialogProps) => {
   return (
     <StyledDialog open={isOpen} fullWidth>
@@ -75,6 +77,7 @@ export const ConfirmDialog = ({
           extendedMessage={extendedMessage}
           copyableExtendedMessage={copyableExtendedMessage}
           key={statusMessage.toString()}
+          isExpandedDefault={isExpandedDefault}
         ></Status>
       )}
       <DialogContent>

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -3184,8 +3184,8 @@ features:
     failedToDelete: Unable to delete service account
     failedToValidate: Service account validation failed
     failedToSave: Failed to save the service account changes
-    helpTitle: Provided Google Service Accounts (GSA) will be leveraged as workload identity, more details on gcloud commands help ... 
-    helpContent: "Internal Kubernetes Service Account(KSA) will be leveraged as workload identity users for Google Service Accounts (GSA) to enhance security and access control in the namespace to perform pipeline design-time operations (pipeline preview, Wrangler, pipeline validation) which requires granting Workload Identity User role to the namespace identity kubernetes service account on the IAM service account which can be done using the gcloud command : "
+    helpTitle: To use the service account with the namespace, Workload Identity Permission is required. Please grant the permission by running the  below commands in CLI. 
+    helpContent: "1. Run below command and export the GSA Project ID <br/> export GSA_PROJECT_ID=<i>&lt;PROJECT_ID&gt;</i> # Google Cloud Project ID where the IAM service account is located.<br/> <br/>2. Copy and Run below command"
     inputHelperText: Provide details of the service account for authorization
     serviceAccount : Service account
   SourceControlManagement:


### PR DESCRIPTION
# Fix the UI tooltip and formatting for the help commands & content in service accounts modal dialog UI

## Description
* Changes in the help content and commands, refer JIRA for details
* Added Formatting support to  the content holder
* Provided option for expand \collapse in the confirm dialog component

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [x] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20902](https://cdap.atlassian.net/browse/CDAP-20902)

## Test Plan

## Screenshots
![image](https://github.com/cdapio/cdap-ui/assets/107839049/da62975d-caa6-4f6e-931e-4a2f14abf523)




[CDAP-20902]: https://cdap.atlassian.net/browse/CDAP-20902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ