### PR TITLE
CDAP-20838 : Namespace selector in Operations tab is drawn under the header, making namespace impossible to select

### DIFF
--- a/app/cdap/components/NamespacesPicker/NamespacesPicker.scss
+++ b/app/cdap/components/NamespacesPicker/NamespacesPicker.scss
@@ -39,7 +39,7 @@ $monitor-more-color: $blue-02;
 
     .popper {
       width: 300px;
-      z-index: 1; // need to be on top of the svg graph
+      z-index: 999; // need to be on top of the svg graph
       text-align: left;
 
       .popover-content {


### PR DESCRIPTION
# Namespace selector in Operations tab is drawn under the header, making namespace impossible to select

## Description
Namespace selector popover is going behind other elements. 
Increased the z-index for the same to ensure that it will be always on top of elements. 
As the same menu is being used in multiple places given z-index:999 to be on safer side.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20838](https://cdap.atlassian.net/browse/CDAP-20838)

## Test Plan
Verified manually.

## Screenshots
<img width="600" alt="image" src="https://github.com/cdapio/cdap-ui/assets/107839049/3bb8a471-fd96-4615-a3ee-55c84b7a2753">




[CDAP-20838]: https://cdap.atlassian.net/browse/CDAP-20838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ