### PR TITLE
Display unique xpaths for elements based on data-testids

### DIFF
--- a/ui-devtools/cdap-get-data-testid/index.html
+++ b/ui-devtools/cdap-get-data-testid/index.html
@@ -19,7 +19,7 @@
     <style type="text/css">
       body {
         width: 300px;
-        height: 150px;
+        height: 250px;
         padding: 10px;
         font-family: sans-serif;
       }
@@ -43,6 +43,16 @@
         margin-bottom: 8px;
       }
 
+      input[type="radio"] {
+        width: 32px;
+        vertical-align: middle;
+        margin: 2px 0;
+      }
+
+      label {
+        vertical-align: middle;
+      }
+
       button {
         padding: 8px 16px;
         color: white;
@@ -61,6 +71,12 @@
     </p>
     <p>Email missing <code>data-testid</code> alerts to:</p>
     <input type="text" placeholder="Comma separated email ids" id="email_input" />
+    <br/>
+    <p>Copyable tooltip for UI elements should contain:</p>
+    <input type="radio" name="popover_content_mode" id="data_testid_radio" />
+    <label for="data_testid_radio">data-testid</label><br/>
+    <input type="radio" name="popover_content_mode" id="xpath_radio" checked/>
+    <label for="xpath_radio">xpath</label><br/>
     <br/>
     <button id="save_button">Save</button>
 

--- a/ui-devtools/cdap-get-data-testid/popup.js
+++ b/ui-devtools/cdap-get-data-testid/popup.js
@@ -17,10 +17,26 @@
 const enableBtn = document.getElementById("enable_button");
 const saveBtn = document.getElementById("save_button");
 const emailInput = document.getElementById("email_input");
+const dataTestidRadio = document.getElementById("data_testid_radio");
+const xpathRadio = document.getElementById("xpath_radio");
 
 (async () => {
   const port = chrome.runtime.connect({ name: "cdap-get-data-testid" });
   port.postMessage({ action: 'get_state' });
+
+  function savePopoverContentMode(mode) {
+    port.postMessage({ action: 'set_popover_content_mode', mode });
+  }
+
+  xpathRadio.addEventListener('change', function (e) {
+    const isChecked = xpathRadio.checked;
+    if (isChecked) savePopoverContentMode('xpath');
+  });
+
+  dataTestidRadio.addEventListener('change', function (e) {
+    const isChecked = dataTestidRadio.checked;
+    if (isChecked) savePopoverContentMode('data_testid');
+  });
 
   saveBtn.addEventListener('click', async function() {
     const emailIds = emailInput.value;
@@ -36,7 +52,7 @@ const emailInput = document.getElementById("email_input");
   port.onMessage.addListener(function(msg) {
     switch (msg.action) {
       case 'state_change':
-        updateUiState(msg.active, msg.emailIds);
+        updateUiState(msg.active, msg.emailIds, msg.popoverContentMode);
         return;
 
       case 'saved_emails':
@@ -50,7 +66,7 @@ const emailInput = document.getElementById("email_input");
 })();
 
 
-function updateUiState(active, emailIds) {
+function updateUiState(active, emailIds, popoverContentMode) {
   if (active) {
     enableBtn.innerText = 'Disable';
     enableBtn.style.background = 'red';
@@ -60,6 +76,12 @@ function updateUiState(active, emailIds) {
   }
 
   emailInput.value = emailIds;
+
+  if (popoverContentMode === 'xpath') {
+    xpathRadio.checked = true;
+  } else {
+    dataTestidRadio.checked = true;
+  }
 }
 
 function blinkSaved() {


### PR DESCRIPTION
# Display unique xpaths for elements based on data-testids

## Description
In this PR we update the cdap-get-data-testid chrome extension to add support for looking up unique xpaths for locating UI elements.

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [x] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20976](https://cdap.atlassian.net/browse/CDAP-20976)

## Test Plan
NA

## Screenshots
To be added.



[CDAP-20976]: https://cdap.atlassian.net/browse/CDAP-20976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ