### PR TITLE
[CDAP-20904] Update the UI to not expose the Github PAT in the Namespace Admin page

### DIFF
--- a/app/cdap/components/NamespaceAdmin/SourceControlManagement/SourceControlManagementForm.tsx
+++ b/app/cdap/components/NamespaceAdmin/SourceControlManagement/SourceControlManagementForm.tsx
@@ -78,11 +78,13 @@ const StyledHr = styled.hr`
 interface ISourceControlManagementFormProps {
   initialSourceControlManagementConfig?: ISourceControlManagementConfig | null;
   onToggle: () => void;
+  isEdit: boolean;
 }
 
 const SourceControlManagementForm = ({
   initialSourceControlManagementConfig,
   onToggle,
+  isEdit,
 }: ISourceControlManagementFormProps) => {
   const [formState, formStateDispatch] = useReducer(
     sourceControlManagementFormReducer,
@@ -94,7 +96,7 @@ const SourceControlManagementForm = ({
     if (!formState.config?.link) {
       count++;
     }
-    if (!formState.config?.auth?.token) {
+    if (!isEdit && !formState.config?.auth?.token) {
       count++;
     }
     if (!formState.config?.auth?.patConfig?.passwordName) {
@@ -326,7 +328,7 @@ const SourceControlManagementForm = ({
                   name: 'token',
                   description: T.translate(`${PREFIX}.auth.pat.tokenHelperText`).toString(),
                   label: T.translate(`${PREFIX}.auth.pat.token`).toString(),
-                  required: true,
+                  required: !isEdit,
                   'widget-type': 'password',
                 }}
                 onChange={(val) => {

--- a/app/cdap/components/NamespaceAdmin/SourceControlManagement/index.tsx
+++ b/app/cdap/components/NamespaceAdmin/SourceControlManagement/index.tsx
@@ -48,6 +48,7 @@ const StyledInfo = styled.div`
 
 export const SourceControlManagement = () => {
   const [isFormOpen, setIsFormOpen] = useState(false);
+  const [isEditingConfig, setIsEditingConfig] = useState(false);
   const [isUnlinkModalOpen, setIsUnlinkModalOpen] = useState(false);
   const [errorMessage, setErrorMessage] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -57,6 +58,17 @@ export const SourceControlManagement = () => {
   const toggleForm = () => {
     setIsFormOpen(!isFormOpen);
   };
+
+  const openCreateForm = () => {
+    setIsEditingConfig(false);
+    setIsFormOpen(true);
+  };
+
+  const openEditForm = () => {
+    setIsEditingConfig(true);
+    setIsFormOpen(true);
+  };
+
   const toggleUnlinkModal = () => {
     setIsUnlinkModalOpen(!isUnlinkModalOpen);
   };
@@ -64,7 +76,7 @@ export const SourceControlManagement = () => {
   const actions = [
     {
       label: T.translate('commons.edit'),
-      actionFn: () => toggleForm(),
+      actionFn: () => openEditForm(),
     },
     {
       label: T.translate('commons.delete'),
@@ -100,7 +112,7 @@ export const SourceControlManagement = () => {
       <StyledInfo>{T.translate(`${PREFIX}.info`)}</StyledInfo>
       {!sourceControlManagementConfig && (
         <PrimaryContainedButton
-          onClick={toggleForm}
+          onClick={openCreateForm}
           style={{ marginBottom: '15px' }}
           data-testid="link-repository-button"
         >
@@ -108,13 +120,12 @@ export const SourceControlManagement = () => {
         </PrimaryContainedButton>
       )}
       {sourceControlManagementConfig && (
-        <Table columnTemplate="100px 2fr 1fr 2fr 1fr 2fr 120px 100px">
+        <Table columnTemplate="100px 2fr 1fr 1fr 2fr 120px 100px">
           <TableHeader>
             <TableRow>
               <TableCell>{T.translate(`${PREFIX}.configModal.provider.label`)}</TableCell>
               <TableCell>{T.translate(`${PREFIX}.configModal.repoUrl.label`)}</TableCell>
               <TableCell>{T.translate(`${PREFIX}.configModal.auth.label`)}</TableCell>
-              <TableCell>{T.translate(`${PREFIX}.configModal.auth.pat.token`)}</TableCell>
               <TableCell>{T.translate(`${PREFIX}.configModal.branch.label`)}</TableCell>
               <TableCell>{T.translate(`${PREFIX}.configModal.pathPrefix.label`)}</TableCell>
               <TableCell></TableCell>
@@ -136,9 +147,6 @@ export const SourceControlManagement = () => {
               </TableCell>
               <TableCell data-testid="repository-auth-type">
                 {sourceControlManagementConfig.auth.type}
-              </TableCell>
-              <TableCell data-testid="repository-auth-token">
-                <StyledPasswordWrapper value={sourceControlManagementConfig.auth.token} />
               </TableCell>
               <TableCell>
                 {sourceControlManagementConfig.defaultBranch
@@ -166,6 +174,7 @@ export const SourceControlManagement = () => {
         <SourceControlManagementForm
           onToggle={toggleForm}
           initialSourceControlManagementConfig={sourceControlManagementConfig}
+          isEdit={isEditingConfig}
         />
       )}
       <UnlinkSourceControlModal

--- a/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/SourceControlManagement.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/SourceControlManagement.java
@@ -93,9 +93,6 @@ public class SourceControlManagement {
     Assert.assertTrue(Helper.locateElementByTestId("repository-provider").getText().contains("GITHUB"));
     Assert.assertTrue(Helper.locateElementByTestId("repository-link").getText().contains(Constants.FAKE_REPO_LINK));
     Assert.assertTrue(Helper.locateElementByTestId("repository-auth-type").getText().contains("PAT"));
-    Assert.assertTrue(Helper.locateElementByTestId("repository-auth-token")
-        .findElement(By.cssSelector("input")).getAttribute("value")
-        .contains(Constants.FAKE_TOKEN));
   }
 
   @Then("Delete the repo config")


### PR DESCRIPTION
# Update the UI to not expose the Github PAT in the Namespace Admin page

## Description
Currently, in the UI, we fetch and display the Github PAT in the namespace admin page. This is not required, as the PAT is not used in the UI for any operations. Also, this is not a secure practice. The following steps are implemented to fix this:

1. Do not fetch the Github PAT and do not display it in the UI. 
2. Also, do not autofill the Github PAT in the form to edit the repository config. If no PAT is provided in the edit form, then the PAT should not be updated in the secure store.
3. During creation of the repository config, the PAT must be mandatory (as it is currently), however during edits to the repository config the PAT must be optional.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20904](https://cdap.atlassian.net/browse/CDAP-20904)

## Test Plan
Updated the e2e tests.

## Screenshots 
<img width="1512" alt="Screenshot 2023-11-22 at 12 59 08" src="https://github.com/cdapio/cdap-ui/assets/4161531/70cffe8e-30fb-4010-9a2f-78db525de43d">



[CDAP-20904]: https://cdap.atlassian.net/browse/CDAP-20904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ