### PR TITLE
Add e2e tests for scm bulk push and pull operations

### DIFF
--- a/app/cdap/components/SourceControlManagement/LocalPipelineListView/PipelineTable.tsx
+++ b/app/cdap/components/SourceControlManagement/LocalPipelineListView/PipelineTable.tsx
@@ -99,7 +99,7 @@ export const LocalPipelineTable = ({
 
   return (
     <TableBox>
-      <Table stickyHeader>
+      <Table stickyHeader data-testid="local-pipelines-table">
         <TableHead>
           <TableRow>
             <TableCell padding="checkbox">

--- a/app/cdap/components/SourceControlManagement/LocalPipelineListView/index.tsx
+++ b/app/cdap/components/SourceControlManagement/LocalPipelineListView/index.tsx
@@ -213,6 +213,7 @@ export const LocalPipelineListView = () => {
           variant="filled"
           severity={getOperationStatusType(operation)}
           action={getOperationAction()}
+          data-testid="latest_operation_banner"
         >
           <AlertTitle>{getOperationRunMessage(operation)}</AlertTitle>
           {getOperationStartTime(operation)}

--- a/app/cdap/components/SourceControlManagement/RemotePipelineListView/index.tsx
+++ b/app/cdap/components/SourceControlManagement/RemotePipelineListView/index.tsx
@@ -233,6 +233,7 @@ export const RemotePipelineListView = ({ redirectOnSubmit }: IRemotePipelineList
             variant="filled"
             severity={getOperationStatusType(operation)}
             action={getOperationAction()}
+            data-testid="latest_operation_banner"
           >
             <AlertTitle>{getOperationRunMessage(operation)}</AlertTitle>
             {getOperationStartTime(operation)}

--- a/server/config/development/cdap.json
+++ b/server/config/development/cdap.json
@@ -15,6 +15,8 @@
   "ui.theme.file": "config/themes/default.json",
   "session.secret.key": "sample-secret-key-for-encryption",
   "feature.lifecycle.management.edit.enabled": "true",
+  "feature.source.control.management.git.enabled": "true",
+  "feature.source.control.management.multi.app.enabled": "true",
   "ui.analyticsTag": "",
   "ui.GTM": "",
   "hsts.enabled": "false",

--- a/src/e2e-test/features/source.control.management.sync.apps.feature
+++ b/src/e2e-test/features/source.control.management.sync.apps.feature
@@ -30,6 +30,74 @@ Feature: Source Control Management - Pulling and pushing applications
     Then Clean up pipeline "test_pipeline2_fll_airport" which is created for testing
 
   @SOURCE_CONTROL_MANAGEMENT_TEST
+  Scenario: Should successfully push and pull multiple pipelines to git from sync page
+    # Setup
+    When Deploy and test pipeline "test_multi_push_fll_airport" with pipeline JSON file "fll_airport_pipeline2.json"
+    When Deploy and test pipeline "test_multi_push_logs_generator" with pipeline JSON file "logs_generator.json"
+    When Deploy and test pipeline "synced_logs_generator" with pipeline JSON file "logs_generator.json"
+    Then Click push button in Actions dropdown
+    Then Commit changes with message "upload pipeline to Git"
+    Then Banner is shown with message "Successfully pushed pipeline synced_logs_generator"
+
+    # Push 2 pipelines in bulk
+    When Open Source Control Sync Page
+    When Select local pipeline "test_multi_push_fll_airport"
+    When Select local pipeline "test_multi_push_logs_generator"
+    When Push selected pipelines to remote with commit message "upload pipelines to git"
+
+    # Verify that when one operation is running, another operation can not be started
+    Then Verify "push" operation is running
+    Then Verify the remote "push" button is disabled
+    When Select remote pipelines tab
+    Then Verify "push" operation is running
+    Then Verify the remote "pull" button is disabled
+
+    # Move to another page and back, the operation should be running
+    When Open CDAP main page
+    When Open Source Control Sync Page
+    Then Verify "push" operation is running
+    Then Verify the remote "push" button is disabled
+
+    # The push operation should succeed
+    Then Wait for "push" operation to complete successfully
+    When Select remote pipelines tab
+    Then Verify "test_multi_push_fll_airport" pipeline exist in list
+    Then Verify "test_multi_push_logs_generator" pipeline exist in list
+
+    # Delete these pipelines locally
+    Then Clean up pipeline "test_multi_push_fll_airport" which is created for testing
+    Then Clean up pipeline "test_multi_push_logs_generator" which is created for testing
+
+    # Then pull these from remote
+    When Open Source Control Sync Page
+    When Select remote pipelines tab
+    When Select remote pipeline "test_multi_push_fll_airport"
+    When Select remote pipeline "test_multi_push_logs_generator"
+    When Pull selected pipelines
+
+    # Verify that when one operation is running, another operation can not be started
+    Then Verify "pull" operation is running
+    Then Verify the remote "pull" button is disabled
+    When Select local pipelines tab
+    Then Verify "pull" operation is running
+    Then Verify the remote "push" button is disabled
+    When Select remote pipelines tab
+
+    # The pull operation should succeed
+    Then Wait for "pull" operation to complete successfully
+    When Select local pipelines tab
+    Then Verify "test_multi_push_fll_airport" pipeline exist in local list
+    Then Verify "test_multi_push_logs_generator" pipeline exist in local list
+    When Open pipeline list page
+    Then Verify pipeline "test_multi_push_fll_airport" is deployed
+    Then Verify pipeline "test_multi_push_logs_generator" is deployed
+
+    # Cleanup
+    Then Clean up pipeline "test_multi_push_fll_airport" which is created for testing
+    And Clean up pipeline "test_multi_push_logs_generator" which is created for testing
+    And Clean up pipeline "synced_logs_generator" which is created for testing
+
+  @SOURCE_CONTROL_MANAGEMENT_TEST
   Scenario: Remote pipeline tab loads pipelines from git
     # Setup
     When Deploy and test pipeline "test_pipeline2_fll_airport" with pipeline JSON file "fll_airport_pipeline2.json"
@@ -37,7 +105,8 @@ Feature: Source Control Management - Pulling and pushing applications
     When Open Source Control Sync Page
     When Select "test_pipeline2_fll_airport" pipeline and push
     Then Commit changes with message "upload pipeline to Git"
-    Then Push success indicator is shown for pipeline "test_pipeline2_fll_airport"
+    Then Verify "push" operation is running
+    Then Wait for "push" operation to complete successfully
     When Select remote pipelines tab
     Then Verify pipeline list size 1
     Then Verify "test_pipeline2_fll_airport" pipeline exist in list
@@ -46,7 +115,12 @@ Feature: Source Control Management - Pulling and pushing applications
     When Open Source Control Sync Page
     When Select remote pipelines tab
     Then Select "test_pipeline2_fll_airport" pipeline and pull
-    Then Pull success indicator is shown for pipeline "test_pipeline2_fll_airport"
+    Then Verify "pull" operation is running
+    Then Wait for "pull" operation to complete successfully
+    When Select local pipelines tab
+    Then Verify "test_pipeline2_fll_airport" pipeline exist in local list
+    When Open pipeline list page
+    Then Verify pipeline "test_pipeline2_fll_airport" is deployed
     # Clean up
     Then Clean up pipeline "test_pipeline2_fll_airport" which is created for testing
 


### PR DESCRIPTION
# Add e2e tests for scm bulk push and pull operations

## Description
Adds e2e tests for pushing and pulling multiple pipelines from the scm sync page. 

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [x] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20888](https://cdap.atlassian.net/browse/CDAP-20888)

## Test Plan
NA

## Screenshots
NA


[CDAP-20888]: https://cdap.atlassian.net/browse/CDAP-20888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ