### PR TITLE
Add support for managing data-testids centrally

### DIFF
--- a/app/cdap/main.js
+++ b/app/cdap/main.js
@@ -65,6 +65,7 @@ import history from 'services/history';
 import { CookieBanner } from 'components/CookieBanner';
 // See ./graphql/fragements/README.md
 import introspectionQueryResultData from '../../graphql/fragments/fragmentTypes.json';
+import { TestidProvider } from './testids/TestidsProvider';
 
 require('../ui-utils/url-generator');
 require('font-awesome-sass-loader!./styles/font-awesome.config.js');
@@ -423,7 +424,11 @@ CDAP.propTypes = {
 };
 
 const RootComp = hot(() => {
-  return <ThemeWrapper render={() => <CDAP />} />;
+  return (
+    <TestidProvider>
+      <ThemeWrapper render={() => <CDAP />} />
+    </TestidProvider>
+  );
 });
 
 ReactDOM.render(<RootComp />, document.getElementById('app-container'));

--- a/app/cdap/testids/TestidContext.ts
+++ b/app/cdap/testids/TestidContext.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { createContext } from 'react';
+
+export type DataTestIdGetter = (prefixPath: string, siblingIndex?: number) => string;
+const defaultDataTestIdGetter: DataTestIdGetter = (prefixPath, index) => `${prefixPath}-${index}`;
+
+export const TestidContext = createContext<DataTestIdGetter>(defaultDataTestIdGetter);

--- a/app/cdap/testids/TestidsProvider.tsx
+++ b/app/cdap/testids/TestidsProvider.tsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { useContext } from 'react';
+import _get from 'lodash/get';
+import testids from './testids.yaml';
+import { DataTestIdGetter, TestidContext } from './TestidContext';
+
+interface ITestidProviderProps {
+  children: React.ReactNode;
+}
+
+function getDataTestidInternal(prefixPath: string, siblingKey?: string | number): string {
+  // testids is the JS object created from testids.yaml
+  // This object represents a prefix tree (the logical heirarchy of UI components/elements in cdap-ui)
+  // The values at the leaf nodes of this tree can be null or strings (strings when we are referencing
+  // previously hardcoded testid values), for all newly added data-testids the value at the leaf node
+  // should be null.
+
+  const actualTestidPrefix = _get(testids, prefixPath);
+
+  // actualTestidPrefix is the value at the node of the prefix tree pointed by the prefixPath provided.
+  // We need to ensure that the prefix path provided points to a leaf node. This can be ensured by checking
+  // the value of actualTestidPrefix. For leaf nodes this value will always be a string or null.
+  if (actualTestidPrefix !== null && typeof actualTestidPrefix !== 'string') {
+    return '';
+  }
+
+  let actualTestid = actualTestidPrefix;
+  if (actualTestidPrefix === null) {
+    actualTestid = prefixPath.replace(/\./g, '-');
+  }
+
+  if (siblingKey) {
+    return `${actualTestid}-${siblingKey}`;
+  }
+
+  return actualTestid;
+}
+
+/**
+ * This function takes a prefix path (from the data-testid heirarchy specified in testids.yaml) and
+ * optionally an unique key (string or numeric) to identify elements of same type and returns a string
+ * that can be used as the data-testid attribute of the UI element.
+ *
+ * In development mode this function also checks for the existence of the prefix path in testids.yaml
+ *
+ * @param prefixPath (string) prefix path from the data-testid heirarchy specified in testids.yaml
+ *                   for example 'features.entityListView.entity.named'
+ * @param siblingKey (string | number) to uniquely identify elements of the same type at the same heirarchial level
+ * @returns (string) an unique string that can be used as the data-testid attribute of the UI element
+ */
+export function getDataTestid(prefixPath: string, siblingKey?: string | number): string {
+  const testidValue = getDataTestidInternal(prefixPath, siblingKey);
+
+  // runs only in development
+  if (window.CDAP_CONFIG.uiValidateTestids) {
+    if (!testidValue) {
+      throw new Error(
+        `Using a data-testid that is not defined in testids.yaml: 
+        prefixPath = ${prefixPath}, siblingIndex = ${siblingKey} .`
+      );
+    }
+  }
+
+  return testidValue;
+}
+
+export function TestidProvider({ children }: ITestidProviderProps): JSX.Element {
+  return <TestidContext.Provider value={getDataTestid}>{children}</TestidContext.Provider>;
+}
+
+export function useTestid(): DataTestIdGetter {
+  return useContext(TestidContext);
+}

--- a/app/cdap/testids/testids.yaml
+++ b/app/cdap/testids/testids.yaml
@@ -1,0 +1,23 @@
+---
+# Keys in this file can contain only alphanumeric characters and underscore.
+#
+# Keys in this file are kept alphabetically sorted.
+# Sorting of the keys (if necessary) is done in the custom webpack loader.
+# Code of the custom loader is located at ui-devtools/testid-yaml-loader.
+#
+# Please do not modify this comment section at the top.
+# This section is added by the testid-yaml-loader.
+
+features:
+  entityListView:
+    allEntities: ~
+    entity:
+      fastActions:
+        delete: ~
+        explore: ~
+        log: ~
+        setPreferences: ~
+        startStop: ~
+        truncate: ~
+      named: ~
+    justAdded: ~

--- a/app/cdap/testids/testids.yaml.d.ts
+++ b/app/cdap/testids/testids.yaml.d.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+export interface TestidTree {
+  [key: string]: string | TestidTree;
+};
+
+const testids: TestidTree;
+export default testids;

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "is-color": "1.0.2",
     "jest": "26.6.1",
     "jest-css-modules-transform": "4.0.1",
+    "js-yaml": "^4.1.0",
     "jshint": "2.11.0-rc1",
     "lodash-webpack-plugin": "0.11.5",
     "merge-stream": "2.0.0",

--- a/server/config/development/cdap.json
+++ b/server/config/development/cdap.json
@@ -1,4 +1,5 @@
 {
+  "ui.validate.testids.enabled": true,
   "router.ssl.bind.port": "10443",
   "dashboard.bind.address": "0.0.0.0",
   "router.ssl.server.port": "10443",

--- a/server/express.js
+++ b/server/express.js
@@ -267,8 +267,8 @@ function makeApp(authAddress, cdapConfig, uiSettings) {
       analyticsTag: cdapConfig['ui.analyticsTag'],
       googleTagManager: cdapConfig['ui.GTM'],
       cookieBannerText: cdapConfig['ui.cookieBannerText'],
-      cookieBannerLink: cdapConfig['ui.cookieBannerLink']
-
+      cookieBannerLink: cdapConfig['ui.cookieBannerLink'],
+      uiValidateTestids: cdapConfig['ui.validate.testids.enabled'] || false,
     });
 
     res.header({

--- a/ui-devtools/testid-yaml-loader/index.js
+++ b/ui-devtools/testid-yaml-loader/index.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const yml = require('js-yaml');
+const crypto = require('crypto');
+
+const topComment = `---
+# Keys in this file can contain only alphanumeric characters and underscore.
+#
+# Keys in this file are kept alphabetically sorted.
+# Sorting of the keys (if necessary) is done in the custom webpack loader.
+# Code of the custom loader is located at ui-devtools/testid-yaml-loader.
+#
+# Please do not modify this comment section at the top.
+# This section is added by the testid-yaml-loader.
+
+`;
+
+let cachedHash = '';
+
+module.exports = function(source) {
+  const filename = path.basename(this.resourcePath);
+  if (filename !== 'testids.yaml') {
+    return source;
+  }
+
+  this.cacheable();
+  const sourceHash = crypto
+    .createHash('sha256')
+    .update(source, 'utf8')
+    .digest('hex');
+
+  if (sourceHash === cachedHash) {
+    return source;
+  }
+
+  try {
+    const data = yml.load(source, {
+      filename,
+      onWarning: (warning) => {
+        this.emitWarning(warning.toString());
+      },
+    });
+    const sortedYaml = yml.dump(data, {
+      styles: {
+        '!!null': 'canonical',
+      },
+      sortKeys: true,
+    });
+
+    const sortedSource = `${topComment}${sortedYaml}`;
+    fs.writeFileSync(this.resourcePath, sortedSource);
+
+    cachedHash = crypto
+      .createHash('sha256')
+      .update(sortedSource, 'utf8')
+      .digest('hex');
+
+    return sortedSource;
+  } catch (err) {
+    this.emitError([
+      `Failed to validate and sort yaml from file: ${this.resourcePath} ! Message: ${err.message}`,
+      `Stack: \n`,
+      err.stack,
+    ]);
+
+    return source;
+  }
+};

--- a/webpack.config.cdap.dev.js
+++ b/webpack.config.cdap.dev.js
@@ -75,6 +75,7 @@ var plugins = [
     collections: true,
     caching: true,
     flattening: true,
+    paths: true,
   }),
   new CopyWebpackPlugin(
     [
@@ -125,6 +126,11 @@ var rules = [
   {
     test: /\.s?css$/,
     use: ['style-loader', 'css-loader', 'postcss-loader', 'sass-loader'],
+  },
+  {
+    enforce: 'pre',
+    test: /testids\.yaml$/,
+    loader: 'testid-yaml-loader',
   },
   {
     test: /\.ya?ml$/,
@@ -254,6 +260,11 @@ var webpackConfig = {
       lib: __dirname + '/app/lib',
       styles: __dirname + '/app/cdap/styles',
       'react-dom': '@hot-loader/react-dom',
+    },
+  },
+  resolveLoader: {
+    alias: {
+      'testid-yaml-loader': path.resolve(__dirname, 'ui-devtools/testid-yaml-loader/index.js'),
     },
   },
   devServer: {

--- a/webpack.config.cdap.js
+++ b/webpack.config.cdap.js
@@ -76,6 +76,7 @@ var plugins = [
     collections: true,
     caching: true,
     flattening: true,
+    paths: true,
   }),
   new CopyWebpackPlugin(
     [
@@ -131,6 +132,11 @@ var rules = [
   {
     test: /\.s?css$/,
     use: ['style-loader', 'css-loader', 'postcss-loader', 'sass-loader'],
+  },
+  {
+    enforce: 'pre',
+    test: /testids\.yaml$/,
+    loader: 'testid-yaml-loader',
   },
   {
     test: /\.ya?ml$/,
@@ -251,6 +257,11 @@ var webpackConfig = {
       api: __dirname + '/app/cdap/api',
       lib: __dirname + '/app/lib',
       styles: __dirname + '/app/cdap/styles',
+    },
+  },
+  resolveLoader: {
+    alias: {
+      'testid-yaml-loader': path.resolve(__dirname, 'ui-devtools/testid-yaml-loader/index.js'),
     },
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5674,6 +5674,11 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
 aria-query@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
@@ -14007,6 +14012,13 @@ js-yaml@^3.13.1, js-yaml@^3.8.3:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
 
 js-yaml@~3.7.0:
   version "3.7.0"


### PR DESCRIPTION
# Add support for managing data-testids in cdap-ui centrally

## Description
Currently data-testids for UI elements are hardcoded in multiple places. This makes it difficult to ensure that there are no collisions among the used data-testids. To improve the maintainability of the codebase it's better to have some mechanism to manage and constrin the addition of data-testids in the codebase.

In this PR we add a yaml file to keep track of the data-testids used, and organize them hierarchically. We also provide a helper function to use these listed data-testids, so that moving forward the developers do not have to resort to hardcoding them. We are also establishing a format/pattern for the data-testid values to be added in this codebase henceforth.

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [x] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20978](https://cdap.atlassian.net/browse/CDAP-20978)

## Test Plan
NA

## Screenshots
NA


[CDAP-20978]: https://cdap.atlassian.net/browse/CDAP-20978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ