### PR TITLE
Operations Page of Data Fusion showing wrong states and times

### DIFF
--- a/app/cdap/components/Administration/AdminConfigTabContent/ReloadSystemArtifacts.js
+++ b/app/cdap/components/Administration/AdminConfigTabContent/ReloadSystemArtifacts.js
@@ -15,6 +15,7 @@
  */
 
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ConfirmationModal from 'components/shared/ConfirmationModal';
 import { MyArtifactApi } from 'api/artifact';
 import T from 'i18n-react';
@@ -28,6 +29,10 @@ export default class ReloadSystemArtifacts extends Component {
     loading: false,
     errorMessage: null,
     extendedMessage: null,
+  };
+
+  static propTypes = {
+    btnDataTestId: PropTypes.string,
   };
 
   onClick = () => {
@@ -65,7 +70,11 @@ export default class ReloadSystemArtifacts extends Component {
 
     return (
       <span>
-        <button className="btn btn-secondary" onClick={this.onClick}>
+        <button
+          className="btn btn-secondary"
+          onClick={this.onClick}
+          data-testid={this.props.btnDataTestId}
+        >
           {T.translate(`${PREFIX}.label`)}
         </button>
 

--- a/app/cdap/components/Administration/AdminConfigTabContent/SystemProfilesAccordion/index.js
+++ b/app/cdap/components/Administration/AdminConfigTabContent/SystemProfilesAccordion/index.js
@@ -28,10 +28,12 @@ import { Label, Input } from 'reactstrap';
 import { getProfiles, resetProfiles } from 'components/Cloud/Profiles/Store/ActionCreator';
 import { SYSTEM_NAMESPACE } from 'services/global-constants';
 import { Theme } from 'services/ThemeHelper';
+import { getDataTestid } from '../../../../testids/TestidsProvider';
 import If from 'components/shared/If';
 require('./SystemProfilesAccordion.scss');
 
 const PREFIX = 'features.Administration.Accordions.SystemProfiles';
+const TESTID_PREFIX = 'features.administration.configuration';
 
 class SystemProfilesAccordion extends Component {
   static propTypes = {
@@ -82,6 +84,7 @@ class SystemProfilesAccordion extends Component {
             <Link
               className="btn btn-secondary create-profile-button"
               to="/ns/system/profiles/create"
+              data-testid={getDataTestid(`${TESTID_PREFIX}.create-profile-btn`)}
             >
               {T.translate(`${PREFIX}.create`)}
             </Link>
@@ -109,6 +112,7 @@ class SystemProfilesAccordion extends Component {
         className={classnames('admin-config-container system-profiles-container', {
           expanded: this.props.expanded,
         })}
+        data-testid={getDataTestid(`${TESTID_PREFIX}.system-profiles-accordion`)}
       >
         {this.renderLabel()}
         {this.renderContent()}

--- a/app/cdap/components/Administration/AdminConfigTabContent/index.js
+++ b/app/cdap/components/Administration/AdminConfigTabContent/index.js
@@ -25,10 +25,12 @@ import { Link } from 'react-router-dom';
 import Helmet from 'react-helmet';
 import { Theme } from 'services/ThemeHelper';
 import T from 'i18n-react';
+import { getDataTestid } from '../../../testids/TestidsProvider';
 
 require('./AdminConfigTabContent.scss');
 
 const I18N_PREFIX = 'features.Administration.Configure';
+const TESTID_PREFIX = 'features.administration.configuration';
 
 export const ADMIN_CONFIG_ACCORDIONS = {
   namespaces: 'NAMESPACES',
@@ -88,8 +90,14 @@ export default class AdminConfigTabContent extends Component {
           })}
         />
         <div className="action-buttons">
-          <ReloadSystemArtifacts />
-          <Link to="/httpexecutor" className="btn btn-secondary">
+          <ReloadSystemArtifacts
+            btnDataTestId={getDataTestid(`${TESTID_PREFIX}.reload-sys-artifacts-btn`)}
+          />
+          <Link
+            to="/httpexecutor"
+            className="btn btn-secondary"
+            data-testid={getDataTestid(`${TESTID_PREFIX}.make-http-calls-btn`)}
+          >
             {T.translate(`${I18N_PREFIX}.buttons.MakeRESTCalls.label`)}
           </Link>
         </div>

--- a/app/cdap/components/Administration/AdminTabSwitch/index.tsx
+++ b/app/cdap/components/Administration/AdminTabSwitch/index.tsx
@@ -25,9 +25,11 @@ import isNil from 'lodash/isNil';
 import classnames from 'classnames';
 import T from 'i18n-react';
 import { Theme } from 'services/ThemeHelper';
+import { getDataTestid } from '../../../testids/TestidsProvider';
 require('./AdminTabSwitch.scss');
 
 const PREFIX = 'features.Administration';
+const TESTID_PREFIX = 'features.administration';
 const TAB_LABELS = {
   MANAGEMENT: 'management',
   CONFIGURATION: 'configuration',
@@ -73,17 +75,29 @@ export default class AdminTabSwitch extends React.PureComponent<IAdminTabSwitchP
     return (
       <span className="tab-title">
         <h5 className={classnames({ active: activeTab === MANAGEMENT })}>
-          <Link to="/administration">{T.translate(`${PREFIX}.Tabs.management`)}</Link>
+          <Link to="/administration" data-testid={getDataTestid(`${TESTID_PREFIX}.management.tab`)}>
+            {T.translate(`${PREFIX}.Tabs.management`)}
+          </Link>
         </h5>
         <span className="divider"> | </span>
         <h5 className={classnames({ active: activeTab === CONFIGURATION })}>
-          <Link to="/administration/configuration">{T.translate(`${PREFIX}.Tabs.config`)}</Link>
+          <Link
+            to="/administration/configuration"
+            data-testid={getDataTestid(`${TESTID_PREFIX}.configuration.tab`)}
+          >
+            {T.translate(`${PREFIX}.Tabs.config`)}
+          </Link>
         </h5>
         {Theme.tethering && (
           <>
             <span className="divider"> | </span>
             <h5 className={classnames({ active: activeTab === TETHERING })}>
-              <Link to="/administration/tethering">{T.translate(`${PREFIX}.Tabs.tethering`)}</Link>
+              <Link
+                to="/administration/tethering"
+                data-testid={getDataTestid(`${TESTID_PREFIX}.tethering.tab`)}
+              >
+                {T.translate(`${PREFIX}.Tabs.tethering`)}
+              </Link>
             </h5>
           </>
         )}

--- a/app/cdap/components/Operations/index.tsx
+++ b/app/cdap/components/Operations/index.tsx
@@ -158,7 +158,7 @@ const OperationsView: React.FC<WithStyles<typeof styles>> = ({ classes }) => {
         </div>
         <div>Last updated {humanReadableDate(data.lastUpdated, true)}</div>
       </div>
-      <JobsTable data={data} />
+      <JobsTable data={data} isCurrentTimeFrame={isNextDisabled()} />
     </div>
   );
 };

--- a/app/cdap/testids/testids.yaml
+++ b/app/cdap/testids/testids.yaml
@@ -9,6 +9,17 @@
 # This section is added by the testid-yaml-loader.
 
 features:
+  administration:
+    configuration:
+      create-profile-btn: ~
+      make-http-calls-btn: ~
+      reload-sys-artifacts-btn: ~
+      system-profiles-accordion: ~
+      tab: ~
+    management:
+      tab: ~
+    tethering:
+      tab: ~
   entityListView:
     allEntities: ~
     entity:


### PR DESCRIPTION
# Operations Page of Data Fusion showing wrong states and times

## Description
* For current time range, show the pipelines in all states (running / terminated states)
* For previous time ranges, only show the pipeline runs in the terminated states (completed, stopped, killed, etc)
* Changed the status column to show icon & status text which is similar to the same in pipelines list UI.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20844](https://cdap.atlassian.net/browse/CDAP-20844)

## Test Plan
n/a

## Screenshots
<img width="700" height="400" alt="image" src="https://github.com/cdapio/cdap-ui/assets/107839049/c6287f3f-cb72-4664-a86a-eceead6c6f77">




[CDAP-20844]: https://cdap.atlassian.net/browse/CDAP-20844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ