### PR TITLE
[cherrypick] Add optional arg keep-strings for parse-xml-to-json directive

### DIFF
--- a/app/cdap/components/DataPrep/Directives/Parse/Modals/XmlToJsonModal.tsx
+++ b/app/cdap/components/DataPrep/Directives/Parse/Modals/XmlToJsonModal.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { useState, useEffect } from 'react';
+import T from 'i18n-react';
+import Mousetrap from 'mousetrap';
+import classnames from 'classnames';
+import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
+
+const PREFIX = 'features.DataPrep.Directives.Parse';
+
+interface IXmlToJsonProps {
+  toggle(): void;
+  onApply(configuration?: string): void;
+}
+
+export default function XmlToJsonModal({ toggle, onApply }: IXmlToJsonProps) {
+  const [depthValue, setDepthValue] = useState<number>(1);
+  const [keepStrings, setKeepStrings] = useState<boolean>(false);
+
+  useEffect(() => {
+    Mousetrap.bind('enter', handleApply);
+
+    return () => Mousetrap.reset();
+  }, []);
+
+  const parserTitle = T.translate(`${PREFIX}.Parsers.XMLTOJSON.label`);
+
+  function onDepthChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setDepthValue(parseInt(e.target.value, 10));
+  }
+
+  function toggleKeepStrings() {
+    setKeepStrings((val) => !val);
+  }
+
+  function handleApply() {
+    onApply(`${depthValue} ${keepStrings || ''}`.trim());
+  }
+
+  return (
+    <Modal
+      isOpen={true}
+      toggle={toggle}
+      size="md"
+      backdrop="static"
+      zIndex="1061"
+      className="dataprep-parse-modal cdap-modal"
+      autoFocus={false}
+    >
+      <ModalHeader>
+        <span>{T.translate(`${PREFIX}.modalTitle`, { parser: parserTitle })}</span>
+        <div className="close-section float-right" onClick={toggle}>
+          <span className="fa fa-times" />
+        </div>
+      </ModalHeader>
+
+      <ModalBody>
+        <div>
+          <label className="control-label">
+            {T.translate(`${PREFIX}.Parsers.XMLTOJSON.fieldLabel`)}
+          </label>
+          <input
+            type="number"
+            min={0}
+            className="form-control mousetrap"
+            placeholder={T.translate(`${PREFIX}.Parsers.XMLTOJSON.placeholder`).toString()}
+            value={depthValue}
+            onChange={onDepthChange}
+            autoFocus
+          />
+        </div>
+        <br />
+        <div className="optional-config">
+          <span onClick={toggleKeepStrings}>
+            <span
+              className={classnames('fa', {
+                'fa-square-o': !keepStrings,
+                'fa-check-square': keepStrings,
+              })}
+            />
+            <span>{T.translate(`${PREFIX}.Parsers.XMLTOJSON.keepStringsLabel`)}</span>
+          </span>
+        </div>
+      </ModalBody>
+
+      <ModalFooter>
+        <button className="btn btn-primary" onClick={handleApply}>
+          {T.translate('features.DataPrep.Directives.apply')}
+        </button>
+        <button className="btn btn-secondary" onClick={toggle}>
+          {T.translate('features.DataPrep.Directives.cancel')}
+        </button>
+      </ModalFooter>
+    </Modal>
+  );
+}

--- a/app/cdap/components/DataPrep/Directives/Parse/index.js
+++ b/app/cdap/components/DataPrep/Directives/Parse/index.js
@@ -17,17 +17,19 @@
 import PropTypes from 'prop-types';
 
 import React, { Component } from 'react';
+import T from 'i18n-react';
+import debounce from 'lodash/debounce';
 import classnames from 'classnames';
+
 import { execute } from 'components/DataPrep/store/DataPrepActionCreator';
 import SingleFieldModal from 'components/DataPrep/Directives/Parse/Modals/SingleFieldModal';
 import CSVModal from 'components/DataPrep/Directives/Parse/Modals/CSVModal';
 import LogModal from 'components/DataPrep/Directives/Parse/Modals/LogModal';
 import DateFormatModal from 'components/DataPrep/Directives/Parse/Modals/DateFormatModal';
 import ExcelModal from 'components/DataPrep/Directives/Parse/Modals/ExcelModal';
-import T from 'i18n-react';
+import XmlToJsonModal from 'components/DataPrep/Directives/Parse/Modals/XmlToJsonModal';
 import DataPrepStore from 'components/DataPrep/store';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
-import debounce from 'lodash/debounce';
 import { setPopoverOffset } from 'components/DataPrep/helper';
 
 const SUFFIX = 'features.DataPrep.Directives.Parse';
@@ -136,14 +138,13 @@ export default class ParseDirective extends Component {
   }
 
   renderSingleFieldModal() {
-    let isRequired = this.state.selectedParse === 'FIXEDLENGTH';
+    const isRequired = this.state.selectedParse === 'FIXEDLENGTH';
+    const hasOptionalField = this.state.selectedParse === 'FIXEDLENGTH';
 
     let defaultValue;
-    if (['JSON', 'XMLTOJSON'].indexOf(this.state.selectedParse) !== -1) {
+    if (this.state.selectedParse === 'JSON') {
       defaultValue = '1';
     }
-
-    let hasOptionalField = this.state.selectedParse === 'FIXEDLENGTH';
 
     return (
       <SingleFieldModal
@@ -162,6 +163,15 @@ export default class ParseDirective extends Component {
       <CSVModal
         toggle={this.selectParse.bind(this, null)}
         onApply={this.applyDirective.bind(this)}
+      />
+    );
+  }
+
+  renderXmlToJsonModal() {
+    return (
+      <XmlToJsonModal
+        toggle={this.selectParse.bind(this, null)}
+        onApply={this.applyDirective.bind(this, 'XMLTOJSON')}
       />
     );
   }
@@ -225,6 +235,8 @@ export default class ParseDirective extends Component {
       return this.renderDateTimeModal();
     } else if (this.state.selectedParse === 'EXCEL') {
       return this.renderExcelModal();
+    } else if (this.state.selectedParse === 'XMLTOJSON') {
+      return this.renderXmlToJsonModal();
     } else {
       return this.renderSingleFieldModal();
     }

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -1236,6 +1236,7 @@ features:
             fieldLabel: Depth
             label: XML to JSON
             placeholder: Enter depth
+            keepStringsLabel: Keep strings
         title: Parse
       SetCharEncoding:
         disabledTooltip: Character encoding can only be set on columns of data type 'bytes'


### PR DESCRIPTION
# cherrypick of #1177 

## Description
Adds support for the optional boolean field keep-strings in the parse-xml-to-json directive in Wrangler.


## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [x] Cherry Pick

## Links
Jira: [CDAP-20945](https://cdap.atlassian.net/browse/CDAP-20945)

## Test Plan
NA

## Screenshots
![image](https://github.com/cdapio/cdap-ui/assets/4161531/49af1147-9319-43fc-91e9-9db4b16205a2)



[CDAP-20945]: https://cdap.atlassian.net/browse/CDAP-20945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ