### PR TITLE
[e2e-tests] fix flaky step to close top banner in studio

### DIFF
--- a/src/e2e-test/java/io/cdap/cdap/ui/utils/Commands.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/utils/Commands.java
@@ -354,8 +354,10 @@ public class Commands implements CdfHelper {
 
   public static void dismissTopBanner() {
     try {
-      ElementHelper.clickOnElement(Helper.locateElementByXPath(
-          "//div[@data-testid='valium-banner-hydrator']//button[@class='close ng-scope']"));
+      WebElement bannerCloseButton = Helper.locateElementByXPath(
+          "//div[@data-testid='valium-banner-hydrator']//button[@class='close ng-scope']");
+      WaitHelper.waitForElementToBeClickable(bannerCloseButton);
+      ElementHelper.clickOnElement(bannerCloseButton);
     } catch (NoSuchElementException e) {
       // pass
     }


### PR DESCRIPTION
# Fix flaky step in e2e tests

## Description
The method to dismiss top banner in studio (in e2e tests) needs to wait for the close button to be clickable before clicking it.


## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [x] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: NA

## Test Plan
The existing e2e-tests should pass.

## Screenshots
NA

