### PR TITLE
Cherry pick PR #1236 to release 6.10: Show tooltip for pipeline runs when run.records.ttl is present.

### DIFF
--- a/app/cdap/components/PipelineDetails/RunLevelInfo/CurrentRunIndex.tsx
+++ b/app/cdap/components/PipelineDetails/RunLevelInfo/CurrentRunIndex.tsx
@@ -86,6 +86,8 @@ const CurrentRunIndex = ({
     runsCount - (runs.length - currentRunIndex)
   );
 
+  const runLimit = Number(window.CDAP_CONFIG.cdap.runRecordsTtl) || 0;
+
   const pipelineLink = getHydratorUrl({
     stateName: 'hydrator.detail',
     stateParams: {
@@ -192,7 +194,16 @@ const CurrentRunIndex = ({
 
   return (
     <div className="run-number-container run-info-container">
-      <h4 className="run-number">
+      <h4
+        className="run-number"
+        title={
+          runLimit > 0
+            ? T.translate(`${PREFIX}.tooltipRunLimit`, {
+                runLimit,
+              }).toString()
+            : ''
+        }
+      >
         {T.translate(`${PREFIX}.currentRunIndex`, {
           currentRunIndex: runIndexInTotalRunsCount + 1,
           numRuns: runsCount,

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -2501,6 +2501,7 @@ features:
         noInfo: Profile information unavailable
       runsCurrentlyRunning: Runs currently running - select one to view
       status: Status
+      tooltipRunLimit: Pipeline runs for only the last {runLimit} days are displayed
       warnings: Warnings
     startTime: Start time
     TopPanel:

--- a/server/express.js
+++ b/server/express.js
@@ -257,6 +257,7 @@ function makeApp(authAddress, cdapConfig, uiSettings) {
         hstsMaxAge: cdapConfig['hsts.max.age'],
         hstsIncludeSubDomains: cdapConfig['hsts.include.sub.domains'],
         hstsPreload: cdapConfig['hsts.preload'],
+        runRecordsTtl: cdapConfig['app.run.records.ttl.days'],
       },
       hydrator: {
         previewEnabled: cdapConfig['enable.preview'] === 'true',


### PR DESCRIPTION
# Cherry pick PR #1236 to release 6.10: Show tooltip for pipeline runs when run.records.ttl is present.

## Description
Refer  PR #1236 

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [x] Cherry Pick

## Links
Jira: [CDAP-21055](https://cdap.atlassian.net/browse/CDAP-21055)

## Test Plan
n/a

## Screenshots
Refer  PR #1236 




[CDAP-21055]: https://cdap.atlassian.net/browse/CDAP-21055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ