### PR TITLE
Command help command changes in service accounts modal UI

### DIFF
--- a/app/cdap/components/NamespaceAdmin/ServiceAccounts/EditConfirmDialog.tsx
+++ b/app/cdap/components/NamespaceAdmin/ServiceAccounts/EditConfirmDialog.tsx
@@ -63,13 +63,13 @@ const StyledTextField = styled(TextField)`
  * @return string, the gcloud cli command to run
  */
 const getGcloudCommand = ({
-  tenantProjectId = '${TENANT_PROJECT_ID}',
+  k8sWorkloadIdentityPool = '${TENANT_PROJECT_ID}.svc.id.goog',
   identity = '${IDENTITY}',
   gsaEmail = '${GSA_EMAIL}',
   gsaProjectId = '${GSA_PROJECT_ID}',
   k8snamespace = 'default',
 }): string =>
-  `gcloud iam service-accounts add-iam-policy-binding --role roles/iam.workloadIdentityUser --member "serviceAccount:${tenantProjectId}.svc.id.goog[${k8snamespace}/${identity}]" ${gsaEmail} --project ${gsaProjectId}`;
+  `gcloud iam service-accounts add-iam-policy-binding --role roles/iam.workloadIdentityUser --member "serviceAccount:${k8sWorkloadIdentityPool}[${k8snamespace}/${identity}]" ${gsaEmail} --project ${gsaProjectId}`;
 
 export const EditConfirmDialog = ({
   selectedServiceAcccount,
@@ -79,6 +79,7 @@ export const EditConfirmDialog = ({
   k8snamespace,
 }: IEditConfirmDialogProps) => {
   const namespacedCreationHookEnabled = window.CDAP_CONFIG.cdap.namespaceCreationHookEnabled;
+  const k8sWorkloadIdentityPool = window.CDAP_CONFIG.cdap.k8sWorkloadIdentityPool;
   const [serviceAccountInputValue, setServiceAccountInputValue] = useState<string>(
     selectedServiceAcccount
   );
@@ -94,6 +95,7 @@ export const EditConfirmDialog = ({
     identity: namespaceIdentity || undefined,
     gsaEmail: serviceAccountInputValue || undefined,
     k8snamespace: (namespacedCreationHookEnabled && k8snamespace) || undefined,
+    k8sWorkloadIdentityPool: k8sWorkloadIdentityPool || undefined,
   };
 
   const copyableExtendedMessage =

--- a/server/express.js
+++ b/server/express.js
@@ -241,6 +241,7 @@ function makeApp(authAddress, cdapConfig, uiSettings) {
         maxRecordsPreview: cdapConfig['preview.max.num.records'],
         ui: uiSettings['ui'],
         k8sWorkloadIdentityEnabled: cdapConfig['master.environment.k8s.workload.identity.enabled'],
+        k8sWorkloadIdentityPool:cdapConfig['credential.provider.system.properties.gcp-wi-credential-provider.k8s.workload.identity.pool'],
         namespaceCreationHookEnabled: cdapConfig['namespaces.creation.hook.enabled'],
         hstsEnabled: cdapConfig['hsts.enabled'],
         hstsMaxAge: cdapConfig['hsts.max.age'],


### PR DESCRIPTION
# Command help command changes in service accounts modal UI

## Description
Replace `${TENANT_PROJECT_ID}.svc.id.goog` in the gcloud command help by the value of this key from cdap conf: `credential.provider.system.properties.gcp-wi-credential-provider.k8s.workload.identity.pool`

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20903](https://cdap.atlassian.net/browse/CDAP-20903)

## Test Plan
Tested Manually.

## Screenshots
With Value present
![image](https://github.com/cdapio/cdap-ui/assets/107839049/d511b54b-65f3-414c-a019-4450ce05a719)

When Value is empty or config property is not present at all
![image](https://github.com/cdapio/cdap-ui/assets/107839049/bc6c460a-37b3-4df5-ac5a-45a777c8af79)




[CDAP-20903]: https://cdap.atlassian.net/browse/CDAP-20903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ