### PR TITLE
Show tooltip for pipeline runs based on  `app.run.records.ttl.days` configuration

### DIFF
--- a/app/cdap/components/PipelineDetails/RunLevelInfo/CurrentRunIndex.tsx
+++ b/app/cdap/components/PipelineDetails/RunLevelInfo/CurrentRunIndex.tsx
@@ -86,6 +86,8 @@ const CurrentRunIndex = ({
     runsCount - (runs.length - currentRunIndex)
   );
 
+  const runLimit = Number(window.CDAP_CONFIG.cdap.runRecordsTtl) || 0;
+
   const pipelineLink = getHydratorUrl({
     stateName: 'hydrator.detail',
     stateParams: {
@@ -192,7 +194,16 @@ const CurrentRunIndex = ({
 
   return (
     <div className="run-number-container run-info-container">
-      <h4 className="run-number">
+      <h4
+        className="run-number"
+        title={
+          runLimit > 0
+            ? T.translate(`${PREFIX}.tooltipRunLimit`, {
+                runLimit,
+              }).toString()
+            : ''
+        }
+      >
         {T.translate(`${PREFIX}.currentRunIndex`, {
           currentRunIndex: runIndexInTotalRunsCount + 1,
           numRuns: runsCount,

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -2505,6 +2505,7 @@ features:
         noInfo: Profile information unavailable
       runsCurrentlyRunning: Runs currently running - select one to view
       status: Status
+      tooltipRunLimit: Pipeline runs for only the last {runLimit} days are displayed
       warnings: Warnings
     startTime: Start time
     TopPanel:

--- a/server/express.js
+++ b/server/express.js
@@ -257,6 +257,7 @@ function makeApp(authAddress, cdapConfig, uiSettings) {
         hstsMaxAge: cdapConfig['hsts.max.age'],
         hstsIncludeSubDomains: cdapConfig['hsts.include.sub.domains'],
         hstsPreload: cdapConfig['hsts.preload'],
+        runRecordsTtl: cdapConfig['app.run.records.ttl.days'],
       },
       hydrator: {
         previewEnabled: cdapConfig['enable.preview'] === 'true',


### PR DESCRIPTION
# Show tooltip for pipeline runs when run.records.ttl is present.

## Description
* TTL days is returned by param `app.run.records.ttl.days` present in cConf. Here value 0 means run record cleanup service is inactive.
* Storing the property under **cdapConfig** as `runRecordsTtl` for use on other pages to display the tooltip: **Pipeline runs for only the last {runLimit} days are displayed**. - The value of `runLimit` is filled from `cdapConfig.runRecordsTtl.`
* If property is not available or it's value is `0`, then no tooltip is shown.

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [x] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-21055](https://cdap.atlassian.net/browse/CDAP-21055)

## Test Plan
n/a

## Screenshots
![image](https://github.com/user-attachments/assets/5fc4e256-99b1-4b77-9f3b-06c02fa02b7a)




[CDAP-21055]: https://cdap.atlassian.net/browse/CDAP-21055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ