### PR TITLE
[CDAP-20927]: Help content area should show without scroll in service accounts edit dialog

### DIFF
--- a/app/cdap/components/shared/ConfirmDialog/index.tsx
+++ b/app/cdap/components/shared/ConfirmDialog/index.tsx
@@ -70,17 +70,17 @@ export const ConfirmDialog = ({
   return (
     <StyledDialog open={isOpen} fullWidth>
       <DialogTitle>{headerTitle}</DialogTitle>
-      {statusMessage && (
-        <Status
-          severity={severity}
-          statusMessage={statusMessage}
-          extendedMessage={extendedMessage}
-          copyableExtendedMessage={copyableExtendedMessage}
-          key={statusMessage.toString()}
-          isExpandedDefault={isExpandedDefault}
-        ></Status>
-      )}
       <DialogContent>
+        {statusMessage && (
+          <Status
+            severity={severity}
+            statusMessage={statusMessage}
+            extendedMessage={extendedMessage}
+            copyableExtendedMessage={copyableExtendedMessage}
+            key={statusMessage.toString()}
+            isExpandedDefault={isExpandedDefault}
+          ></Status>
+        )}
         {confirmationText}
         {confirmationElem}
       </DialogContent>

--- a/app/cdap/components/shared/ConfirmDialog/styles.ts
+++ b/app/cdap/components/shared/ConfirmDialog/styles.ts
@@ -25,6 +25,9 @@ export const StyledDialog = styled(Dialog)`
       font-size: 24px;
     }
   }
+  & .MuiDialogContent-root {
+    padding-top: 0px;
+  }
   & .MuiDialogActions-root {
     margin-right: 16px;
     & .MuiButton-label {
@@ -35,12 +38,12 @@ export const StyledDialog = styled(Dialog)`
 
 export const StyledAlert = styled(Alert)`
   font-size: 12px;
-  margin-bottom: 8px;
+  margin: 0 -24px 8px -24px;
 `;
 
 export const StyledBox = styled(Box)`
   overflow-y: auto;
-  max-height: 14vh;
+  max-height: 30vh;
   word-break: break-word;
 
   & pre {


### PR DESCRIPTION
# [CDAP-20927]: Help content area should show without scroll in service accounts edit dialog

## Description
Increased height of help area in new dialog and adjusted scrolls in dialog content section so that proper scrolling is applied.

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [x] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20927](https://cdap.atlassian.net/browse/CDAP-20927)

## Test Plan

## Screenshots
<img width="400" alt="image" src="https://github.com/cdapio/cdap-ui/assets/107839049/00cdd368-16cc-427e-a1e0-8d8358109194">




[CDAP-20927]: https://cdap.atlassian.net/browse/CDAP-20927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20927]: https://cdap.atlassian.net/browse/CDAP-20927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ