### PR TITLE
Cherry pick CDAP-20838 - UI issue in namespace selector menu

### DIFF
--- a/app/cdap/components/NamespacesPicker/NamespacesPicker.scss
+++ b/app/cdap/components/NamespacesPicker/NamespacesPicker.scss
@@ -39,7 +39,7 @@ $monitor-more-color: $blue-02;
 
     .popper {
       width: 300px;
-      z-index: 1; // need to be on top of the svg graph
+      z-index: 999; // need to be on top of the svg graph
       text-align: left;
 
       .popover-content {


### PR DESCRIPTION
# Cherry pick https://github.com/cdapio/cdap-ui/pull/1158

## Description
Namespace selector in Operations tab is drawn under the header, making namespace impossible to select.

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [x] Cherry Pick

## Links
Jira: [CDAP-20838 ](https://cdap.atlassian.net/browse/CDAP-20838)

## Test Plan

## Screenshots


