### PR TITLE
adding optional field for XMLTOJSON directive

### DIFF
--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -1240,6 +1240,8 @@ features:
             fieldLabel: Depth
             label: XML to JSON
             placeholder: Enter depth
+            optionalFieldLabel: Keep Strings
+            optionalPlaceholder: Optional Boolean parameter
         title: Parse
       SetCharEncoding:
         disabledTooltip: Character encoding can only be set on columns of data type 'bytes'


### PR DESCRIPTION
This Change needs to be tested. 

Jira : https://cdap.atlassian.net/browse/CDAP-20934 

Added new optional field in a directive `parse-xml-to-json` https://github.com/data-integrations/wrangler/pull/695 

Steps to check : 

WRANGLER > pick any file > on the column drop down , click parse 
<img width="1140" alt="Screenshot 2024-01-23 at 15 24 53" src="https://github.com/cdapio/cdap-ui/assets/86019177/ad6d723c-ac46-4544-ab81-9d35cb92f04d">

Need to show 1 more field 


