### PR TITLE
Restrict running of github CI jobs without approval

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,11 @@
 name: Build with Unit and Integration Tests
 
 on:
-  workflow_run:
-    workflows:
-      - Trigger build
-    types:
-      - completed
+  push:
+    branches: [ develop, release/** ]
+  pull_request:
+    branches: [ develop, release/** ]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
     inputs:
       branch:
@@ -36,11 +36,8 @@ jobs:
 
     steps:
     # Pinned 1.0.0 version
-    - uses: marocchino/action-workflow_run-status@54b6e87d6cb552fc5f36dbe9a722a6048725917a
-      if: github.event_name != 'workflow_dispatch'
     - uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.workflow_run.head_sha }}
         submodules: recursive
 
     # installing node 16.16


### PR DESCRIPTION
# TITLE
Restrict running of github CI jobs without approval for PRs not raised by members.

## Description

Automatic execution of the CI job must be gated; the PR to be reviewed by the members manually and started manually.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [Jira issue #](fill-in.org)

## Test Plan

## Screenshots


