### PR TITLE
[CDAP-20917] Sync status UI changes

### DIFF
--- a/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsMetadata.tsx
+++ b/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsMetadata.tsx
@@ -18,7 +18,7 @@ import React, { useEffect } from 'react';
 import { connect, Provider } from 'react-redux';
 import T from 'i18n-react';
 import styled from 'styled-components';
-import { green, red } from '@material-ui/core/colors';
+import { green, orange } from '@material-ui/core/colors';
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import ErrorIcon from '@material-ui/icons/Error';
 
@@ -30,6 +30,7 @@ import { GLOBALS } from 'services/global-constants';
 import { Chip } from '@material-ui/core';
 import { useFeatureFlagDefaultFalse } from 'services/react/customHooks/useFeatureFlag';
 import { getScmSyncStatus } from '../store/ActionCreator';
+import moment from 'moment';
 
 const PREFIX = 'features.PipelineDetails.TopPanel';
 const SCM_PREFIX = 'features.SourceControlManagement';
@@ -80,7 +81,7 @@ interface IPipelineDetailsMetadata {
   };
   scmSyncStatus?: {
     isSynced?: boolean;
-    lastModified?: number;
+    lastSyncedAt?: number;
   };
 }
 
@@ -136,19 +137,33 @@ const PipelineDetailsMetadata = ({
             </Popover>
           </StyledSpan>
         )}
-        {scmMultiSyncEnabled && (
+        {scmMultiSyncEnabled && scmSyncStatus && (
           <StyledSpan>
             {scmSyncStatus.isSynced ? (
               <StyledChip
                 variant="outlined"
                 label={T.translate(`${SCM_PREFIX}.table.gitSyncStatusSynced`)}
                 icon={<CheckCircleIcon style={{ color: green[500] }} fontSize="small" />}
+                title={
+                  scmSyncStatus.lastSyncedAt
+                    ? T.translate(`${SCM_PREFIX}.table.lastSyncedAtRelative`, {
+                        diff: moment(scmSyncStatus.lastSyncedAt).fromNow(true),
+                      })
+                    : undefined
+                }
               />
             ) : (
               <StyledChip
                 variant="outlined"
                 label={T.translate(`${SCM_PREFIX}.table.gitSyncStatusUnsynced`)}
-                icon={<ErrorIcon style={{ color: red[500] }} fontSize="small" />}
+                icon={<ErrorIcon style={{ color: orange[300] }} fontSize="small" />}
+                title={
+                  scmSyncStatus.lastSyncedAt
+                    ? T.translate(`${SCM_PREFIX}.table.lastSyncedAtRelative`, {
+                        diff: moment(scmSyncStatus.lastSyncedAt).fromNow(true),
+                      })
+                    : undefined
+                }
               />
             )}
             <Popover

--- a/app/cdap/components/PipelineDetails/store/ActionCreator.js
+++ b/app/cdap/components/PipelineDetails/store/ActionCreator.js
@@ -494,12 +494,21 @@ const getScmSyncStatus = (appId) => {
   MyPipelineApi.getScmSyncStatus({
     namespace,
     appId,
-  }).subscribe((res) => {
-    PipelineDetailStore.dispatch({
-      type: ACTIONS.SET_SCM_SYNC_STATUS,
-      payload: res,
-    });
-  });
+  }).subscribe(
+    (res) => {
+      PipelineDetailStore.dispatch({
+        type: ACTIONS.SET_SCM_SYNC_STATUS,
+        payload: res,
+      });
+    },
+    // eslint-disable-next-line no-unused-vars
+    (err) => {
+      PipelineDetailStore.dispatch({
+        type: ACTIONS.SET_SCM_SYNC_STATUS,
+        payload: null,
+      });
+    }
+  );
 };
 
 const reset = () => {

--- a/app/cdap/components/PipelineDetails/store/index.js
+++ b/app/cdap/components/PipelineDetails/store/index.js
@@ -106,7 +106,8 @@ const DEFAULT_PIPELINE_DETAILS = {
   sourceControlMeta: null,
   pullLoading: false,
   pullStatus: null,
-  scmSyncStatus: {},
+  scmSyncStatus: null,
+  scmSyncStatusRefreshTime: null,
 };
 
 const pipelineDetails = (state = DEFAULT_PIPELINE_DETAILS, action = defaultAction) => {
@@ -289,7 +290,8 @@ const pipelineDetails = (state = DEFAULT_PIPELINE_DETAILS, action = defaultActio
     case ACTIONS.SET_SCM_SYNC_STATUS:
       return {
         ...state,
-        scmSyncStatus: action.payload,
+        scmSyncStatus: action.payload ? action.payload.app : null,
+        scmSyncStatusRefreshTime: action.payload ? action.payload.lastRefreshTime : null,
       };
     case ACTIONS.RESET:
       return DEFAULT_PIPELINE_DETAILS;

--- a/app/cdap/components/SourceControlManagement/LocalPipelineListView/PipelineTable.tsx
+++ b/app/cdap/components/SourceControlManagement/LocalPipelineListView/PipelineTable.tsx
@@ -27,7 +27,7 @@ import {
   TableSortLabel,
 } from '@material-ui/core';
 import InfoIcon from '@material-ui/icons/Info';
-import { green, red } from '@material-ui/core/colors';
+import { green, orange } from '@material-ui/core/colors';
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import ErrorIcon from '@material-ui/icons/Error';
 
@@ -267,7 +267,7 @@ export const LocalPipelineTable = ({
                         </SyncStatusWrapper>
                       ) : (
                         <SyncStatusWrapper>
-                          <ErrorIcon style={{ color: red[500] }} />
+                          <ErrorIcon style={{ color: orange[300] }} />
                           {T.translate(`${PREFIX}.gitSyncStatusUnsynced`)}
                         </SyncStatusWrapper>
                       )}

--- a/app/cdap/components/SourceControlManagement/RemotePipelineListView/RemotePipelineTable.tsx
+++ b/app/cdap/components/SourceControlManagement/RemotePipelineListView/RemotePipelineTable.tsx
@@ -28,7 +28,7 @@ import {
   TableRow,
 } from '@material-ui/core';
 import TableSortLabel from '@material-ui/core/TableSortLabel';
-import { green, red } from '@material-ui/core/colors';
+import { green, orange } from '@material-ui/core/colors';
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import ErrorIcon from '@material-ui/icons/Error';
 import StatusButton from 'components/StatusButton';
@@ -255,7 +255,7 @@ export const RemotePipelineTable = ({
                         </SyncStatusWrapper>
                       ) : (
                         <SyncStatusWrapper>
-                          <ErrorIcon style={{ color: red[500] }} />
+                          <ErrorIcon style={{ color: orange[300] }} />
                           {T.translate(`${PREFIX}.gitSyncStatusUnsynced`)}
                         </SyncStatusWrapper>
                       )}

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -3292,7 +3292,7 @@ features:
       gitStatus: Connected to Git
       syncStatus: Sync status
       gitStatusHelperText: This status indicates that the pipeline has been pushed to or pulled from the git repository in the past. It does not necessarily mean the content is up to date.
-      syncStatusHelperText: This status indicates whether the pipeline is in sync with the linked remote repository. 
+      syncStatusHelperText: Indicates the sync status with linked remote repository 
       pullFail: Failed to pull this pipeline from remote.
       pushFail: Failed to push this pipeline to remote.
       synced: Synced
@@ -3302,6 +3302,7 @@ features:
       gitSyncStatusUnsynced: Unsynced
       serverSidePaginationLabel: "Results {from} - {to}"
       lastRefreshedAtLabel: Last refreshed at {datetime}
+      lastSyncedAtRelative: Last synced {diff} ago
     syncButton: Sync Pipelines
     title: Source Control Management
     unlinkButton: Unlink Repository


### PR DESCRIPTION
# Sync Status UI changes

## Description

The following changes are added:
1. If `GET apps/{app-id}/sourceconrol` API returns 404, do not display the sync status chip
2. The `unsynced` status chip is orange in color (like a warning), not red
3. Last sync time added in the tooltip for the sync status chip

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-20917](https://cdap.atlassian.net/browse/CDAP-20917)

## Test Plan
NA

## Screenshots
<img width="1512" alt="Screenshot 2024-05-07 at 12 57 46 PM" src="https://github.com/cdapio/cdap-ui/assets/4161531/a55366bd-a151-4ce2-b641-55790ab57005">




[CDAP-20917]: https://cdap.atlassian.net/browse/CDAP-20917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ