### PR TITLE
Add missing data-testids in control center page

### DIFF
--- a/app/cdap/components/EntityCard/FastActions/index.js
+++ b/app/cdap/components/EntityCard/FastActions/index.js
@@ -20,6 +20,9 @@ import React, { Component } from 'react';
 import FastAction from 'components/FastAction';
 import { objectQuery } from 'services/helpers';
 import isNil from 'lodash/isNil';
+import { getDataTestid } from '../../../testids/TestidsProvider';
+
+const TESTID_PREFIX = 'features.entityListView.entity.fastActions';
 
 export default class FastActions extends Component {
   constructor(props) {
@@ -86,6 +89,7 @@ export default class FastActions extends Component {
                     ? {}
                     : this.props.argsToActions[action]
                 }
+                dataTestId={getDataTestid(`${TESTID_PREFIX}.${action}`)}
               />
             );
           } else {
@@ -100,6 +104,7 @@ export default class FastActions extends Component {
                     ? {}
                     : this.props.argsToActions[action]
                 }
+                dataTestId={getDataTestid(`${TESTID_PREFIX}.${action}`)}
               />
             );
           }

--- a/app/cdap/components/EntityCard/index.js
+++ b/app/cdap/components/EntityCard/index.js
@@ -30,8 +30,10 @@ import isNil from 'lodash/isNil';
 import capitalize from 'lodash/capitalize';
 import { getCurrentNamespace } from 'services/NamespaceStore';
 import { objectQuery } from 'services/helpers';
-
 require('./EntityCard.scss');
+import { getDataTestid } from '../../testids/TestidsProvider';
+
+const TESTID_PREFIX = 'features.entityListView.entity';
 
 export default class EntityCard extends Component {
   constructor(props) {
@@ -126,6 +128,7 @@ export default class EntityCard extends Component {
             : `entity-cards-${this.props.entity.type}`
         }
         onClick={this.onClick.bind(this)}
+        dataTestId={getDataTestid(`${TESTID_PREFIX}.named`, this.props.entity.id)}
       >
         <div className="entity-information clearfix">
           <div

--- a/app/cdap/components/EntityListView/JustAddedSection/index.js
+++ b/app/cdap/components/EntityListView/JustAddedSection/index.js
@@ -34,6 +34,9 @@ import SearchStoreActions from 'components/EntityListView/SearchStore/SearchStor
 import { SCOPES } from 'services/global-constants';
 import { MyAppApi } from 'api/app';
 require('./JustAddedSection.scss');
+import { getDataTestid } from '../../../testids/TestidsProvider';
+
+const TESTID_PREFIX = 'features.entityListView.justAdded';
 
 export default class JustAddedSection extends Component {
   constructor(props) {
@@ -276,7 +279,9 @@ export default class JustAddedSection extends Component {
           <span>{T.translate('features.EntityListView.JustAddedSection.subtitle')}</span>
         </div>
 
-        <div className="just-added-entities-list">{content}</div>
+        <div className="just-added-entities-list" data-testid={getDataTestid(TESTID_PREFIX)}>
+          {content}
+        </div>
       </div>
     );
   }

--- a/app/cdap/components/EntityListView/ListView/index.js
+++ b/app/cdap/components/EntityListView/ListView/index.js
@@ -33,6 +33,9 @@ import {
 import isNil from 'lodash/isNil';
 import { getCurrentNamespace } from 'services/NamespaceStore';
 import { MyAppApi } from 'api/app';
+import { getDataTestid } from '../../../testids/TestidsProvider';
+
+const TESTID_PREFIX = 'features.entityListView';
 
 export default class HomeListView extends Component {
   constructor(props) {
@@ -237,7 +240,12 @@ export default class HomeListView extends Component {
           />
         )}
         <ListViewHeader />
-        <div className="entities-all-list-container">{content}</div>
+        <div
+          className="entities-all-list-container"
+          data-testid={getDataTestid(`${TESTID_PREFIX}.allEntities`)}
+        >
+          {content}
+        </div>
       </div>
     );
   }

--- a/app/cdap/components/FastAction/DeleteAction/index.js
+++ b/app/cdap/components/FastAction/DeleteAction/index.js
@@ -118,7 +118,12 @@ export default class DeleteAction extends Component {
 
     return (
       <span className="btn btn-secondary btn-sm">
-        <FastActionButton icon="icon-trash" action={this.toggleModal} id={tooltipID} />
+        <FastActionButton
+          icon="icon-trash"
+          action={this.toggleModal}
+          id={tooltipID}
+          dataTestId={this.props.dataTestId}
+        />
         <Tooltip
           placement="top"
           className="fast-action-tooltip"
@@ -159,4 +164,5 @@ DeleteAction.propTypes = {
     type: PropTypes.oneOf(['application', 'artifact', 'dataset']).isRequired,
   }),
   onSuccess: PropTypes.func,
+  dataTestId: PropTypes.string,
 };

--- a/app/cdap/components/FastAction/FastActionButton/index.js
+++ b/app/cdap/components/FastAction/FastActionButton/index.js
@@ -20,7 +20,7 @@ import React from 'react';
 import IconSVG from 'components/shared/IconSVG';
 import { preventPropagation } from 'services/helpers';
 
-export default function FastActionButton({ icon, action, disabled, id, iconClasses }) {
+export default function FastActionButton({ icon, action, disabled, id, iconClasses, dataTestId }) {
   let onButtonClick = (event) => {
     preventPropagation(event);
     action(event);
@@ -31,7 +31,12 @@ export default function FastActionButton({ icon, action, disabled, id, iconClass
     // have to create a wrapper, because disabled elements don't fire mouse events in Firefox
     // also set tooltip ID on this wrapper, so that the tooltip shows up even on a disabled button
     <span onClick={preventPropagation.bind(this)} id={id}>
-      <button className="btn btn-link" disabled={disabled} onClick={onButtonClick.bind(this)}>
+      <button
+        className="btn btn-link"
+        disabled={disabled}
+        onClick={onButtonClick.bind(this)}
+        data-testid={dataTestId}
+      >
         <IconSVG name={icon} className={iconClasses} />
       </button>
     </span>
@@ -44,4 +49,5 @@ FastActionButton.propTypes = {
   disabled: PropTypes.bool,
   id: PropTypes.string,
   iconClasses: PropTypes.string,
+  dataTestId: PropTypes.string,
 };

--- a/app/cdap/components/FastAction/FastActionLink/index.js
+++ b/app/cdap/components/FastAction/FastActionLink/index.js
@@ -18,9 +18,9 @@ import PropTypes from 'prop-types';
 
 import React from 'react';
 
-export default function FastActionLink({icon, link}) {
+export default function FastActionLink({ icon, link, dataTestId }) {
   return (
-    <a href={link} className="btn btn-link">
+    <a href={link} className="btn btn-link" data-testid={dataTestId}>
       <span className={icon}></span>
     </a>
   );
@@ -28,5 +28,6 @@ export default function FastActionLink({icon, link}) {
 
 FastActionLink.propTypes = {
   icon: PropTypes.string,
-  link: PropTypes.string
+  link: PropTypes.string,
+  dataTestId: PropTypes.string,
 };

--- a/app/cdap/components/FastAction/LogAction/index.js
+++ b/app/cdap/components/FastAction/LogAction/index.js
@@ -86,7 +86,7 @@ export default class LogAction extends Component {
     // have to do this because ID cannot start with a number
     const tooltipID = `logs-${this.props.entity.uniqueId}`;
     const renderDisabled = (
-      <button className="btn btn-link" disabled>
+      <button className="btn btn-link" disabled data-testid={this.props.dataTestId}>
         <IconSVG name="icon-file-text-o" />
       </button>
     );
@@ -94,7 +94,13 @@ export default class LogAction extends Component {
     const link = this.generateLink();
 
     const renderLog = (
-      <a href={link} target="_blank" className="btn btn-link" rel="noopener noreferrer">
+      <a
+        href={link}
+        target="_blank"
+        className="btn btn-link"
+        rel="noopener noreferrer"
+        data-testid={this.props.dataTestId}
+      >
         <IconSVG name="icon-file-text" />
       </a>
     );
@@ -128,4 +134,5 @@ LogAction.propTypes = {
     programType: PropTypes.string.isRequired,
     runId: PropTypes.string,
   }),
+  dataTestId: PropTypes.string,
 };

--- a/app/cdap/components/FastAction/SetPreferenceAction/index.js
+++ b/app/cdap/components/FastAction/SetPreferenceAction/index.js
@@ -95,6 +95,7 @@ export default class SetPreferenceAction extends Component {
           iconClasses={iconClasses}
           action={this.toggleModal}
           id={tooltipID}
+          dataTestId={this.props.dataTestId}
         />
         <Tooltip
           placement="top"
@@ -133,6 +134,7 @@ SetPreferenceAction.propTypes = {
   modalIsOpen: PropTypes.func,
   onSuccess: PropTypes.func,
   savedMessageState: PropTypes.bool,
+  dataTestId: PropTypes.string,
 };
 
 SetPreferenceAction.defaultProps = {

--- a/app/cdap/components/FastAction/StartStopAction/index.js
+++ b/app/cdap/components/FastAction/StartStopAction/index.js
@@ -186,6 +186,7 @@ export default class StartStopAction extends Component {
               iconClasses={iconClass}
               action={this.toggleModal}
               id={this.tooltipID}
+              dataTestId={this.props.dataTestId}
             />
             <Tooltip
               placement="top"
@@ -211,4 +212,5 @@ StartStopAction.propTypes = {
     programType: PropTypes.string.isRequired,
   }),
   onSuccess: PropTypes.func,
+  dataTestId: PropTypes.string,
 };

--- a/app/cdap/components/FastAction/TruncateAction/index.js
+++ b/app/cdap/components/FastAction/TruncateAction/index.js
@@ -119,6 +119,7 @@ export default class TruncateAction extends Component {
           action={this.toggleModal}
           id={tooltipID}
           iconClasses={classnames({ 'text-success': this.state.success })}
+          dataTestId={this.props.dataTestId}
         />
         <Tooltip
           placement="top"
@@ -158,4 +159,5 @@ TruncateAction.propTypes = {
     type: PropTypes.oneOf(['dataset']).isRequired,
   }),
   onSuccess: PropTypes.func,
+  dataTestId: PropTypes.string,
 };

--- a/app/cdap/components/FastAction/index.js
+++ b/app/cdap/components/FastAction/index.js
@@ -40,6 +40,7 @@ export default class FastAction extends Component {
             entity={this.props.entity}
             onSuccess={this.props.onSuccess}
             argsToAction={objectQuery(this.props.argsToAction)}
+            dataTestId={this.props.dataTestId}
           />
         );
       case 'truncate':
@@ -48,6 +49,7 @@ export default class FastAction extends Component {
             entity={this.props.entity}
             onSuccess={this.props.onSuccess}
             argsToAction={objectQuery(this.props.argsToAction)}
+            dataTestId={this.props.dataTestId}
           />
         );
       case 'startStop':
@@ -56,6 +58,7 @@ export default class FastAction extends Component {
             entity={this.props.entity}
             onSuccess={this.props.onSuccess}
             argsToAction={objectQuery(this.props.argsToAction)}
+            dataTestId={this.props.dataTestId}
           />
         );
       case 'setPreferences':
@@ -64,6 +67,7 @@ export default class FastAction extends Component {
             entity={this.props.entity}
             onSuccess={this.props.onSuccess}
             argsToAction={objectQuery(this.props.argsToAction)}
+            dataTestId={this.props.dataTestId}
           />
         );
       case 'log':
@@ -71,6 +75,7 @@ export default class FastAction extends Component {
           <LogAction
             entity={this.props.entity}
             argsToAction={objectQuery(this.props.argsToAction)}
+            dataTestId={this.props.dataTestId}
           />
         );
       default:
@@ -89,4 +94,5 @@ FastAction.propTypes = {
   onSuccess: PropTypes.func,
   opened: PropTypes.bool,
   argsToAction: PropTypes.object,
+  dataTestId: PropTypes.string,
 };

--- a/app/cdap/components/shared/Card/index.js
+++ b/app/cdap/components/shared/Card/index.js
@@ -101,6 +101,7 @@ export default class Card extends Component {
         onClick={this.onClickHandler.bind(this)}
         style={this.props.cardStyle}
         ref={(ref) => (this.container = ref)}
+        data-testid={this.props.dataTestId}
       >
         {this.getHeader()}
         {this.getBody()}
@@ -123,4 +124,5 @@ Card.propTypes = {
   cardStyle: PropTypes.object,
   onClick: PropTypes.func,
   id: PropTypes.string,
+  dataTestId: PropTypes.string,
 };


### PR DESCRIPTION
# Add missing data-testids in the control center page.

## Description
Add missing data-testids in the control center page as reported by the test team.

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [x] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20979](https://cdap.atlassian.net/browse/CDAP-20979)

## Test Plan
NA

## Screenshots
NA



[CDAP-20979]: https://cdap.atlassian.net/browse/CDAP-20979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ