### PR TITLE
[CDAP-17849]: Add indicator for nullable checkbox for schema editor

### DIFF
--- a/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/Nullable.tsx
+++ b/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/Nullable.tsx
@@ -18,6 +18,7 @@ import * as React from 'react';
 import CheckBox from '@material-ui/core/Checkbox';
 import CheckBoxIcon from '@material-ui/icons/CheckBox';
 import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
+import T from 'i18n-react';
 
 interface INullableBaseProps {
   nullable: boolean;
@@ -37,6 +38,7 @@ const NullableBase = ({ nullable, onNullable: onChange }: INullableBaseProps) =>
       }}
       disabled={typeof onChange !== 'function'}
       data-testid="schema-field-nullable-checkbox"
+      title={T.translate('features.SchemaEditor.Tooltips.nullableCheckbox').toString()}
     />
   );
 };

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -3175,6 +3175,8 @@ features:
     Labels:
       fieldName: Field name
       symbolName: Symbol name
+    Tooltips:
+      nullableCheckbox: Select to make the column nullable
   ServiceEnableUtility:
     serviceNotFound: Cannot find {artifactName} artifact
   ServiceAccounts:


### PR DESCRIPTION
# Add indicator for nullable checkbox for schema editor

## Description
 Add indicator for nullable checkbox for schema editor, added tooltip for checkbox
  - 'Select to make the column nullable'
  
## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [x] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-17849](https://cdap.atlassian.net/browse/CDAP-17849)

## Test Plan

## Screenshots

<img width="650" alt="image" src="https://github.com/cdapio/cdap-ui/assets/107839049/1233496f-08c4-43a1-8ecd-1a6e36eabeac">


[CDAP-17849]: https://cdap.atlassian.net/browse/CDAP-17849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ