### PR TITLE
add testids in wrangler part-2

### DIFF
--- a/app/cdap/components/Administration/AdminConfigTabContent/SystemProfilesAccordion/index.js
+++ b/app/cdap/components/Administration/AdminConfigTabContent/SystemProfilesAccordion/index.js
@@ -28,7 +28,7 @@ import { Label, Input } from 'reactstrap';
 import { getProfiles, resetProfiles } from 'components/Cloud/Profiles/Store/ActionCreator';
 import { SYSTEM_NAMESPACE } from 'services/global-constants';
 import { Theme } from 'services/ThemeHelper';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 import If from 'components/shared/If';
 require('./SystemProfilesAccordion.scss');
 

--- a/app/cdap/components/Administration/AdminConfigTabContent/index.js
+++ b/app/cdap/components/Administration/AdminConfigTabContent/index.js
@@ -25,7 +25,7 @@ import { Link } from 'react-router-dom';
 import Helmet from 'react-helmet';
 import { Theme } from 'services/ThemeHelper';
 import T from 'i18n-react';
-import { getDataTestid } from '../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 require('./AdminConfigTabContent.scss');
 

--- a/app/cdap/components/Administration/AdminTabSwitch/index.tsx
+++ b/app/cdap/components/Administration/AdminTabSwitch/index.tsx
@@ -25,7 +25,7 @@ import isNil from 'lodash/isNil';
 import classnames from 'classnames';
 import T from 'i18n-react';
 import { Theme } from 'services/ThemeHelper';
-import { getDataTestid } from '../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 require('./AdminTabSwitch.scss');
 
 const PREFIX = 'features.Administration';

--- a/app/cdap/components/DataPrep/AutoComplete/index.js
+++ b/app/cdap/components/DataPrep/AutoComplete/index.js
@@ -26,7 +26,7 @@ import classnames from 'classnames';
 import NamespaceStore from 'services/NamespaceStore';
 import ee from 'event-emitter';
 import globalEvents from 'services/global-events';
-import { getDataTestid } from '../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 require('./AutoComplete.scss');
 

--- a/app/cdap/components/DataPrep/ColumnActionsDropdown/index.js
+++ b/app/cdap/components/DataPrep/ColumnActionsDropdown/index.js
@@ -27,7 +27,7 @@ import isEqual from 'lodash/isEqual';
 import DataPrepStore from 'components/DataPrep/store';
 import ScrollableList from 'components/shared/ScrollableList';
 import { Theme } from 'services/ThemeHelper';
-import { getDataTestid } from '../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 // Directives List
 import ParseDirective from 'components/DataPrep/Directives/Parse';

--- a/app/cdap/components/DataPrep/ColumnTextSelection/index.js
+++ b/app/cdap/components/DataPrep/ColumnTextSelection/index.js
@@ -22,9 +22,12 @@ import classnames from 'classnames';
 import uuidV4 from 'uuid/v4';
 import { Observable } from 'rxjs/Observable';
 import intersection from 'lodash/intersection';
+import { getDataTestid } from '../../../testids/TestidsProvider';
 
 require('../DataPrepTable/DataPrepTable.scss');
+
 const CELLHIGHLIGHTCLASSNAME = 'cl-highlight';
+const TESTID_PREFIX = 'features.dataprep.columnTextSelection';
 
 export default class ColumnTextSelection extends Component {
   constructor(props) {
@@ -137,10 +140,14 @@ export default class ColumnTextSelection extends Component {
     let { data, headers } = DataPrepStore.getState().dataprep;
     let column = this.props.columns[0];
 
-    const renderTableCell = (row, index, head, highlightColumn) => {
+    const renderTableCell = (row, index, head, highlightColumn, colIndex) => {
       if (head !== highlightColumn) {
         return (
-          <td key={uuidV4()} className="gray-out">
+          <td
+            key={uuidV4()}
+            className="gray-out"
+            data-testid={getDataTestid(`${TESTID_PREFIX}.cell`, `${index}-${colIndex}`)}
+          >
             <div>{row[head]}</div>
           </td>
         );
@@ -151,6 +158,7 @@ export default class ColumnTextSelection extends Component {
           className={CELLHIGHLIGHTCLASSNAME}
           onMouseDown={this.mouseDownHandler}
           onMouseUp={this.mouseUpHandler.bind(this, head, index)}
+          data-testid={getDataTestid(`${TESTID_PREFIX}.cell`, `${index}-${colIndex}`)}
         >
           <div className={CELLHIGHLIGHTCLASSNAME}>
             {index === this.state.textSelectionRange.index ? (
@@ -174,14 +182,22 @@ export default class ColumnTextSelection extends Component {
     const renderTableHeader = (head, index) => {
       if (head !== column) {
         return (
-          <th key={index} className="gray-out">
+          <th
+            key={index}
+            className="gray-out"
+            data-testid={getDataTestid(`${TESTID_PREFIX}.header`, index)}
+          >
             <div>{head}</div>
           </th>
         );
       }
 
       return (
-        <th key={index} id="highlighted-header">
+        <th
+          key={index}
+          id="highlighted-header"
+          data-testid={getDataTestid(`${TESTID_PREFIX}.header`, index)}
+        >
           <div>{head}</div>
         </th>
       );
@@ -198,6 +214,7 @@ export default class ColumnTextSelection extends Component {
                   className={classnames({
                     'highlight-column': head === column,
                   })}
+                  data-testid={getDataTestid(`${TESTID_PREFIX}.column`, i)}
                 />
               );
             })}
@@ -215,8 +232,8 @@ export default class ColumnTextSelection extends Component {
               return (
                 <tr key={i}>
                   <td>{i}</td>
-                  {headers.map((head) => {
-                    return renderTableCell(row, i, head, column);
+                  {headers.map((head, j) => {
+                    return renderTableCell(row, i, head, column, j);
                   })}
                 </tr>
               );

--- a/app/cdap/components/DataPrep/ColumnTextSelection/index.js
+++ b/app/cdap/components/DataPrep/ColumnTextSelection/index.js
@@ -22,7 +22,7 @@ import classnames from 'classnames';
 import uuidV4 from 'uuid/v4';
 import { Observable } from 'rxjs/Observable';
 import intersection from 'lodash/intersection';
-import { getDataTestid } from '../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 require('../DataPrepTable/DataPrepTable.scss');
 

--- a/app/cdap/components/DataPrep/DataPrepCLI/index.js
+++ b/app/cdap/components/DataPrep/DataPrepCLI/index.js
@@ -20,7 +20,7 @@ import DataPrepAutoComplete from 'components/DataPrep/AutoComplete';
 import { execute } from 'components/DataPrep/store/DataPrepActionCreator';
 import DataPrepStore from 'components/DataPrep/store';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
-import { getDataTestid } from '../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 require('./DataPrepCLI.scss');
 
 const TESTID_PREFIX = 'features.dataprep.workspace.cli';

--- a/app/cdap/components/DataPrep/DataPrepContentWrapper/index.js
+++ b/app/cdap/components/DataPrep/DataPrepContentWrapper/index.js
@@ -29,7 +29,7 @@ import LoadingSVGCentered from 'components/shared/LoadingSVGCentered';
 import DataPrepSidePanel from 'components/DataPrep/DataPrepSidePanel';
 import classnames from 'classnames';
 import T from 'i18n-react';
-import { getDataTestid } from '../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 require('./DataPrepContentWrapper.scss');
 
 const DataPrepVisualization = Loadable({

--- a/app/cdap/components/DataPrep/DataPrepSidePanel/ColumnsTab/ColumnsTabDetail.js
+++ b/app/cdap/components/DataPrep/DataPrepSidePanel/ColumnsTab/ColumnsTabDetail.js
@@ -18,7 +18,7 @@ import PropTypes from 'prop-types';
 
 import React from 'react';
 import T from 'i18n-react';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 const PREFIX = 'features.DataPrep.DataPrepSidePanel.ColumnsTab.ColumnDetail';
 const TESTID_PREFIX = 'features.dataprep.workspace.columnsPanel.list.column';

--- a/app/cdap/components/DataPrep/DataPrepSidePanel/ColumnsTab/ColumnsTabRow.js
+++ b/app/cdap/components/DataPrep/DataPrepSidePanel/ColumnsTab/ColumnsTabRow.js
@@ -21,7 +21,7 @@ import { preventPropagation } from 'services/helpers';
 import isEqual from 'lodash/isEqual';
 import classnames from 'classnames';
 import { CSSTransition } from 'react-transition-group';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 const TESTID_PREFIX = 'features.dataprep.workspace.columnsPanel.list.column';
 

--- a/app/cdap/components/DataPrep/DataPrepSidePanel/ColumnsTab/index.js
+++ b/app/cdap/components/DataPrep/DataPrepSidePanel/ColumnsTab/index.js
@@ -26,7 +26,7 @@ import findIndex from 'lodash/findIndex';
 import T from 'i18n-react';
 import ColumnActions from 'components/DataPrep/Directives/ColumnActions';
 import IconSVG from 'components/shared/IconSVG';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 const PREFIX = 'features.DataPrep.DataPrepSidePanel.ColumnsTab';
 const TESTID_PREFIX = 'features.dataprep.workspace.columnsPanel';

--- a/app/cdap/components/DataPrep/DataPrepSidePanel/DirectivesTab/index.js
+++ b/app/cdap/components/DataPrep/DataPrepSidePanel/DirectivesTab/index.js
@@ -21,7 +21,7 @@ import DirectivesTabRow from 'components/DataPrep/DataPrepSidePanel/DirectivesTa
 import fileDownload from 'js-file-download';
 import { execute } from 'components/DataPrep/store/DataPrepActionCreator';
 import T from 'i18n-react';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 require('./DirectivesTab.scss');
 

--- a/app/cdap/components/DataPrep/DataPrepSidePanel/index.js
+++ b/app/cdap/components/DataPrep/DataPrepSidePanel/index.js
@@ -23,7 +23,7 @@ import TargetTab from 'components/DataPrep/DataPrepSidePanel/TargetTab';
 import DirectivesTab from 'components/DataPrep/DataPrepSidePanel/DirectivesTab';
 import T from 'i18n-react';
 import If from 'components/shared/If';
-import { getDataTestid } from '../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 require('./DataPrepSidePanel.scss');
 const PREFIX = 'features.DataPrep.DataPrepSidePanel';

--- a/app/cdap/components/DataPrep/DataPrepTable/DataType/index.js
+++ b/app/cdap/components/DataPrep/DataPrepTable/DataType/index.js
@@ -20,7 +20,7 @@ import T from 'i18n-react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import DataPrepStore from 'components/DataPrep/store';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 const PREFIX = 'features.DataPrep.DataPrepTable.DataType';
 const TESTID_PREFIX = 'features.dataprep.workspace.dataTable';

--- a/app/cdap/components/DataPrep/DataPrepTable/index.js
+++ b/app/cdap/components/DataPrep/DataPrepTable/index.js
@@ -33,7 +33,7 @@ import DataQuality from 'components/DataPrep/DataPrepTable/DataQuality';
 import DataType from 'components/DataPrep/DataPrepTable/DataType';
 import Page500 from 'components/500';
 import Page404 from 'components/404';
-import { getDataTestid } from '../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 // Lazy load polyfill in safari as InteresectionObservers are not implemented there yet.
 (async function() {

--- a/app/cdap/components/DataPrep/Directives/Calculate/index.js
+++ b/app/cdap/components/DataPrep/Directives/Calculate/index.js
@@ -33,11 +33,13 @@ import { preventPropagation } from 'services/helpers';
 import { NUMBER_TYPES, NATIVE_NUMBER_TYPES } from 'services/global-constants';
 import capitalize from 'lodash/capitalize';
 import Mousetrap from 'mousetrap';
+import { getDataTestid } from '../../../../testids/TestidsProvider';
 
 require('./Calculate.scss');
 
 const PREFIX = 'features.DataPrep.Directives.Calculate';
 const COPY_NEW_COLUMN_PREFIX = 'features.DataPrep.DataPrepTable.copyToNewColumn';
+const TESTID_PREFIX = 'features.dataprep.directives.calculate';
 
 export default class Calculate extends Component {
   constructor(props) {
@@ -674,6 +676,7 @@ export default class Calculate extends Component {
             active: this.state.operationPopoverOpen === option.name,
           })}
           onClick={this.popoverOptionClick.bind(this, option.name)}
+          data-testid={getDataTestid(`${TESTID_PREFIX}.option`, option.name)}
         >
           <span>{T.translate(`${PREFIX}.OptionsLabels.${option.name}`)}</span>
           <span className="float-right">
@@ -713,7 +716,11 @@ export default class Calculate extends Component {
   renderNewColumnNameInputWithCheckbox() {
     return (
       <div>
-        <div className="create-new-column-line" onClick={this.toggleCreateNewColumn}>
+        <div
+          className="create-new-column-line"
+          onClick={this.toggleCreateNewColumn}
+          data-testid={getDataTestid(`${TESTID_PREFIX}.submenu.copyToNewColumn`)}
+        >
           <span className="fa fa-fw">
             <IconSVG name={this.state.createNewColumn ? 'icon-check-square' : 'icon-square-o'} />
           </span>
@@ -753,6 +760,7 @@ export default class Calculate extends Component {
           onChange={this.setNewColumnInput}
           placeholder={inputPlaceholder}
           autoFocus
+          data-testid={getDataTestid(`${TESTID_PREFIX}.submenu.destinationColumnNameInput`)}
         />
         {columnNameAlreadyExists(this.state.newColumnInput) ? (
           <WarningContainer message={T.translate(`${COPY_NEW_COLUMN_PREFIX}.inputDuplicate`)} />
@@ -768,11 +776,16 @@ export default class Calculate extends Component {
           className="btn btn-primary float-left"
           disabled={this.isApplyDisabled()}
           onClick={this.getExpressionAndApply}
+          data-testid={getDataTestid(`${TESTID_PREFIX}.submenu.applyButton`)}
         >
           {T.translate('features.DataPrep.Directives.apply')}
         </button>
 
-        <button className="btn btn-link float-right" onClick={this.setDefaultState}>
+        <button
+          className="btn btn-link float-right"
+          onClick={this.setDefaultState}
+          data-testid={getDataTestid(`${TESTID_PREFIX}.submenu.cancelButton`)}
+        >
           {T.translate('features.DataPrep.Directives.cancel')}
         </button>
       </div>
@@ -846,6 +859,7 @@ export default class Calculate extends Component {
             step="any"
             min={inputMin}
             autoFocus
+            data-testid={getDataTestid(`${TESTID_PREFIX}.submenu.operandInput`)}
           />
         </div>
         {this.renderNewColumnNameInputWithCheckbox()}
@@ -868,6 +882,7 @@ export default class Calculate extends Component {
             active: this.props.isOpen && !this.state.isDisabled,
             disabled: this.state.isDisabled,
           })}
+          data-testid={getDataTestid(`${TESTID_PREFIX}.title`)}
         >
           <span>{T.translate(`${PREFIX}.title`)}</span>
 

--- a/app/cdap/components/DataPrep/Directives/Calculate/index.js
+++ b/app/cdap/components/DataPrep/Directives/Calculate/index.js
@@ -33,7 +33,7 @@ import { preventPropagation } from 'services/helpers';
 import { NUMBER_TYPES, NATIVE_NUMBER_TYPES } from 'services/global-constants';
 import capitalize from 'lodash/capitalize';
 import Mousetrap from 'mousetrap';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 require('./Calculate.scss');
 

--- a/app/cdap/components/DataPrep/Directives/ChangeDataType/DecimalOptions.tsx
+++ b/app/cdap/components/DataPrep/Directives/ChangeDataType/DecimalOptions.tsx
@@ -31,7 +31,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import Button from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 import {
   ISubmenuProps,

--- a/app/cdap/components/DataPrep/Directives/ChangeDataType/DecimalOptions.tsx
+++ b/app/cdap/components/DataPrep/Directives/ChangeDataType/DecimalOptions.tsx
@@ -31,6 +31,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import Button from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
+import { getDataTestid } from '../../../../testids/TestidsProvider';
 
 import {
   ISubmenuProps,
@@ -45,6 +46,7 @@ const PREFIX = 'features.DataPrep.Directives.ChangeDataType.decimalConfig';
 const ROUNDING_PREFIX = `${PREFIX}.roundingOptions`;
 
 const ID_PREFIX = 'DataPrep-Directives-ChangeDataType-decimal';
+const TESTID_PREFIX = 'features.dataprep.directives.changeDataType.submenu.decimal';
 
 const SCALE_INPUT_ID = `${ID_PREFIX}-scaleInputId`;
 const PRECISION_INPUT_ID = `${ID_PREFIX}-precisionInputId`;
@@ -161,6 +163,7 @@ export const DecimalOptions = ({ onApply, onCancel }: ISubmenuProps): JSX.Elemen
               type="number"
               value={scale}
               onChange={handleScaleChange}
+              data-testid={getDataTestid(`${TESTID_PREFIX}.scaleInput`)}
               endAdornment={
                 <InputAdornment position="end">
                   <Tooltip
@@ -192,6 +195,7 @@ export const DecimalOptions = ({ onApply, onCancel }: ISubmenuProps): JSX.Elemen
               type="number"
               value={precision}
               onChange={handlePrecisionChange}
+              data-testid={getDataTestid(`${TESTID_PREFIX}.precisionInput`)}
               endAdornment={
                 <InputAdornment position="end">
                   <Tooltip
@@ -231,6 +235,7 @@ export const DecimalOptions = ({ onApply, onCancel }: ISubmenuProps): JSX.Elemen
                 value={rounding}
                 onChange={handleRoundingChange}
                 label={T.translate(`${PREFIX}.roundingLabel`)}
+                data-testid={getDataTestid(`${TESTID_PREFIX}.roundingSelector`)}
                 endAdornment={
                   <InputAdornment position="end">
                     <Tooltip
@@ -253,7 +258,11 @@ export const DecimalOptions = ({ onApply, onCancel }: ISubmenuProps): JSX.Elemen
                 }
               >
                 {ROUNDING_MODES.map((mode: IRoundingMode) => (
-                  <MenuItem value={mode.value} key={mode.value}>
+                  <MenuItem
+                    value={mode.value}
+                    key={mode.value}
+                    data-testid={getDataTestid(`${TESTID_PREFIX}.roundingOption`, mode.text)}
+                  >
                     <Tooltip
                       arrow
                       enterDelay={500}
@@ -272,10 +281,20 @@ export const DecimalOptions = ({ onApply, onCancel }: ISubmenuProps): JSX.Elemen
             </FormControl>
           </Tooltip>
           <ButtonsContainer>
-            <Button variant="contained" color="primary" disableElevation onClick={applyDirective}>
+            <Button
+              variant="contained"
+              color="primary"
+              disableElevation
+              onClick={applyDirective}
+              data-testid={getDataTestid(`${TESTID_PREFIX}.applyButton`)}
+            >
               {T.translate(`${PREFIX}.applyButton`)}
             </Button>
-            <Button color="primary" onClick={onCancel}>
+            <Button
+              color="primary"
+              onClick={onCancel}
+              data-testid={getDataTestid(`${TESTID_PREFIX}.cancelButton`)}
+            >
               {T.translate(`${PREFIX}.cancelButton`)}
             </Button>
           </ButtonsContainer>

--- a/app/cdap/components/DataPrep/Directives/ChangeDataType/index.js
+++ b/app/cdap/components/DataPrep/Directives/ChangeDataType/index.js
@@ -29,8 +29,10 @@ import { preventPropagation } from 'services/helpers';
 import { UncontrolledTooltip } from 'components/UncontrolledComponents';
 import If from 'components/shared/If';
 import { DecimalOptions } from 'components/DataPrep/Directives/ChangeDataType/DecimalOptions';
+import { getDataTestid } from '../../../../testids/TestidsProvider';
 
 const PREFIX = 'features.DataPrep.Directives.ChangeDataType';
+const TESTID_PREFIX = 'features.dataprep.directives.changeDataType';
 
 require('./ChangeDataType.scss');
 
@@ -152,6 +154,7 @@ export default class ChangeDataTypeDirective extends Component {
               className='option clearfix'
               key={i}
               onClick={this.handleOptionSelect.bind(this, option)}
+              data-testid={getDataTestid(`${TESTID_PREFIX}.option`, option)}
             >
               <span>{T.translate(`${PREFIX}.Options.${option}`)}</span>
               { !!DATATYPES_WITH_SUBMENU[option] &&
@@ -179,6 +182,7 @@ export default class ChangeDataTypeDirective extends Component {
             active: this.props.isOpen && !this.state.isDisabled,
             disabled: this.state.isDisabled,
           })}
+          data-testid={getDataTestid(`${TESTID_PREFIX}.title`)}
         >
           <span>{T.translate(`${PREFIX}.title`)}</span>
 

--- a/app/cdap/components/DataPrep/Directives/ChangeDataType/index.js
+++ b/app/cdap/components/DataPrep/Directives/ChangeDataType/index.js
@@ -29,7 +29,7 @@ import { preventPropagation } from 'services/helpers';
 import { UncontrolledTooltip } from 'components/UncontrolledComponents';
 import If from 'components/shared/If';
 import { DecimalOptions } from 'components/DataPrep/Directives/ChangeDataType/DecimalOptions';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 const PREFIX = 'features.DataPrep.Directives.ChangeDataType';
 const TESTID_PREFIX = 'features.dataprep.directives.changeDataType';

--- a/app/cdap/components/DataPrep/Directives/ColumnActions/index.js
+++ b/app/cdap/components/DataPrep/Directives/ColumnActions/index.js
@@ -24,7 +24,7 @@ import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import Bulkset from 'components/DataPrep/Directives/ColumnActions/Bulkset';
 import ReplaceColumns from 'components/DataPrep/Directives/ColumnActions/ReplaceColumns';
 import T from 'i18n-react';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 require('./ColumnActions.scss');
 
 const PREFIX = 'features.DataPrep.Directives.ColumnActions';

--- a/app/cdap/components/DataPrep/Directives/CopyColumn/index.js
+++ b/app/cdap/components/DataPrep/Directives/CopyColumn/index.js
@@ -25,7 +25,7 @@ import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import WarningContainer from 'components/shared/WarningContainer';
 import { columnNameAlreadyExists } from 'components/DataPrep/helper';
 import { setPopoverOffset } from 'components/DataPrep/helper';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 const PREFIX = 'features.DataPrep.Directives.Copy';
 const COPY_NEW_COLUMN_PREFIX = 'features.DataPrep.DataPrepTable.copyToNewColumn';

--- a/app/cdap/components/DataPrep/Directives/CopyColumn/index.js
+++ b/app/cdap/components/DataPrep/Directives/CopyColumn/index.js
@@ -25,9 +25,11 @@ import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import WarningContainer from 'components/shared/WarningContainer';
 import { columnNameAlreadyExists } from 'components/DataPrep/helper';
 import { setPopoverOffset } from 'components/DataPrep/helper';
+import { getDataTestid } from '../../../../testids/TestidsProvider';
 
 const PREFIX = 'features.DataPrep.Directives.Copy';
 const COPY_NEW_COLUMN_PREFIX = 'features.DataPrep.DataPrepTable.copyToNewColumn';
+const TESTID_PREFIX = 'features.dataprep.directives.copyColumn';
 
 export default class CopyColumnDirective extends Component {
   constructor(props) {
@@ -118,6 +120,7 @@ export default class CopyColumnDirective extends Component {
             onKeyPress={this.handleKeyPress}
             placeholder={T.translate(`${COPY_NEW_COLUMN_PREFIX}.inputPlaceholder`)}
             ref={(ref) => (this.inputBox = ref)}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.newColumnNameInput`)}
           />
         </div>
 
@@ -132,11 +135,16 @@ export default class CopyColumnDirective extends Component {
             className="btn btn-primary float-left"
             onClick={this.applyDirective}
             disabled={this.state.input.length === 0}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.applyButton`)}
           >
             {T.translate('features.DataPrep.Directives.apply')}
           </button>
 
-          <button className="btn btn-link float-right" onClick={this.props.close}>
+          <button
+            className="btn btn-link float-right"
+            onClick={this.props.close}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.cancelButton`)}
+          >
             {T.translate('features.DataPrep.Directives.cancel')}
           </button>
         </div>
@@ -151,6 +159,7 @@ export default class CopyColumnDirective extends Component {
         className={classnames('copy-directive clearfix action-item', {
           active: this.props.isOpen,
         })}
+        data-testid={getDataTestid(`${TESTID_PREFIX}.title`)}
       >
         <span>{T.translate(`${PREFIX}.title`)}</span>
 

--- a/app/cdap/components/DataPrep/Directives/CustomTransform/index.js
+++ b/app/cdap/components/DataPrep/Directives/CustomTransform/index.js
@@ -26,10 +26,12 @@ import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import { preventPropagation } from 'services/helpers';
 import Mousetrap from 'mousetrap';
 import { setPopoverOffset } from 'components/DataPrep/helper';
+import { getDataTestid } from '../../../../testids/TestidsProvider';
 
 require('./CustomTransform.scss');
 
 const PREFIX = 'features.DataPrep.Directives.CustomTransform';
+const TESTID_PREFIX = 'features.dataprep.directives.customTransform';
 
 export default class CustomTransform extends Component {
   static propTypes = {
@@ -106,6 +108,7 @@ export default class CustomTransform extends Component {
           onChange={this.handleInputChange}
           placeholder={T.translate(`${PREFIX}.placeholder`, { column: this.props.column })}
           autoFocus
+          data-testid={getDataTestid(`${TESTID_PREFIX}.expressionTextarea`)}
         />
 
         <hr />
@@ -115,11 +118,16 @@ export default class CustomTransform extends Component {
             className="btn btn-primary float-left"
             onClick={this.applyDirective}
             disabled={this.state.input.length === 0}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.applyButton`)}
           >
             {T.translate('features.DataPrep.Directives.apply')}
           </button>
 
-          <button className="btn btn-link float-right" onClick={this.props.close}>
+          <button
+            className="btn btn-link float-right"
+            onClick={this.props.close}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.cancelButton`)}
+          >
             {T.translate('features.DataPrep.Directives.cancel')}
           </button>
         </div>
@@ -134,6 +142,7 @@ export default class CustomTransform extends Component {
         className={classnames('clearfix action-item', {
           active: this.props.isOpen,
         })}
+        data-testid={getDataTestid(`${TESTID_PREFIX}.title`)}
       >
         <span>{T.translate(`${PREFIX}.title`)}</span>
 

--- a/app/cdap/components/DataPrep/Directives/CustomTransform/index.js
+++ b/app/cdap/components/DataPrep/Directives/CustomTransform/index.js
@@ -26,7 +26,7 @@ import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import { preventPropagation } from 'services/helpers';
 import Mousetrap from 'mousetrap';
 import { setPopoverOffset } from 'components/DataPrep/helper';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 require('./CustomTransform.scss');
 

--- a/app/cdap/components/DataPrep/Directives/DefineVariable/index.js
+++ b/app/cdap/components/DataPrep/Directives/DefineVariable/index.js
@@ -25,10 +25,12 @@ import { setPopoverOffset } from 'components/DataPrep/helper';
 import { execute } from 'components/DataPrep/store/DataPrepActionCreator';
 import Mousetrap from 'mousetrap';
 import { preventPropagation } from 'services/helpers';
+import { getDataTestid } from '../../../../testids/TestidsProvider';
 
 require('./DefineVariable.scss');
 
 const PREFIX = `features.DataPrep.Directives.DefineVariable`;
+const TESTID_PREFIX = 'features.dataprep.directives.defineVariable';
 
 export default class DefineVariableDirective extends Component {
   constructor(props) {
@@ -164,6 +166,7 @@ export default class DefineVariableDirective extends Component {
           onChange={this.handleStateValueChange.bind(this, 'customFilter')}
           ref={(ref) => (this.customFilterRef = ref)}
           placeholder={T.translate(`${PREFIX}.Placeholders.CUSTOMCONDITION`)}
+          data-testid={getDataTestid(`${TESTID_PREFIX}.customConditionInput`)}
         />
       </div>
     );
@@ -184,6 +187,7 @@ export default class DefineVariableDirective extends Component {
           placeholder={T.translate(`${PREFIX}.Placeholders.${this.state.selectedCondition}`)}
           ref={(ref) => (this.textFilterRef = ref)}
           onKeyPress={this.handleKeyPress}
+          data-testid={getDataTestid(`${TESTID_PREFIX}.conditionTextInput`)}
         />
       </div>
     );
@@ -209,10 +213,18 @@ export default class DefineVariableDirective extends Component {
                 className="form-control mousetrap"
                 value={this.state.selectedCondition}
                 onChange={this.handleStateValueChange.bind(this, 'selectedCondition')}
+                data-testid={getDataTestid(`${TESTID_PREFIX}.conditionSelector`)}
               >
                 {selectConditions.map((condition) => {
                   return (
-                    <option value={condition.filter} key={condition.filter}>
+                    <option
+                      value={condition.filter}
+                      key={condition.filter}
+                      data-testid={getDataTestid(
+                        `${TESTID_PREFIX}.conditionOption`, 
+                        condition.filter
+                      )}
+                    >
                       {condition.displayText}
                     </option>
                   );
@@ -220,7 +232,13 @@ export default class DefineVariableDirective extends Component {
                 <option disabled="disabled" role="separator">
                   &#x2500;&#x2500;&#x2500;&#x2500;
                 </option>
-                <option value="CUSTOMCONDITION">
+                <option
+                  value="CUSTOMCONDITION"
+                  data-testid={getDataTestid(
+                    `${TESTID_PREFIX}.conditionOption`,
+                    'CUSTOMCONDITION'
+                  )}
+                >
                   {T.translate(`${PREFIX}.Conditions.CUSTOMCONDITION`)}
                 </option>
               </select>
@@ -247,6 +265,7 @@ export default class DefineVariableDirective extends Component {
             onChange={this.handleStateValueChange.bind(this, 'variableName')}
             placeholder={T.translate(`${PREFIX}.variableNamePlaceholder`)}
             onKeyPress={this.handleKeyPress}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.variableNameInput`)}
           />
         </div>
       </div>
@@ -266,10 +285,18 @@ export default class DefineVariableDirective extends Component {
               className="form-control"
               value={this.state.selectedColumn}
               onChange={this.handleStateValueChange.bind(this, 'selectedColumn')}
+              data-testid={getDataTestid(`${TESTID_PREFIX}.columnSelector`)}
             >
               {this.columnsList.map((column) => {
                 return (
-                  <option value={column} key={column}>
+                  <option
+                    value={column}
+                    key={column}
+                    data-testid={getDataTestid(
+                      `${TESTID_PREFIX}.columnOption`,
+                      column
+                    )}
+                  >
                     {column}
                   </option>
                 );
@@ -289,7 +316,7 @@ export default class DefineVariableDirective extends Component {
     return (
       <div className="summary">
         <strong className="summary-label">{T.translate(`${PREFIX}.summaryLabel`)}</strong>
-        <span>
+        <span data-testid={getDataTestid(`${TESTID_PREFIX}.summaryText`)}>
           {T.translate(`${PREFIX}.summaryText`, {
             variableName: this.state.variableName,
             condition: T.translate(`${PREFIX}.Conditions.${this.state.selectedCondition}`),
@@ -328,11 +355,16 @@ export default class DefineVariableDirective extends Component {
             className="btn btn-primary float-left"
             onClick={this.applyDirective}
             disabled={this.isApplyDisabled()}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.applyButton`)}
           >
             {T.translate('features.DataPrep.Directives.apply')}
           </button>
 
-          <button className="btn btn-link float-right" onClick={this.props.close}>
+          <button
+            className="btn btn-link float-right"
+            onClick={this.props.close}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.cancelButton`)}
+          >
             {T.translate('features.DataPrep.Directives.cancel')}
           </button>
         </div>
@@ -347,6 +379,7 @@ export default class DefineVariableDirective extends Component {
         className={classnames('set-variable-directive clearfix action-item', {
           active: this.state.isOpen,
         })}
+        data-testid={getDataTestid(`${TESTID_PREFIX}.title`)}
       >
         <span>{T.translate(`${PREFIX}.title`)}</span>
 

--- a/app/cdap/components/DataPrep/Directives/DefineVariable/index.js
+++ b/app/cdap/components/DataPrep/Directives/DefineVariable/index.js
@@ -25,7 +25,7 @@ import { setPopoverOffset } from 'components/DataPrep/helper';
 import { execute } from 'components/DataPrep/store/DataPrepActionCreator';
 import Mousetrap from 'mousetrap';
 import { preventPropagation } from 'services/helpers';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 require('./DefineVariable.scss');
 

--- a/app/cdap/components/DataPrep/Directives/DropColumn/index.js
+++ b/app/cdap/components/DataPrep/Directives/DropColumn/index.js
@@ -21,7 +21,7 @@ import T from 'i18n-react';
 import { execute } from 'components/DataPrep/store/DataPrepActionCreator';
 import DataPrepStore from 'components/DataPrep/store';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 const PREFIX = 'features.DataPrep.Directives.Drop';
 const TESTID_PREFIX = 'features.dataprep.directives.dropColumn';

--- a/app/cdap/components/DataPrep/Directives/DropColumn/index.js
+++ b/app/cdap/components/DataPrep/Directives/DropColumn/index.js
@@ -21,7 +21,10 @@ import T from 'i18n-react';
 import { execute } from 'components/DataPrep/store/DataPrepActionCreator';
 import DataPrepStore from 'components/DataPrep/store';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
+import { getDataTestid } from '../../../../testids/TestidsProvider';
+
 const PREFIX = 'features.DataPrep.Directives.Drop';
+const TESTID_PREFIX = 'features.dataprep.directives.dropColumn';
 
 export default class DropColumnDirective extends Component {
   constructor(props) {
@@ -60,7 +63,11 @@ export default class DropColumnDirective extends Component {
     }
 
     return (
-      <div className="drop-column-directive clearfix action-item" onClick={this.applyDirective}>
+      <div
+        className="drop-column-directive clearfix action-item"
+        onClick={this.applyDirective}
+        data-testid={getDataTestid(`${TESTID_PREFIX}.title`)}
+      >
         <span>{title}</span>
       </div>
     );

--- a/app/cdap/components/DataPrep/Directives/EncodeDecode/index.js
+++ b/app/cdap/components/DataPrep/Directives/EncodeDecode/index.js
@@ -25,7 +25,7 @@ import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import { UncontrolledTooltip } from 'components/UncontrolledComponents';
 import { setPopoverOffset } from 'components/DataPrep/helper';
 import { preventPropagation } from 'services/helpers';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 require('./EncodeDecode.scss');
 const PREFIX = 'features.DataPrep.Directives.Encode';

--- a/app/cdap/components/DataPrep/Directives/EncodeDecode/index.js
+++ b/app/cdap/components/DataPrep/Directives/EncodeDecode/index.js
@@ -25,9 +25,12 @@ import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import { UncontrolledTooltip } from 'components/UncontrolledComponents';
 import { setPopoverOffset } from 'components/DataPrep/helper';
 import { preventPropagation } from 'services/helpers';
+import { getDataTestid } from '../../../../testids/TestidsProvider';
 
 require('./EncodeDecode.scss');
 const PREFIX = 'features.DataPrep.Directives.Encode';
+const TESTID_PREFIX = 'features.dataprep.directives.encodeDecode';
+
 const ENCODEOPTIONS = [
   {
     label: T.translate(`${PREFIX}.base64`),
@@ -93,7 +96,12 @@ export default class EncodeDecode extends Component {
       <div className="encode-decode-options second-level-popover" onClick={this.preventPropagation}>
         {this.props.options.map((option, i) => {
           return (
-            <div className="option" key={i} onClick={this.applyDirective.bind(this, option)}>
+            <div
+              className="option"
+              key={i}
+              onClick={this.applyDirective.bind(this, option)}
+              data-testid={getDataTestid(`${TESTID_PREFIX}.options`, option.label)}
+            >
               {option.label}
             </div>
           );
@@ -111,6 +119,10 @@ export default class EncodeDecode extends Component {
             active: this.props.isOpen && !this.props.isDisabled,
             disabled: this.props.isDisabled,
           })}
+          data-testid={getDataTestid(
+            `${TESTID_PREFIX}.title`,
+            this.props.mainMenuLabel
+          )}
         >
           <span>{this.props.mainMenuLabel}</span>
 

--- a/app/cdap/components/DataPrep/Directives/Explode/index.js
+++ b/app/cdap/components/DataPrep/Directives/Explode/index.js
@@ -25,7 +25,7 @@ import DataPrepStore from 'components/DataPrep/store';
 import { execute } from 'components/DataPrep/store/DataPrepActionCreator';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import { setPopoverOffset } from 'components/DataPrep/helper';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 require('./Explode.scss');
 
 const TESTID_PREFIX = 'features.dataprep.directives.explode';

--- a/app/cdap/components/DataPrep/Directives/Explode/index.js
+++ b/app/cdap/components/DataPrep/Directives/Explode/index.js
@@ -25,8 +25,11 @@ import DataPrepStore from 'components/DataPrep/store';
 import { execute } from 'components/DataPrep/store/DataPrepActionCreator';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import { setPopoverOffset } from 'components/DataPrep/helper';
-
+import { getDataTestid } from '../../../../testids/TestidsProvider';
 require('./Explode.scss');
+
+const TESTID_PREFIX = 'features.dataprep.directives.explode';
+
 export default class Explode extends Component {
   constructor(props) {
     super(props);
@@ -128,17 +131,29 @@ export default class Explode extends Component {
             disabled: disableFilterSubmenu,
           })}
         >
-          <div onClick={this.explodeUsingFilters} className="option">
+          <div
+            onClick={this.explodeUsingFilters}
+            className="option"
+            data-testid={getDataTestid(`${TESTID_PREFIX}.options.delimited`)}
+          >
             {T.translate(`${PREFIX}.filtersSubmenuTitle`)}
           </div>
         </div>
         <div className="explode-field-options">
-          <div onClick={this.explodeByFlattening} className="option">
+          <div
+            onClick={this.explodeByFlattening}
+            className="option"
+            data-testid={getDataTestid(`${TESTID_PREFIX}.options.arrayFlattening`)}
+          >
             {T.translate(`${PREFIX}.flatteningSubmenuTitle`)}
           </div>
         </div>
         <div className="explode-field-options">
-          <div onClick={this.explodeRecordByFlattening} className="option">
+          <div
+            onClick={this.explodeRecordByFlattening}
+            className="option"
+            data-testid={getDataTestid(`${TESTID_PREFIX}.options.recordFlattening`)}
+          >
             {T.translate(`${PREFIX}.recordFlatteningSubmenuTitle`)}
           </div>
         </div>
@@ -153,6 +168,7 @@ export default class Explode extends Component {
         className={classnames('clearfix action-item', {
           active: this.props.isOpen,
         })}
+        data-testid={getDataTestid(`${TESTID_PREFIX}.title`)}
       >
         <span className="option">{T.translate(`${PREFIX}.title`)}</span>
 

--- a/app/cdap/components/DataPrep/Directives/ExtractFields/UsingDelimiterModal/index.js
+++ b/app/cdap/components/DataPrep/Directives/ExtractFields/UsingDelimiterModal/index.js
@@ -21,7 +21,7 @@ import classnames from 'classnames';
 import T from 'i18n-react';
 import Mousetrap from 'mousetrap';
 import isEmpty from 'lodash/isEmpty';
-import { getDataTestid } from '../../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 require('./UsingDelimiter.scss');
 
 const PREFIX = 'features.DataPrep.Directives.ExtractFields.UsingDelimiters';

--- a/app/cdap/components/DataPrep/Directives/ExtractFields/UsingDelimiterModal/index.js
+++ b/app/cdap/components/DataPrep/Directives/ExtractFields/UsingDelimiterModal/index.js
@@ -21,9 +21,11 @@ import classnames from 'classnames';
 import T from 'i18n-react';
 import Mousetrap from 'mousetrap';
 import isEmpty from 'lodash/isEmpty';
+import { getDataTestid } from '../../../../../testids/TestidsProvider';
 require('./UsingDelimiter.scss');
 
 const PREFIX = 'features.DataPrep.Directives.ExtractFields.UsingDelimiters';
+const TESTID_PREFIX = 'features.dataprep.directives.extractFields.modal.delimiters';
 const DEFAULT_DELIMITER = T.translate(`${PREFIX}.comma`);
 const DELIMITER_MAP = {
   [T.translate(`${PREFIX}.comma`)]: ',',
@@ -87,6 +89,7 @@ export default class UsingDelimiterModal extends Component {
           value={this.state.customDelimiter}
           placeholder="e.g. \d+"
           autoFocus
+          data-testid={getDataTestid(`${TESTID_PREFIX}.customDelimiterInput`)}
         />
       </div>
     );
@@ -122,9 +125,15 @@ export default class UsingDelimiterModal extends Component {
         className="dataprep-parse-modal using-delimiter-modal cdap-modal"
       >
         <ModalHeader>
-          <span>{T.translate(`${PREFIX}.modalTitle`)}</span>
+          <span data-testid={getDataTestid(`${TESTID_PREFIX}.title`)}>
+            {T.translate(`${PREFIX}.modalTitle`)}
+          </span>
 
-          <div className="close-section float-right" onClick={this.props.onClose}>
+          <div
+            className="close-section float-right"
+            onClick={this.props.onClose}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.closeButton`)}
+          >
             <span className="fa fa-times" />
           </div>
         </ModalHeader>
@@ -135,6 +144,7 @@ export default class UsingDelimiterModal extends Component {
                 key={option}
                 onClick={this.handleSplitByClick.bind(this, option)}
                 className="cursor-pointer"
+                data-testid={getDataTestid(`${TESTID_PREFIX}.delimiterOption`, option)}
               >
                 <span
                   className={classnames('fa fa-fw', {
@@ -154,10 +164,15 @@ export default class UsingDelimiterModal extends Component {
             className="btn btn-primary"
             onClick={this.applyDirective}
             disabled={getApplyBtnDisabledState()}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.applyButton`)}
           >
             {T.translate('features.DataPrep.Directives.ExtractFields.extractBtnLabel')}
           </button>
-          <button className="btn btn-secondary" onClick={this.props.onClose}>
+          <button
+            className="btn btn-secondary"
+            onClick={this.props.onClose}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.cancelButton`)}
+          >
             {T.translate('features.DataPrep.Directives.cancel')}
           </button>
         </ModalFooter>

--- a/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPatternsModal/index.js
+++ b/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPatternsModal/index.js
@@ -27,7 +27,7 @@ import Mousetrap from 'mousetrap';
 import DataPrepStore from 'components/DataPrep/store';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import { UncontrolledDropdown } from 'components/UncontrolledComponents';
-import { getDataTestid } from '../../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 require('./UsingPatternsModal.scss');
 
 const PREFIX = 'features.DataPrep.Directives.ExtractFields.UsingPatterns';

--- a/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPatternsModal/index.js
+++ b/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPatternsModal/index.js
@@ -23,13 +23,15 @@ import isNil from 'lodash/isNil';
 import isEmpty from 'lodash/isEmpty';
 import { Input, DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap';
 import { execute } from 'components/DataPrep/store/DataPrepActionCreator';
-const PREFIX = 'features.DataPrep.Directives.ExtractFields.UsingPatterns';
 import Mousetrap from 'mousetrap';
 import DataPrepStore from 'components/DataPrep/store';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import { UncontrolledDropdown } from 'components/UncontrolledComponents';
-
+import { getDataTestid } from '../../../../../testids/TestidsProvider';
 require('./UsingPatternsModal.scss');
+
+const PREFIX = 'features.DataPrep.Directives.ExtractFields.UsingPatterns';
+const TESTID_PREFIX = 'features.dataprep.directives.extractFields.modal.patterns';
 
 export default class UsingPatternsModal extends Component {
   constructor(props) {
@@ -276,6 +278,7 @@ export default class UsingPatternsModal extends Component {
           onChange={this.setStartEndPattern.bind(this, 'start')}
           value={this.state.startAndEndPattern.start}
           autoFocus
+          data-testid={getDataTestid(`${TESTID_PREFIX}.patternStartInput`)}
         />
         {T.translate(`${PREFIX}.startEndPatternContent.description2`)}
         <Input
@@ -283,6 +286,7 @@ export default class UsingPatternsModal extends Component {
           placeholder={`${T.translate(`${PREFIX}.exampleLabel`)} >`}
           onChange={this.setStartEndPattern.bind(this, 'end')}
           value={this.state.startAndEndPattern.end}
+          data-testid={getDataTestid(`${TESTID_PREFIX}.patternEndInput`)}
         />
       </span>
     );
@@ -298,6 +302,7 @@ export default class UsingPatternsModal extends Component {
           value={this.state.nDigitPattern}
           type="number"
           autoFocus
+          data-testid={getDataTestid(`${TESTID_PREFIX}.numDigitsPatternInput`)}
         />
         {T.translate(`${PREFIX}.ndigitnumberPatternContent.description2`)}
       </span>
@@ -312,6 +317,7 @@ export default class UsingPatternsModal extends Component {
           placeholder={`${T.translate(`${PREFIX}.exampleLabel`)} [^(]+\(([0-9]{4})\).* `}
           onChange={this.setCustomPattern}
           autoFocus
+          data-testid={getDataTestid(`${TESTID_PREFIX}.customPatternInput`)}
         />
       </span>
     );
@@ -335,10 +341,15 @@ export default class UsingPatternsModal extends Component {
         className="btn btn-primary"
         onClick={this.applyDirective}
         disabled={isNil(this.state.pattern) ? 'disabled' : null}
+        data-testid={getDataTestid(`${TESTID_PREFIX}.applyButton`)}
       >
         {T.translate('features.DataPrep.Directives.ExtractFields.extractBtnLabel')}
       </button>,
-      <button className="btn btn-secondary" onClick={this.props.onClose}>
+      <button
+        className="btn btn-secondary"
+        onClick={this.props.onClose}
+        data-testid={getDataTestid(`${TESTID_PREFIX}.cancelButton`)}
+      >
         {T.translate('features.DataPrep.Directives.cancel')}
       </button>,
     ];
@@ -353,7 +364,11 @@ export default class UsingPatternsModal extends Component {
         showHideLink = T.translate(`${PREFIX}.showPatternLabel`);
       }
       showHideLink = (
-        <div className="showhidelink" onClick={this.toggleShowEditPatternTxtBox}>
+        <div
+          className="showhidelink"
+          onClick={this.toggleShowEditPatternTxtBox}
+          data-testid={getDataTestid(`${TESTID_PREFIX}.togglePatternEdit`)}
+        >
           {showHideLink}
         </div>
       );
@@ -368,9 +383,15 @@ export default class UsingPatternsModal extends Component {
         className="dataprep-parse-modal using-patterns-modal cdap-modal"
       >
         <ModalHeader>
-          <span>{T.translate(`${PREFIX}.modalTitle`, { parser: 'Log' })}</span>
+          <span data-testid={getDataTestid(`${TESTID_PREFIX}.title`)}>
+            {T.translate(`${PREFIX}.modalTitle`, { parser: 'Log' })}
+          </span>
 
-          <div className="close-section float-right" onClick={this.props.onClose}>
+          <div
+            className="close-section float-right"
+            onClick={this.props.onClose}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.closeButton`)}
+          >
             <span className="fa fa-times" />
           </div>
         </ModalHeader>
@@ -378,7 +399,7 @@ export default class UsingPatternsModal extends Component {
           <p>{T.translate(`${PREFIX}.patternDescription`, { column: this.props.column })}</p>
           {this.patterns[0].patternLabel}
           <UncontrolledDropdown>
-            <DropdownToggle caret>
+            <DropdownToggle caret data-testid={getDataTestid(`${TESTID_PREFIX}.patternsSelector`)}>
               {isNil(this.state.patternLabel) ? this.patterns[0].label : this.state.patternLabel}
             </DropdownToggle>
 
@@ -386,7 +407,10 @@ export default class UsingPatternsModal extends Component {
               <div className="using-patterns-modal-dropdown">
                 {this.patterns.map((pattern, index) => {
                   return (
-                    <DropdownItem onClick={this.onPatternChange.bind(this, index)}>
+                    <DropdownItem
+                      onClick={this.onPatternChange.bind(this, index)}
+                      data-testid={getDataTestid(`${TESTID_PREFIX}.patternsOption`, pattern.patternName || 'none')}
+                    >
                       <span>{pattern.label}</span>
                     </DropdownItem>
                   );
@@ -407,6 +431,7 @@ export default class UsingPatternsModal extends Component {
                 onChange={this.onRawPatternChange}
                 value={this.state.pattern}
                 autoFocus
+                data-testid={getDataTestid(`${TESTID_PREFIX}.editPatternInput`)}
               />
             ) : null}
           </div>

--- a/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPositions/CutDirective.js
+++ b/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPositions/CutDirective.js
@@ -26,12 +26,13 @@ import isNil from 'lodash/isNil';
 import { execute } from 'components/DataPrep/store/DataPrepActionCreator';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import DataPrepStore from 'components/DataPrep/store';
-
+import { getDataTestid } from '../../../../../testids/TestidsProvider';
 require('./CutDirective.scss');
 
 const CELLHIGHLIGHTCLASSNAME = 'cl-highlight';
 const POPOVERTHETHERCLASSNAME = 'highlight-popover';
 const PREFIX = `features.DataPrep.Directives.CutDirective`;
+const TESTID_PREFIX = 'features.dataprep.directives.extractFields.modal.positions';
 
 export default class CutDirective extends Component {
   constructor(props) {
@@ -124,7 +125,10 @@ export default class CutDirective extends Component {
           className={`${CELLHIGHLIGHTCLASSNAME} popover-content`}
           onClick={this.preventPropagation}
         >
-          <span className={CELLHIGHLIGHTCLASSNAME}>
+          <span
+            className={CELLHIGHLIGHTCLASSNAME}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.selectionRangeText`)}
+          >
             {T.translate(`${PREFIX}.extractDescription`, { range: `${start + 1}-${end}` })}
           </span>
           <div className={classnames('col-input-container', CELLHIGHLIGHTCLASSNAME)}>
@@ -136,15 +140,21 @@ export default class CutDirective extends Component {
               onChange={this.handleColNameChange}
               value={this.newColName}
               validCharacterRegex={/^\w+$/}
+              dataTestid={getDataTestid(`${TESTID_PREFIX}.destinationColumnNameInput`)}
             />
           </div>
           <div
             className={`btn btn-primary ${CELLHIGHLIGHTCLASSNAME}`}
             onClick={this.applyDirective}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.applyButton`)}
           >
             {T.translate('features.DataPrep.Directives.apply')}
           </div>
-          <div className={`btn ${CELLHIGHLIGHTCLASSNAME}`} onClick={this.props.onClose}>
+          <div
+            className={`btn ${CELLHIGHLIGHTCLASSNAME}`}
+            onClick={this.props.onClose}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.cancelButton`)}
+          >
             {T.translate(`${PREFIX}.cancelBtnLabel`)}
           </div>
         </PopoverBody>

--- a/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPositions/CutDirective.js
+++ b/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPositions/CutDirective.js
@@ -26,7 +26,7 @@ import isNil from 'lodash/isNil';
 import { execute } from 'components/DataPrep/store/DataPrepActionCreator';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import DataPrepStore from 'components/DataPrep/store';
-import { getDataTestid } from '../../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 require('./CutDirective.scss');
 
 const CELLHIGHLIGHTCLASSNAME = 'cl-highlight';

--- a/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPositions/CutMenuItem.js
+++ b/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPositions/CutMenuItem.js
@@ -20,7 +20,7 @@ import React, { Component } from 'react';
 import DataPrepStore from 'components/DataPrep/store';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import T from 'i18n-react';
-import { getDataTestid } from '../../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 const TESTID_PREFIX = 'features.dataprep.directives.extractFields.modal.positions';
 

--- a/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPositions/CutMenuItem.js
+++ b/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPositions/CutMenuItem.js
@@ -20,6 +20,9 @@ import React, { Component } from 'react';
 import DataPrepStore from 'components/DataPrep/store';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import T from 'i18n-react';
+import { getDataTestid } from '../../../../../testids/TestidsProvider';
+
+const TESTID_PREFIX = 'features.dataprep.directives.extractFields.modal.positions';
 
 export default class CutMenuItem extends Component {
   constructor(props) {
@@ -41,7 +44,11 @@ export default class CutMenuItem extends Component {
   }
   render() {
     return (
-      <div className="cut-menu-item option clearfix" onClick={this.highlightColumn}>
+      <div
+        className="cut-menu-item option clearfix"
+        onClick={this.highlightColumn}
+        data-testid={getDataTestid(`${TESTID_PREFIX}.modalTrigger`)}
+      >
         <span>{T.translate('features.DataPrep.Directives.CutMenuItem.menuLabel')}</span>
       </div>
     );

--- a/app/cdap/components/DataPrep/Directives/ExtractFields/index.js
+++ b/app/cdap/components/DataPrep/Directives/ExtractFields/index.js
@@ -28,7 +28,7 @@ import DataPrepStore from 'components/DataPrep/store';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import { setPopoverOffset } from 'components/DataPrep/helper';
 import { UncontrolledTooltip } from 'components/UncontrolledComponents';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 const TESTID_PREFIX = 'features.dataprep.directives.extractFields';
 

--- a/app/cdap/components/DataPrep/Directives/ExtractFields/index.js
+++ b/app/cdap/components/DataPrep/Directives/ExtractFields/index.js
@@ -28,6 +28,9 @@ import DataPrepStore from 'components/DataPrep/store';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import { setPopoverOffset } from 'components/DataPrep/helper';
 import { UncontrolledTooltip } from 'components/UncontrolledComponents';
+import { getDataTestid } from '../../../../testids/TestidsProvider';
+
+const TESTID_PREFIX = 'features.dataprep.directives.extractFields';
 
 require('./ExtractFields.scss');
 export default class ExtractFields extends Component {
@@ -73,7 +76,11 @@ export default class ExtractFields extends Component {
             disabled: this.isUsingPatternsDisabled,
           })}
         >
-          <div onClick={this.parseUsingPatterns} className="option">
+          <div
+            onClick={this.parseUsingPatterns}
+            className="option"
+            data-testid={getDataTestid(`${TESTID_PREFIX}.options.patterns`)}
+          >
             {T.translate(`${PREFIX}.patternSubmenuTitle`)}
           </div>
         </div>
@@ -83,12 +90,19 @@ export default class ExtractFields extends Component {
           </UncontrolledTooltip>
         ) : null}
         <div className="extract-field-options">
-          <div onClick={this.parseUsingDelimiters} className="option">
+          <div
+            onClick={this.parseUsingDelimiters}
+            className="option"
+            data-testid={getDataTestid(`${TESTID_PREFIX}.options.delimiters`)}
+          >
             {T.translate(`${PREFIX}.delimitersSubmenuTitle`)}
           </div>
         </div>
         <div className="extract-field-options">
-          <div onClick={this.parseUsingPosition}>
+          <div
+            onClick={this.parseUsingPosition}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.options.positions`)}
+          >
             <CutMenuItem
               column={Array.isArray(this.props.column) ? this.props.column[0] : this.props.column}
               onComplete={this.props.onComplete}
@@ -169,6 +183,7 @@ export default class ExtractFields extends Component {
         className={classnames('clearfix action-item', {
           active: this.props.isOpen,
         })}
+        data-testid={getDataTestid(`${TESTID_PREFIX}.title`)}
       >
         <span className="option">{T.translate(`${PREFIX}.title`)}</span>
 

--- a/app/cdap/components/DataPrep/Directives/FillNullOrEmpty/index.js
+++ b/app/cdap/components/DataPrep/Directives/FillNullOrEmpty/index.js
@@ -23,7 +23,7 @@ import DataPrepStore from 'components/DataPrep/store';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import { setPopoverOffset } from 'components/DataPrep/helper';
 import T from 'i18n-react';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 const PREFIX = 'features.DataPrep.Directives.FillNullOrEmpty';
 const TESTID_PREFIX = 'features.dataprep.directives.fillNullOrEmpty';

--- a/app/cdap/components/DataPrep/Directives/FillNullOrEmpty/index.js
+++ b/app/cdap/components/DataPrep/Directives/FillNullOrEmpty/index.js
@@ -23,8 +23,10 @@ import DataPrepStore from 'components/DataPrep/store';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import { setPopoverOffset } from 'components/DataPrep/helper';
 import T from 'i18n-react';
+import { getDataTestid } from '../../../../testids/TestidsProvider';
 
 const PREFIX = 'features.DataPrep.Directives.FillNullOrEmpty';
+const TESTID_PREFIX = 'features.dataprep.directives.fillNullOrEmpty';
 
 export default class FillNullOrEmptyDirective extends Component {
   constructor(props) {
@@ -118,6 +120,7 @@ export default class FillNullOrEmptyDirective extends Component {
             onKeyPress={this.handleKeyPress}
             placeholder="Enter value to set"
             ref={(ref) => (this.inputBox = ref)}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.fillerValueInput`)}
           />
         </div>
 
@@ -128,11 +131,16 @@ export default class FillNullOrEmptyDirective extends Component {
             className="btn btn-primary float-left"
             onClick={this.applyDirective}
             disabled={this.state.input.length === 0}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.applyButton`)}
           >
             {T.translate('features.DataPrep.Directives.apply')}
           </button>
 
-          <button className="btn btn-link float-right" onClick={this.props.close}>
+          <button
+            className="btn btn-link float-right"
+            onClick={this.props.close}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.cancelButton`)}
+          >
             {T.translate('features.DataPrep.Directives.cancel')}
           </button>
         </div>
@@ -147,6 +155,7 @@ export default class FillNullOrEmptyDirective extends Component {
         className={classnames('clearfix action-item', {
           active: this.props.isOpen,
         })}
+        data-testid={getDataTestid(`${TESTID_PREFIX}.title`)}
       >
         <span>{T.translate(`${PREFIX}.title`)}</span>
 

--- a/app/cdap/components/DataPrep/Directives/Filter/index.js
+++ b/app/cdap/components/DataPrep/Directives/Filter/index.js
@@ -26,7 +26,7 @@ import MouseTrap from 'mousetrap';
 import { Popover, PopoverHeader, PopoverBody } from 'reactstrap';
 import IconSVG from 'components/shared/IconSVG';
 import { setPopoverOffset } from 'components/DataPrep/helper';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 require('./FilterDirective.scss');
 

--- a/app/cdap/components/DataPrep/Directives/Filter/index.js
+++ b/app/cdap/components/DataPrep/Directives/Filter/index.js
@@ -26,10 +26,12 @@ import MouseTrap from 'mousetrap';
 import { Popover, PopoverHeader, PopoverBody } from 'reactstrap';
 import IconSVG from 'components/shared/IconSVG';
 import { setPopoverOffset } from 'components/DataPrep/helper';
+import { getDataTestid } from '../../../../testids/TestidsProvider';
 
 require('./FilterDirective.scss');
 
 const PREFIX = 'features.DataPrep.Directives.Filter';
+const TESTID_PREFIX = 'features.dataprep.directives.filter';
 
 const DIRECTIVES_MAP = {
   KEEP: {
@@ -277,6 +279,7 @@ export default class FilterDirective extends Component {
           onChange={this.handleCustomFilterChange}
           ref={(ref) => (this.customFilterRef = ref)}
           placeholder={T.translate(`${PREFIX}.Placeholders.CUSTOMCONDITION`)}
+          data-testid={getDataTestid(`${TESTID_PREFIX}.customFilterTextarea`)}
         />
       </div>
     );
@@ -291,7 +294,11 @@ export default class FilterDirective extends Component {
     if (this.state.selectedCondition !== 'TEXTREGEX') {
       ignoreCase = (
         <div>
-          <span className="cursor-pointer" onClick={this.toggleIgnoreCase}>
+          <span
+            className="cursor-pointer"
+            onClick={this.toggleIgnoreCase}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.ignoreCase`)}
+          >
             <span
               className={classnames('fa', {
                 'fa-square-o': !this.state.ignoreCase,
@@ -316,6 +323,7 @@ export default class FilterDirective extends Component {
             placeholder={T.translate(`${PREFIX}.Placeholders.${this.state.selectedCondition}`)}
             ref={(ref) => (this.textFilterRef = ref)}
             onKeyPress={this.handleKeyPress}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.textFilterInput`)}
           />
         </div>
         {ignoreCase}
@@ -339,6 +347,7 @@ export default class FilterDirective extends Component {
               active: this.state.rowFilter === 'KEEP',
             })}
             onClick={this.handleRowFilter.bind(this, 'KEEP')}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.keepRows`)}
           >
             {T.translate(`${PREFIX}.KEEP`)}
           </span>
@@ -348,6 +357,7 @@ export default class FilterDirective extends Component {
               active: this.state.rowFilter === 'REMOVE',
             })}
             onClick={this.handleRowFilter.bind(this, 'REMOVE')}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.removeRows`)}
           >
             {T.translate(`${PREFIX}.REMOVE`)}
           </span>
@@ -361,10 +371,15 @@ export default class FilterDirective extends Component {
                 className="form-control mousetrap"
                 value={this.state.selectedCondition}
                 onChange={this.handleConditionSelect}
+                data-testid={getDataTestid(`${TESTID_PREFIX}.conditionSelector`)}
               >
                 {filterConditions.map((condition) => {
                   return (
-                    <option value={condition.filter} key={condition.filter}>
+                    <option
+                      value={condition.filter} 
+                      key={condition.filter}
+                      data-testid={getDataTestid(`${TESTID_PREFIX}.conditionOption`, condition.filter)}
+                    >
                       {condition.displayText}
                     </option>
                   );
@@ -372,7 +387,10 @@ export default class FilterDirective extends Component {
                 <option disabled="disabled" role="separator">
                   &#x2500;&#x2500;&#x2500;&#x2500;
                 </option>
-                <option value="CUSTOMCONDITION">
+                <option 
+                  value="CUSTOMCONDITION"
+                  data-testid={getDataTestid(`${TESTID_PREFIX}.conditionOption`, 'CUSTOMCONDITION')}
+                >
                   {T.translate(`${PREFIX}.Conditions.CUSTOMCONDITION`)}
                 </option>
               </select>
@@ -406,11 +424,16 @@ export default class FilterDirective extends Component {
             className="btn btn-primary float-left"
             onClick={this.applyDirective}
             disabled={disabled}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.applyButton`)}
           >
             {T.translate('features.DataPrep.Directives.apply')}
           </button>
 
-          <button className="btn btn-link float-right" onClick={this.props.close}>
+          <button
+            className="btn btn-link float-right"
+            onClick={this.props.close}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.cancelButton`)}
+          >
             {T.translate('features.DataPrep.Directives.cancel')}
           </button>
         </div>
@@ -425,6 +448,7 @@ export default class FilterDirective extends Component {
         className={classnames('filter-directive clearfix action-item', {
           active: this.props.isOpen,
         })}
+        data-testid={getDataTestid(`${TESTID_PREFIX}.title`)}
       >
         <span>{T.translate(`${PREFIX}.title`)}</span>
 

--- a/app/cdap/components/DataPrep/Directives/FindAndReplace/index.js
+++ b/app/cdap/components/DataPrep/Directives/FindAndReplace/index.js
@@ -24,8 +24,10 @@ import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import T from 'i18n-react';
 import { setPopoverOffset } from 'components/DataPrep/helper';
 import MouseTrap from 'mousetrap';
+import { getDataTestid } from '../../../../testids/TestidsProvider';
 
 const PREFIX = `features.DataPrep.Directives.FindAndReplace`;
+const TESTID_PREFIX = 'features.dataprep.directives.findAndReplace';
 
 export default class FindAndReplaceDirective extends Component {
   constructor(props) {
@@ -168,10 +170,15 @@ export default class FindAndReplaceDirective extends Component {
               onChange={this.handleFindInputChange}
               placeholder={T.translate(`${PREFIX}.findPlaceholder`)}
               ref={(ref) => (this.findInputBox = ref)}
+              data-testid={getDataTestid(`${TESTID_PREFIX}.oldValueInput`)}
             />
           </div>
           <div>
-            <span className="cursor-pointer" onClick={this.handleExactMatchChange}>
+            <span
+              className="cursor-pointer"
+              onClick={this.handleExactMatchChange}
+              data-testid={getDataTestid(`${TESTID_PREFIX}.exactMatch`)}
+            >
               <span
                 className={classnames('fa', {
                   'fa-square-o': !this.state.exactMatch,
@@ -182,7 +189,11 @@ export default class FindAndReplaceDirective extends Component {
             </span>
           </div>
           <div>
-            <span className="cursor-pointer" onClick={this.handleIgnoreCaseChange}>
+            <span
+              className="cursor-pointer"
+              onClick={this.handleIgnoreCaseChange}
+              data-testid={getDataTestid(`${TESTID_PREFIX}.ignoreCase`)}
+            >
               <span
                 className={classnames('fa', {
                   'fa-square-o': !this.state.ignoreCase,
@@ -206,6 +217,7 @@ export default class FindAndReplaceDirective extends Component {
             onKeyPress={this.handleKeyPress}
             onChange={this.handleReplaceInputChange}
             placeholder={T.translate(`${PREFIX}.replacePlaceholder`)}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.newValueInput`)}
           />
         </div>
 
@@ -216,11 +228,16 @@ export default class FindAndReplaceDirective extends Component {
             className="btn btn-primary float-left"
             onClick={this.applyDirective}
             disabled={this.state.findInput.length === 0}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.applyButton`)}
           >
             {T.translate(`${PREFIX}.buttonLabel`)}
           </button>
 
-          <button className="btn btn-link float-right" onClick={this.props.close}>
+          <button
+            className="btn btn-link float-right"
+            onClick={this.props.close}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.cancelButton`)}
+          >
             {T.translate('features.DataPrep.Directives.cancel')}
           </button>
         </div>
@@ -235,6 +252,7 @@ export default class FindAndReplaceDirective extends Component {
         className={classnames('clearfix action-item', {
           active: this.state.isOpen,
         })}
+        data-testid={getDataTestid(`${TESTID_PREFIX}.title`)}
       >
         <span>{T.translate(`${PREFIX}.title`)}</span>
 

--- a/app/cdap/components/DataPrep/Directives/FindAndReplace/index.js
+++ b/app/cdap/components/DataPrep/Directives/FindAndReplace/index.js
@@ -24,7 +24,7 @@ import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import T from 'i18n-react';
 import { setPopoverOffset } from 'components/DataPrep/helper';
 import MouseTrap from 'mousetrap';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 const PREFIX = `features.DataPrep.Directives.FindAndReplace`;
 const TESTID_PREFIX = 'features.dataprep.directives.findAndReplace';

--- a/app/cdap/components/DataPrep/Directives/Format/index.js
+++ b/app/cdap/components/DataPrep/Directives/Format/index.js
@@ -32,7 +32,7 @@ import { preventPropagation } from 'services/helpers';
 import { columnNameAlreadyExists } from 'components/DataPrep/helper';
 import capitalize from 'lodash/capitalize';
 import Mousetrap from 'mousetrap';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 const PREFIX = 'features.DataPrep.Directives.Format';
 const COPY_NEW_COLUMN_PREFIX = 'features.DataPrep.DataPrepTable.copyToNewColumn';

--- a/app/cdap/components/DataPrep/Directives/Format/index.js
+++ b/app/cdap/components/DataPrep/Directives/Format/index.js
@@ -32,9 +32,11 @@ import { preventPropagation } from 'services/helpers';
 import { columnNameAlreadyExists } from 'components/DataPrep/helper';
 import capitalize from 'lodash/capitalize';
 import Mousetrap from 'mousetrap';
+import { getDataTestid } from '../../../../testids/TestidsProvider';
 
 const PREFIX = 'features.DataPrep.Directives.Format';
 const COPY_NEW_COLUMN_PREFIX = 'features.DataPrep.DataPrepTable.copyToNewColumn';
+const TESTID_PREFIX = 'features.dataprep.directives.format';
 const VALID_TYPES = ['string', 'date', 'datetime'];
 
 export default class Format extends Component {
@@ -260,11 +262,16 @@ export default class Format extends Component {
           className="btn btn-primary float-left"
           disabled={this.isApplyDisabled()}
           onClick={this.getConcatExpressionAndApply}
+          data-testid={getDataTestid(`${TESTID_PREFIX}.submenu.concat.applyButton`)}
         >
           {T.translate('features.DataPrep.Directives.apply')}
         </button>
 
-        <button className="btn btn-link float-right" onClick={this.setDefaultFormatPopoverState}>
+        <button
+          className="btn btn-link float-right"
+          onClick={this.setDefaultFormatPopoverState}
+          data-testid={getDataTestid(`${TESTID_PREFIX}.submenu.concat.cancelButton`)}
+        >
           {T.translate('features.DataPrep.Directives.cancel')}
         </button>
       </div>
@@ -285,6 +292,7 @@ export default class Format extends Component {
           onChange={this.setNewColumnInput}
           placeholder={T.translate(`${COPY_NEW_COLUMN_PREFIX}.inputPlaceholder`)}
           autoFocus
+          data-testid={getDataTestid(`${TESTID_PREFIX}.submenu.concat.newColumnNameInput`)}
         />
         {columnNameAlreadyExists(this.state.newColumnInput) ? (
           <WarningContainer message={T.translate(`${COPY_NEW_COLUMN_PREFIX}.inputDuplicate`)} />
@@ -307,16 +315,22 @@ export default class Format extends Component {
           placeholder={T.translate(`${PREFIX}.Formats.CONCATENATE.inputPlaceholder`)}
           onChange={this.setFormatInput}
           autoFocus
+          data-testid={getDataTestid(`${TESTID_PREFIX}.submenu.concat.stringInput`)}
         />
         <Input
           type="select"
           className="concatenate-option-select"
           onChange={this.setConcatOption}
           value={this.state.concatOption}
+          data-testid={getDataTestid(`${TESTID_PREFIX}.submenu.concat.optionSelector`)}
         >
           {this.CONCATENATE_OPTIONS.map((option) => {
             return (
-              <option key={option.name} value={option.name}>
+              <option
+                key={option.name}
+                value={option.name}
+                data-testid={getDataTestid(`${TESTID_PREFIX}.submenu.concat.option`, option.name)}
+              >
                 {option.label}
               </option>
             );
@@ -324,7 +338,11 @@ export default class Format extends Component {
         </Input>
         <div>{T.translate(`${PREFIX}.Formats.CONCATENATE.addDescription`)}</div>
 
-        <div className="create-new-column-line" onClick={this.toggleCreateNewColumn}>
+        <div
+          className="create-new-column-line"
+          onClick={this.toggleCreateNewColumn}
+          data-testid={getDataTestid(`${TESTID_PREFIX}.submenu.concat.copyToNewColumn`)}
+        >
           <span className="fa fa-fw">
             <IconSVG name={this.state.createNewColumn ? 'icon-check-square' : 'icon-square-o'} />
           </span>
@@ -355,6 +373,7 @@ export default class Format extends Component {
             active: this.state.formatPopoverOpen === option.name,
           })}
           onClick={option.onClick}
+          data-testid={getDataTestid(`${TESTID_PREFIX}.option`, option.name)}
         >
           {T.translate(`${PREFIX}.Formats.${option.name}.label`)}
           {option.name === 'CONCATENATE' ? (
@@ -392,6 +411,7 @@ export default class Format extends Component {
             active: this.props.isOpen && !this.state.isDisabled,
             disabled: this.state.isDisabled,
           })}
+          data-testid={getDataTestid(`${TESTID_PREFIX}.title`)}
         >
           <span>{T.translate(`${PREFIX}.title`)}</span>
 

--- a/app/cdap/components/DataPrep/Directives/Hash/index.tsx
+++ b/app/cdap/components/DataPrep/Directives/Hash/index.tsx
@@ -23,7 +23,7 @@ import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import MouseTrap from 'mousetrap';
 import { setPopoverOffset } from 'components/DataPrep/helper';
 import { preventPropagation } from 'services/helpers';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 require('./Hash.scss');
 

--- a/app/cdap/components/DataPrep/Directives/Hash/index.tsx
+++ b/app/cdap/components/DataPrep/Directives/Hash/index.tsx
@@ -23,10 +23,12 @@ import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import MouseTrap from 'mousetrap';
 import { setPopoverOffset } from 'components/DataPrep/helper';
 import { preventPropagation } from 'services/helpers';
+import { getDataTestid } from '../../../../testids/TestidsProvider';
 
 require('./Hash.scss');
 
 const PREFIX = 'features.DataPrep.Directives.Hash';
+const TESTID_PREFIX = 'features.dataprep.directives.hash';
 const VALID_TYPES = ['string', 'byte[]'];
 
 interface IHashProps {
@@ -170,7 +172,11 @@ export default class Hash extends Component<IHashProps> {
   public renderEncode = () => {
     const encode = (
       <div>
-        <span className="cursor-pointer" onClick={this.toggleEncode}>
+        <span
+          className="cursor-pointer"
+          onClick={this.toggleEncode}
+          data-testid={getDataTestid(`${TESTID_PREFIX}.encode`)}
+        >
           <span
             className={classnames('fa', {
               'fa-square-o': !this.state.encode,
@@ -202,10 +208,18 @@ export default class Hash extends Component<IHashProps> {
                 className="form-control mousetrap"
                 value={this.state.selectedHashAlgorithm}
                 onChange={this.handleHashAlgorithmSelect}
+                data-testid={getDataTestid(`${TESTID_PREFIX}.hashSelector`)}
               >
                 {hashAlgorithms.map((algorithm) => {
                   return (
-                    <option value={algorithm.algorithm} key={algorithm.algorithm}>
+                    <option
+                      value={algorithm.algorithm}
+                      key={algorithm.algorithm}
+                      data-testid={getDataTestid(
+                        `${TESTID_PREFIX}.hashOptions`,
+                        algorithm.algorithm
+                      )}
+                    >
                       {algorithm.displayText}
                     </option>
                   );
@@ -232,11 +246,19 @@ export default class Hash extends Component<IHashProps> {
         <hr />
 
         <div className="action-buttons">
-          <button className="btn btn-primary float-left" onClick={this.applyDirective}>
+          <button
+            className="btn btn-primary float-left"
+            onClick={this.applyDirective}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.applyButton`)}
+          >
             {T.translate('features.DataPrep.Directives.apply')}
           </button>
 
-          <button className="btn btn-link float-right" onClick={this.props.close}>
+          <button
+            className="btn btn-link float-right"
+            onClick={this.props.close}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.cancelButton`)}
+          >
             {T.translate('features.DataPrep.Directives.cancel')}
           </button>
         </div>
@@ -252,6 +274,7 @@ export default class Hash extends Component<IHashProps> {
           active: this.props.isOpen && !this.state.isDisabled,
           disabled: this.state.isDisabled,
         })}
+        data-testid={getDataTestid(`${TESTID_PREFIX}.title`)}
       >
         <span>{T.translate(`${PREFIX}.title`)}</span>
 

--- a/app/cdap/components/DataPrep/Directives/KeepColumn/index.js
+++ b/app/cdap/components/DataPrep/Directives/KeepColumn/index.js
@@ -21,7 +21,7 @@ import T from 'i18n-react';
 import { execute } from 'components/DataPrep/store/DataPrepActionCreator';
 import DataPrepStore from 'components/DataPrep/store';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 const PREFIX = 'features.DataPrep.Directives.Keep';
 const TESTID_PREFIX = 'features.dataprep.directives.keepColumn';

--- a/app/cdap/components/DataPrep/Directives/KeepColumn/index.js
+++ b/app/cdap/components/DataPrep/Directives/KeepColumn/index.js
@@ -21,7 +21,10 @@ import T from 'i18n-react';
 import { execute } from 'components/DataPrep/store/DataPrepActionCreator';
 import DataPrepStore from 'components/DataPrep/store';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
+import { getDataTestid } from '../../../../testids/TestidsProvider';
+
 const PREFIX = 'features.DataPrep.Directives.Keep';
+const TESTID_PREFIX = 'features.dataprep.directives.keepColumn';
 
 export default class KeepColumnDirective extends Component {
   constructor(props) {
@@ -60,7 +63,11 @@ export default class KeepColumnDirective extends Component {
     }
 
     return (
-      <div className="keep-column-directive clearfix action-item" onClick={this.applyDirective}>
+      <div
+        className="keep-column-directive clearfix action-item"
+        onClick={this.applyDirective}
+        data-testid={getDataTestid(`${TESTID_PREFIX}.title`)}
+      >
         <span>{title}</span>
       </div>
     );

--- a/app/cdap/components/DataPrep/Directives/MarkAsError/index.js
+++ b/app/cdap/components/DataPrep/Directives/MarkAsError/index.js
@@ -26,7 +26,7 @@ import DataPrepStore from 'components/DataPrep/store';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import IconSVG from 'components/shared/IconSVG';
 import MouseTrap from 'mousetrap';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 require('./MarkAsError.scss');
 

--- a/app/cdap/components/DataPrep/Directives/MarkAsError/index.js
+++ b/app/cdap/components/DataPrep/Directives/MarkAsError/index.js
@@ -26,10 +26,13 @@ import DataPrepStore from 'components/DataPrep/store';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import IconSVG from 'components/shared/IconSVG';
 import MouseTrap from 'mousetrap';
+import { getDataTestid } from '../../../../testids/TestidsProvider';
 
 require('./MarkAsError.scss');
 
 const PREFIX = 'features.DataPrep.Directives.MarkAsError';
+const TESTID_PREFIX = 'features.dataprep.directives.markAsError';
+
 const addPrefix = (directive) => [`IS${directive}`, `ISNOT${directive}`];
 const conditionsOptions = [
   'EMPTY',
@@ -268,7 +271,11 @@ export default class MarkAsError extends Component {
     if (['TEXTREGEX', ...dateFormatConditions].indexOf(this.state.selectedCondition) === -1) {
       ignoreCase = (
         <div>
-          <span className="cursor-pointer" onClick={this.toggleIgnoreCase}>
+          <span
+            className="cursor-pointer"
+            onClick={this.toggleIgnoreCase}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.ignoreCase`)}
+          >
             <IconSVG
               className="fa"
               name={this.state.ignoreCase ? 'icon-check-square-o' : 'icon-square-o'}
@@ -290,6 +297,7 @@ export default class MarkAsError extends Component {
             onChange={this.handleConditionValueChange}
             placeholder={T.translate(`${PREFIX}.Placeholders.${this.state.selectedCondition}`)}
             ref={(ref) => (this.conditionValueRef = ref)}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.textConditionInput`)}
           />
         </div>
         {ignoreCase}
@@ -313,6 +321,7 @@ export default class MarkAsError extends Component {
           placeholder={T.translate(`${PREFIX}.Placeholders.CUSTOMCONDITION`, {
             column: this.props.column,
           })}
+          data-testid={getDataTestid(`${TESTID_PREFIX}.customConditionInput`)}
         />
       </div>
     );
@@ -341,6 +350,7 @@ export default class MarkAsError extends Component {
                 className="form-control mousetrap"
                 value={this.state.selectedCondition}
                 onChange={this.setCondition}
+                data-testid={getDataTestid(`${TESTID_PREFIX}.conditionSelector`)}
               >
                 {markAsConditions.map((condition, i) => {
                   const key = `${condition.id}${i}`;
@@ -352,7 +362,11 @@ export default class MarkAsError extends Component {
                     );
                   }
                   return (
-                    <option value={condition.id} key={key}>
+                    <option
+                      value={condition.id}
+                      key={key}
+                      data-testid={getDataTestid(`${TESTID_PREFIX}.conditionOption`, condition.id)}
+                    >
                       {condition.displayText}
                     </option>
                   );
@@ -400,11 +414,16 @@ export default class MarkAsError extends Component {
             className="btn btn-primary float-left"
             onClick={this.applyDirective}
             disabled={this.isApplyDisabled()}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.applyButton`)}
           >
             {T.translate('features.DataPrep.Directives.apply')}
           </button>
 
-          <button className="btn btn-link float-right" onClick={this.props.close}>
+          <button
+            className="btn btn-link float-right"
+            onClick={this.props.close}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.cancelButton`)}
+          >
             {T.translate('features.DataPrep.Directives.cancel')}
           </button>
         </div>
@@ -419,6 +438,7 @@ export default class MarkAsError extends Component {
         className={classnames('clearfix action-item', {
           active: this.state.isOpen,
         })}
+        data-testid={getDataTestid(`${TESTID_PREFIX}.title`)}
       >
         <span>{T.translate(`${PREFIX}.title`)}</span>
 

--- a/app/cdap/components/DataPrep/Directives/MaskData/MaskSelection/index.js
+++ b/app/cdap/components/DataPrep/Directives/MaskData/MaskSelection/index.js
@@ -24,10 +24,12 @@ import DataPrepStore from 'components/DataPrep/store';
 import { execute } from 'components/DataPrep/store/DataPrepActionCreator';
 import Mousetrap from 'mousetrap';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
+import { getDataTestid } from '../../../../../testids/TestidsProvider';
 
 const POPOVERTHETHERCLASSNAME = 'highlight-popover';
 const CELLHIGHLIGHTCLASSNAME = 'cl-highlight';
 const PREFIX = `features.DataPrep.Directives.MaskSelection`;
+const TESTID_PREFIX = 'features.dataprep.directives.maskData';
 
 export default class MaskSelection extends Component {
   constructor(props) {
@@ -134,10 +136,15 @@ export default class MaskSelection extends Component {
           <div
             className={`btn btn-primary ${CELLHIGHLIGHTCLASSNAME}`}
             onClick={this.applyDirective}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.customSelectionApplyButton`)}
           >
             {T.translate('features.DataPrep.Directives.apply')}
           </div>
-          <div className={`btn ${CELLHIGHLIGHTCLASSNAME}`} onClick={this.props.onClose}>
+          <div
+            className={`btn ${CELLHIGHLIGHTCLASSNAME}`}
+            onClick={this.props.onClose}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.customSelectionCancelButton`)}
+          >
             {T.translate(`${PREFIX}.cancelBtnLabel`)}
           </div>
         </PopoverBody>

--- a/app/cdap/components/DataPrep/Directives/MaskData/MaskSelection/index.js
+++ b/app/cdap/components/DataPrep/Directives/MaskData/MaskSelection/index.js
@@ -24,7 +24,7 @@ import DataPrepStore from 'components/DataPrep/store';
 import { execute } from 'components/DataPrep/store/DataPrepActionCreator';
 import Mousetrap from 'mousetrap';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
-import { getDataTestid } from '../../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 const POPOVERTHETHERCLASSNAME = 'highlight-popover';
 const CELLHIGHLIGHTCLASSNAME = 'cl-highlight';

--- a/app/cdap/components/DataPrep/Directives/MaskData/index.js
+++ b/app/cdap/components/DataPrep/Directives/MaskData/index.js
@@ -23,7 +23,7 @@ import { execute } from 'components/DataPrep/store/DataPrepActionCreator';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import DataPrepStore from 'components/DataPrep/store';
 import T from 'i18n-react';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 require('./MaskData.scss');
 
 const PREFIX = 'features.DataPrep.Directives.MaskData';

--- a/app/cdap/components/DataPrep/Directives/MaskData/index.js
+++ b/app/cdap/components/DataPrep/Directives/MaskData/index.js
@@ -23,9 +23,11 @@ import { execute } from 'components/DataPrep/store/DataPrepActionCreator';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import DataPrepStore from 'components/DataPrep/store';
 import T from 'i18n-react';
+import { getDataTestid } from '../../../../testids/TestidsProvider';
 require('./MaskData.scss');
 
 const PREFIX = 'features.DataPrep.Directives.MaskData';
+const TESTID_PREFIX = 'features.dataprep.directives.maskData';
 
 export default class MaskData extends Component {
   constructor(props) {
@@ -115,17 +117,29 @@ export default class MaskData extends Component {
     return (
       <div className="mask-fields second-level-popover" onClick={this.preventPropagation}>
         <div className="mask-field-options">
-          <div onClick={this.maskLast4Digits} className="option">
+          <div
+            onClick={this.maskLast4Digits}
+            className="option"
+            data-testid={getDataTestid(`${TESTID_PREFIX}.options.last4Chars`)}
+          >
             {T.translate(`${PREFIX}.option1`)}
           </div>
         </div>
         <div className="mask-field-options">
-          <div onClick={this.maskLast2Digits} className="option">
+          <div
+            onClick={this.maskLast2Digits}
+            className="option"
+            data-testid={getDataTestid(`${TESTID_PREFIX}.options.last2Chars`)}
+          >
             {T.translate(`${PREFIX}.option2`)}
           </div>
         </div>
         <div className="mask-field-options">
-          <div onClick={this.maskCustomSelection} className="option">
+          <div
+            onClick={this.maskCustomSelection}
+            className="option"
+            data-testid={getDataTestid(`${TESTID_PREFIX}.options.customSelection`)}
+          >
             {T.translate(`${PREFIX}.option3`)}
           </div>
         </div>
@@ -133,7 +147,11 @@ export default class MaskData extends Component {
           <hr />
         </div>
         <div className="mask-field-options">
-          <div onClick={this.maskByShuffling} className="option">
+          <div
+            onClick={this.maskByShuffling}
+            className="option"
+            data-testid={getDataTestid(`${TESTID_PREFIX}.options.shuffling`)}
+          >
             {T.translate(`${PREFIX}.option4`)}
           </div>
         </div>
@@ -148,6 +166,7 @@ export default class MaskData extends Component {
           active: this.props.isOpen && this.isDirectiveEnabled(),
           disabled: !this.isDirectiveEnabled(),
         })}
+        data-testid={getDataTestid(`${TESTID_PREFIX}.title`)}
       >
         <span className="option">{T.translate(`${PREFIX}.menuLabel`)}</span>
 

--- a/app/cdap/components/DataPrep/Directives/MergeColumns/index.js
+++ b/app/cdap/components/DataPrep/Directives/MergeColumns/index.js
@@ -25,11 +25,14 @@ import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import { columnNameAlreadyExists } from 'components/DataPrep/helper';
 import WarningContainer from 'components/shared/WarningContainer';
 import { setPopoverOffset } from 'components/DataPrep/helper';
+import { getDataTestid } from '../../../../testids/TestidsProvider';
 
 import T from 'i18n-react';
 require('./MergeColumns.scss');
 
 const PREFIX = `features.DataPrep.Directives.Merge`;
+const TESTID_PREFIX = 'features.dataprep.directives.mergeColumns';
+
 const DEFAULT_DELIMITER = 'COMMA';
 const DELIMITER_MAP = {
   COMMA: ',',
@@ -165,6 +168,7 @@ export default class MergeColumnsDirective extends Component {
           onChange={this.handleCustomDelimiterChange}
           autoFocus
           placeholder={T.translate(`${PREFIX}.customDelimiterPlaceholder`)}
+          data-testid={getDataTestid(`${TESTID_PREFIX}.customDelimiterInput`)}
         />
       </div>
     );
@@ -191,11 +195,19 @@ export default class MergeColumnsDirective extends Component {
 
         <div className="columns-order">
           <span className="columns-names">
-            <span>{this.state.firstColumn}</span>
+            <span data-testid={getDataTestid(`${TESTID_PREFIX}.firstColumnName`)}>
+              {this.state.firstColumn}
+            </span>
             <hr />
-            <span>{this.state.secondColumn}</span>
+            <span data-testid={getDataTestid(`${TESTID_PREFIX}.secondColumnName`)}>
+              {this.state.secondColumn}
+            </span>
           </span>
-          <span className="fa fa-exchange" onClick={this.switchColumnOrder} />
+          <span
+            className="fa fa-exchange"
+            onClick={this.switchColumnOrder}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.changeOrder`)}
+          />
         </div>
 
         <br />
@@ -207,10 +219,15 @@ export default class MergeColumnsDirective extends Component {
             className="form-control mousetrap"
             value={this.state.selectedDelimiter}
             onChange={this.handleDelimiterSelect}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.delimiterSelector`)}
           >
             {mergeDelimiters.map((delimiterOption) => {
               return (
-                <option value={delimiterOption.delimiter} key={delimiterOption.delimiter}>
+                <option
+                  value={delimiterOption.delimiter}
+                  key={delimiterOption.delimiter}
+                  data-testid={getDataTestid(`${TESTID_PREFIX}.delimiterOption`, delimiterOption.delimiter)}
+                >
                   {delimiterOption.displayText}
                 </option>
               );
@@ -218,7 +235,10 @@ export default class MergeColumnsDirective extends Component {
             <option disabled="disabled" role="separator">
               &#x2500;&#x2500;&#x2500;&#x2500;
             </option>
-            <option value="CUSTOMDELIMITER">
+            <option
+              value="CUSTOMDELIMITER"
+              data-testid={getDataTestid(`${TESTID_PREFIX}.delimiterOption`, 'CUSTOMDELIMITER')}
+            >
               {T.translate(`${PREFIX}.Delimiters.CUSTOMDELIMITER`)}
             </option>
           </select>
@@ -239,6 +259,7 @@ export default class MergeColumnsDirective extends Component {
             onChange={this.handleNewColumnInputChange}
             placeholder={T.translate(`${PREFIX}.newColumnPlaceholder`)}
             autoFocus
+            data-testid={getDataTestid(`${TESTID_PREFIX}.newColumnNameInput`)}
           />
         </div>
 
@@ -253,11 +274,16 @@ export default class MergeColumnsDirective extends Component {
             className="btn btn-primary float-left"
             onClick={this.applyDirective}
             disabled={disabledCondition}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.applyButton`)}
           >
             {T.translate(`${PREFIX}.buttonLabel`)}
           </button>
 
-          <button className="btn btn-link float-right" onClick={this.props.close}>
+          <button
+            className="btn btn-link float-right"
+            onClick={this.props.close}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.cancelButton`)}
+          >
             {T.translate('features.DataPrep.Directives.cancel')}
           </button>
         </div>
@@ -272,6 +298,7 @@ export default class MergeColumnsDirective extends Component {
         className={classnames('merge-columns-directive clearfix action-item', {
           active: this.state.isOpen,
         })}
+        data-testid={getDataTestid(`${TESTID_PREFIX}.title`)}
       >
         <span>{T.translate(`${PREFIX}.title`)}</span>
 

--- a/app/cdap/components/DataPrep/Directives/MergeColumns/index.js
+++ b/app/cdap/components/DataPrep/Directives/MergeColumns/index.js
@@ -25,7 +25,7 @@ import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import { columnNameAlreadyExists } from 'components/DataPrep/helper';
 import WarningContainer from 'components/shared/WarningContainer';
 import { setPopoverOffset } from 'components/DataPrep/helper';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 import T from 'i18n-react';
 require('./MergeColumns.scss');

--- a/app/cdap/components/DataPrep/Directives/Parse/Modals/CSVModal.js
+++ b/app/cdap/components/DataPrep/Directives/Parse/Modals/CSVModal.js
@@ -22,7 +22,7 @@ import classnames from 'classnames';
 import T from 'i18n-react';
 import MouseTrap from 'mousetrap';
 import DeprecatedMessage from 'components/shared/DeprecatedMessage';
-import { getDataTestid } from '../../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 const PREFIX = 'features.DataPrep.Directives.Parse';
 const TESTID_PREFIX = 'features.dataprep.directives.parse.modal.csv';

--- a/app/cdap/components/DataPrep/Directives/Parse/Modals/CSVModal.js
+++ b/app/cdap/components/DataPrep/Directives/Parse/Modals/CSVModal.js
@@ -99,7 +99,7 @@ export default class CSVModal extends Component {
           onChange={this.handleCustomDelimiterChange}
           placeholder={T.translate(`${PREFIX}.Parsers.CSV.customPlaceholder`)}
           autoFocus
-          data-testid={getDataTestid(`${TESTID_PREFIX}.customDelimeterInput`)}
+          data-testid={getDataTestid(`${TESTID_PREFIX}.customDelimiterInput`)}
         />
       </div>
     );

--- a/app/cdap/components/DataPrep/Directives/Parse/Modals/DateFormatModal.js
+++ b/app/cdap/components/DataPrep/Directives/Parse/Modals/DateFormatModal.js
@@ -21,7 +21,7 @@ import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 import classnames from 'classnames';
 import T from 'i18n-react';
 import MouseTrap from 'mousetrap';
-import { getDataTestid } from '../../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 const PREFIX = 'features.DataPrep.Directives.Parse';
 const TESTID_PREFIX = 'features.dataprep.directives.parse.modal.dateFormats';

--- a/app/cdap/components/DataPrep/Directives/Parse/Modals/DateFormatModal.js
+++ b/app/cdap/components/DataPrep/Directives/Parse/Modals/DateFormatModal.js
@@ -21,7 +21,10 @@ import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 import classnames from 'classnames';
 import T from 'i18n-react';
 import MouseTrap from 'mousetrap';
+import { getDataTestid } from '../../../../../testids/TestidsProvider';
+
 const PREFIX = 'features.DataPrep.Directives.Parse';
+const TESTID_PREFIX = 'features.dataprep.directives.parse.modal.dateFormats';
 
 const OPTIONS_MAP = {
   OPTION1: {
@@ -166,6 +169,7 @@ export default class DateFormatModal extends Component {
           value={this.state.customFormat}
           onChange={this.handleCustomFormatChange}
           placeholder={T.translate(`${PREFIX}.Parsers.SIMPLEDATE.customPlaceholder`)}
+          data-testid={getDataTestid(`${TESTID_PREFIX}.customFormatInput`)}
           autoFocus
         />
       </div>
@@ -185,13 +189,17 @@ export default class DateFormatModal extends Component {
         className="dataprep-parse-modal cdap-modal"
       >
         <ModalHeader>
-          <span>
+          <span data-testid={getDataTestid(`${TESTID_PREFIX}.title`)}>
             {T.translate(`${PREFIX}.Parsers.SIMPLEDATE.ModalHeader.${this.props.source}`, {
               parser: this.props.parserName,
             })}
           </span>
 
-          <div className="close-section float-right" onClick={this.props.toggle}>
+          <div
+            className="close-section float-right"
+            onClick={this.props.toggle}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.closeButton`)}
+          >
             <span className="fa fa-times" />
           </div>
         </ModalHeader>
@@ -203,7 +211,11 @@ export default class DateFormatModal extends Component {
           <div className="list-options">
             {this.state.options.map((option) => {
               return (
-                <div key={option} onClick={this.selectFormat.bind(this, option)}>
+                <div
+                  key={option}
+                  onClick={this.selectFormat.bind(this, option)}
+                  data-testid={getDataTestid(`${TESTID_PREFIX}.option`, option)}
+                >
                   <span
                     className={classnames('fa', {
                       'fa-circle-o': option !== this.state.format,
@@ -220,10 +232,19 @@ export default class DateFormatModal extends Component {
         </ModalBody>
 
         <ModalFooter>
-          <button className="btn btn-primary" onClick={this.apply} disabled={disabled}>
+          <button
+            className="btn btn-primary"
+            onClick={this.apply}
+            disabled={disabled}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.applyButton`)}
+          >
             {T.translate('features.DataPrep.Directives.apply')}
           </button>
-          <button className="btn btn-secondary" onClick={this.props.toggle}>
+          <button
+            className="btn btn-secondary"
+            onClick={this.props.toggle}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.cancelButton`)}
+          >
             {T.translate('features.DataPrep.Directives.cancel')}
           </button>
         </ModalFooter>

--- a/app/cdap/components/DataPrep/Directives/Parse/Modals/ExcelModal.js
+++ b/app/cdap/components/DataPrep/Directives/Parse/Modals/ExcelModal.js
@@ -22,7 +22,7 @@ import isNil from 'lodash/isNil';
 import MouseTrap from 'mousetrap';
 import classnames from 'classnames';
 import T from 'i18n-react';
-import { getDataTestid } from '../../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 const PREFIX = 'features.DataPrep.Directives.Parse.Parsers.EXCEL';
 const TESTID_PREFIX = 'features.dataprep.directives.parse.modal.excel';

--- a/app/cdap/components/DataPrep/Directives/Parse/Modals/ExcelModal.js
+++ b/app/cdap/components/DataPrep/Directives/Parse/Modals/ExcelModal.js
@@ -22,8 +22,10 @@ import isNil from 'lodash/isNil';
 import MouseTrap from 'mousetrap';
 import classnames from 'classnames';
 import T from 'i18n-react';
+import { getDataTestid } from '../../../../../testids/TestidsProvider';
 
 const PREFIX = 'features.DataPrep.Directives.Parse.Parsers.EXCEL';
+const TESTID_PREFIX = 'features.dataprep.directives.parse.modal.excel';
 
 export default class ExcelModal extends Component {
   constructor(props) {
@@ -114,11 +116,15 @@ export default class ExcelModal extends Component {
         autoFocus={false}
       >
         <ModalHeader>
-          <span>
+          <span data-testid={getDataTestid(`${TESTID_PREFIX}.title`)}>
             {T.translate(`features.DataPrep.Directives.Parse.modalTitle`, { parser: 'Excel' })}
           </span>
 
-          <div className="close-section float-right" onClick={this.props.toggle}>
+          <div
+            className="close-section float-right"
+            onClick={this.props.toggle}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.closeButton`)}
+          >
             <span className="fa fa-times" />
           </div>
         </ModalHeader>
@@ -132,6 +138,7 @@ export default class ExcelModal extends Component {
                 min="0"
                 onChange={this.onSheetSourceChange}
                 checked={this.state.sheetSource === 'sheetnumber'}
+                data-testid={getDataTestid(`${TESTID_PREFIX}.sheetNumberRadio`)}
               />{' '}
               {T.translate(`${PREFIX}.modal.sheetNumberLabel`)}
             </Label>
@@ -142,6 +149,7 @@ export default class ExcelModal extends Component {
                 value={this.state.sheetNumber}
                 onChange={this.onSheetNumberChange}
                 autoFocus
+                data-testid={getDataTestid(`${TESTID_PREFIX}.sheetNumberInput`)}
               />
             ) : null}
           </FormGroup>
@@ -152,6 +160,7 @@ export default class ExcelModal extends Component {
                 value="sheetname"
                 onChange={this.onSheetSourceChange}
                 checked={this.state.sheetSource === 'sheetname'}
+                data-testid={getDataTestid(`${TESTID_PREFIX}.sheetNameRadio`)}
               />{' '}
               {T.translate(`${PREFIX}.modal.sheetNameLabel`)}
             </Label>
@@ -163,11 +172,15 @@ export default class ExcelModal extends Component {
                 onChange={this.onSheetNameChange}
                 placeholder={T.translate(`${PREFIX}.modal.sheetNameInputPlaceholder`)}
                 autoFocus
+                data-testid={getDataTestid(`${TESTID_PREFIX}.sheetNameInput`)}
               />
             ) : null}
           </FormGroup>
           <div className="optional-config">
-            <span onClick={this.toggleSetFirstRow}>
+            <span
+              onClick={this.toggleSetFirstRow}
+              data-testid={getDataTestid(`${TESTID_PREFIX}.setFirstRowAsHeader`)}
+            >
               <span
                 className={classnames('fa', {
                   'fa-square-o': !this.state.firstRowHeader,
@@ -183,10 +196,15 @@ export default class ExcelModal extends Component {
             className="btn btn-primary"
             disabled={this.isApplyDisabled() ? 'disabled' : null}
             onClick={this.applyDirective}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.applyButton`)}
           >
             {T.translate('features.DataPrep.Directives.apply')}
           </button>
-          <button className="btn btn-secondary" onClick={this.props.toggle}>
+          <button
+            className="btn btn-secondary"
+            onClick={this.props.toggle}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.cancelButton`)}
+          >
             {T.translate('features.DataPrep.Directives.cancel')}
           </button>
         </ModalFooter>

--- a/app/cdap/components/DataPrep/Directives/Parse/Modals/LogModal.js
+++ b/app/cdap/components/DataPrep/Directives/Parse/Modals/LogModal.js
@@ -21,7 +21,7 @@ import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 import classnames from 'classnames';
 import T from 'i18n-react';
 import MouseTrap from 'mousetrap';
-import { getDataTestid } from '../../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 const PREFIX = 'features.DataPrep.Directives.Parse';
 const TESTID_PREFIX = 'features.dataprep.directives.parse.modal.log';

--- a/app/cdap/components/DataPrep/Directives/Parse/Modals/SingleFieldModal.js
+++ b/app/cdap/components/DataPrep/Directives/Parse/Modals/SingleFieldModal.js
@@ -20,7 +20,7 @@ import React, { Component } from 'react';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 import T from 'i18n-react';
 import MouseTrap from 'mousetrap';
-import { getDataTestid } from '../../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 const SUFFIX = 'features.DataPrep.Directives.Parse';
 const TESTID_PREFIX = 'features.dataprep.directives.parse.modal.singleField';

--- a/app/cdap/components/DataPrep/Directives/Parse/Modals/SingleFieldModal.js
+++ b/app/cdap/components/DataPrep/Directives/Parse/Modals/SingleFieldModal.js
@@ -20,7 +20,10 @@ import React, { Component } from 'react';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 import T from 'i18n-react';
 import MouseTrap from 'mousetrap';
+import { getDataTestid } from '../../../../../testids/TestidsProvider';
+
 const SUFFIX = 'features.DataPrep.Directives.Parse';
+const TESTID_PREFIX = 'features.dataprep.directives.parse.modal.singleField';
 
 export default class SingleFieldModal extends Component {
   constructor(props) {
@@ -84,6 +87,7 @@ export default class SingleFieldModal extends Component {
           placeholder={T.translate(`${SUFFIX}.Parsers.${parser}.optionalPlaceholder`)}
           value={this.state.optionalText}
           onChange={this.onOptionalTextChange}
+          data-testid={getDataTestid(`${TESTID_PREFIX}.optionalFieldInput`)}
         />
       </div>
     );
@@ -106,9 +110,15 @@ export default class SingleFieldModal extends Component {
         autoFocus={false}
       >
         <ModalHeader>
-          <span>{T.translate(`${SUFFIX}.modalTitle`, { parser: parserTitle })}</span>
+          <span data-testid={getDataTestid(`${TESTID_PREFIX}.title`)}>
+            {T.translate(`${SUFFIX}.modalTitle`, { parser: parserTitle })}
+          </span>
 
-          <div className="close-section float-right" onClick={this.props.toggle}>
+          <div
+            className="close-section float-right"
+            onClick={this.props.toggle}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.closeButton`)}
+          >
             <span className="fa fa-times" />
           </div>
         </ModalHeader>
@@ -123,6 +133,7 @@ export default class SingleFieldModal extends Component {
               placeholder={T.translate(`${SUFFIX}.Parsers.${parser}.placeholder`)}
               value={this.state.text}
               onChange={this.onTextChange}
+              data-testid={getDataTestid(`${TESTID_PREFIX}.mainFieldInput`)}
               autoFocus
             />
           </div>
@@ -131,10 +142,19 @@ export default class SingleFieldModal extends Component {
         </ModalBody>
 
         <ModalFooter>
-          <button className="btn btn-primary" disabled={disabled} onClick={this.apply}>
+          <button
+            className="btn btn-primary"
+            disabled={disabled}
+            onClick={this.apply}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.applyButton`)}
+          >
             {T.translate('features.DataPrep.Directives.apply')}
           </button>
-          <button className="btn btn-secondary" onClick={this.props.toggle}>
+          <button
+            className="btn btn-secondary"
+            onClick={this.props.toggle}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.cancelButton`)}
+          >
             {T.translate('features.DataPrep.Directives.cancel')}
           </button>
         </ModalFooter>

--- a/app/cdap/components/DataPrep/Directives/Parse/Modals/XmlToJsonModal.tsx
+++ b/app/cdap/components/DataPrep/Directives/Parse/Modals/XmlToJsonModal.tsx
@@ -19,7 +19,7 @@ import T from 'i18n-react';
 import Mousetrap from 'mousetrap';
 import classnames from 'classnames';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
-import { getDataTestid } from '../../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 const PREFIX = 'features.DataPrep.Directives.Parse';
 const TESTID_PREFIX = 'features.dataprep.directives.parse.modal.xmlToJson';

--- a/app/cdap/components/DataPrep/Directives/Parse/index.js
+++ b/app/cdap/components/DataPrep/Directives/Parse/index.js
@@ -31,7 +31,7 @@ import XmlToJsonModal from 'components/DataPrep/Directives/Parse/Modals/XmlToJso
 import DataPrepStore from 'components/DataPrep/store';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import { setPopoverOffset } from 'components/DataPrep/helper';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 const SUFFIX = 'features.DataPrep.Directives.Parse';
 const TESTID_PREFIX = 'features.dataprep.directives.parse';

--- a/app/cdap/components/DataPrep/Directives/SetCounter/index.js
+++ b/app/cdap/components/DataPrep/Directives/SetCounter/index.js
@@ -25,7 +25,7 @@ import { setPopoverOffset } from 'components/DataPrep/helper';
 import { execute } from 'components/DataPrep/store/DataPrepActionCreator';
 import { preventPropagation } from 'services/helpers';
 import Mousetrap from 'mousetrap';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 require('./SetCounter.scss');
 

--- a/app/cdap/components/DataPrep/Directives/SetCounter/index.js
+++ b/app/cdap/components/DataPrep/Directives/SetCounter/index.js
@@ -25,10 +25,12 @@ import { setPopoverOffset } from 'components/DataPrep/helper';
 import { execute } from 'components/DataPrep/store/DataPrepActionCreator';
 import { preventPropagation } from 'services/helpers';
 import Mousetrap from 'mousetrap';
+import { getDataTestid } from '../../../../testids/TestidsProvider';
 
 require('./SetCounter.scss');
 
 const PREFIX = `features.DataPrep.Directives.SetCounter`;
+const TESTID_PREFIX = 'features.dataprep.directives.setCounter';
 
 export default class SetCounterDirective extends Component {
   constructor(props) {
@@ -116,6 +118,7 @@ export default class SetCounterDirective extends Component {
         value={this.state.ifCondition}
         onChange={this.handleStateValueChange.bind(this, 'ifCondition')}
         placeholder={T.translate(`${PREFIX}.ifConditionPlaceholder`)}
+        data-testid={getDataTestid(`${TESTID_PREFIX}.customConditionInput`)}
       />
     );
   }
@@ -127,10 +130,18 @@ export default class SetCounterDirective extends Component {
           className="form-control"
           value={this.state.selectedCondition}
           onChange={this.handleStateValueChange.bind(this, 'selectedCondition')}
+          data-testid={getDataTestid(`${TESTID_PREFIX}.conditionSelector`)}
         >
           {this.conditions.map((condition) => {
             return (
-              <option key={condition} value={condition}>
+              <option
+                key={condition}
+                value={condition}
+                data-testid={getDataTestid(
+                  `${TESTID_PREFIX}.conditionOption`,
+                  condition
+                )}
+              >
                 {T.translate(`${PREFIX}.Conditions.${condition}`)}
               </option>
             );
@@ -152,6 +163,7 @@ export default class SetCounterDirective extends Component {
           className="form-control"
           value={this.state.incrementBy}
           onChange={this.handleStateValueChange.bind(this, 'incrementBy')}
+          data-testid={getDataTestid(`${TESTID_PREFIX}.counterIncrementInput`)}
         />
       </div>
     );
@@ -168,6 +180,7 @@ export default class SetCounterDirective extends Component {
           value={this.state.variableName}
           onChange={this.handleStateValueChange.bind(this, 'variableName')}
           placeholder={T.translate(`${PREFIX}.variableNamePlaceholder`)}
+          data-testid={getDataTestid(`${TESTID_PREFIX}.counterNameInput`)}
         />
       </div>
     );
@@ -198,11 +211,16 @@ export default class SetCounterDirective extends Component {
             className="btn btn-primary float-left"
             onClick={this.applyDirective}
             disabled={disabled}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.applyButton`)}
           >
             {T.translate('features.DataPrep.Directives.apply')}
           </button>
 
-          <button className="btn btn-link float-right" onClick={this.props.close}>
+          <button
+            className="btn btn-link float-right"
+            onClick={this.props.close}
+            data-testid={getDataTestid(`${TESTID_PREFIX}.cancelButton`)}
+          >
             {T.translate('features.DataPrep.Directives.cancel')}
           </button>
         </div>
@@ -217,6 +235,7 @@ export default class SetCounterDirective extends Component {
         className={classnames('set-counter-directive clearfix action-item', {
           active: this.state.isOpen,
         })}
+        data-testid={getDataTestid(`${TESTID_PREFIX}.title`)}
       >
         <span>{T.translate(`${PREFIX}.title`)}</span>
 

--- a/app/cdap/components/DataPrep/Directives/SwapColumns/index.js
+++ b/app/cdap/components/DataPrep/Directives/SwapColumns/index.js
@@ -21,6 +21,9 @@ import T from 'i18n-react';
 import { execute } from 'components/DataPrep/store/DataPrepActionCreator';
 import DataPrepStore from 'components/DataPrep/store';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
+import { getDataTestid } from '../../../../testids/TestidsProvider';
+
+const TESTID_PREFIX = 'features.dataprep.directives.swapColumns';
 
 export default class SwapColumnsDirective extends Component {
   constructor(props) {
@@ -54,6 +57,7 @@ export default class SwapColumnsDirective extends Component {
       <div
         className="swap-column-directive clearfix action-item"
         onClick={!this.props.isDisabled ? this.applyDirective : undefined}
+        data-testid={getDataTestid(`${TESTID_PREFIX}.title`)}
       >
         <span>{T.translate('features.DataPrep.Directives.Swap.title')}</span>
       </div>

--- a/app/cdap/components/DataPrep/Directives/SwapColumns/index.js
+++ b/app/cdap/components/DataPrep/Directives/SwapColumns/index.js
@@ -21,7 +21,7 @@ import T from 'i18n-react';
 import { execute } from 'components/DataPrep/store/DataPrepActionCreator';
 import DataPrepStore from 'components/DataPrep/store';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 const TESTID_PREFIX = 'features.dataprep.directives.swapColumns';
 

--- a/app/cdap/components/DataPrep/TopPanel/index.js
+++ b/app/cdap/components/DataPrep/TopPanel/index.js
@@ -30,7 +30,7 @@ import IconSVG from 'components/shared/IconSVG';
 import DataPrepPlusButton from 'components/DataPrep/TopPanel/PlusButton';
 import { Theme } from 'services/ThemeHelper';
 import classnames from 'classnames';
-import { getDataTestid } from '../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 const SchemaModal = Loadable({
   loader: () =>

--- a/app/cdap/components/DataPrep/WorkspaceTabs/WorkspaceTab/index.js
+++ b/app/cdap/components/DataPrep/WorkspaceTabs/WorkspaceTab/index.js
@@ -20,7 +20,7 @@ import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import NamespaceStore from 'services/NamespaceStore';
 import IconSVG from 'components/shared/IconSVG';
-import { getDataTestid } from '../../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 require('./WorkspaceTab.scss');
 

--- a/app/cdap/components/EntityCard/FastActions/index.js
+++ b/app/cdap/components/EntityCard/FastActions/index.js
@@ -20,7 +20,7 @@ import React, { Component } from 'react';
 import FastAction from 'components/FastAction';
 import { objectQuery } from 'services/helpers';
 import isNil from 'lodash/isNil';
-import { getDataTestid } from '../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 const TESTID_PREFIX = 'features.entityListView.entity.fastActions';
 

--- a/app/cdap/components/EntityCard/index.js
+++ b/app/cdap/components/EntityCard/index.js
@@ -31,7 +31,7 @@ import capitalize from 'lodash/capitalize';
 import { getCurrentNamespace } from 'services/NamespaceStore';
 import { objectQuery } from 'services/helpers';
 require('./EntityCard.scss');
-import { getDataTestid } from '../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 const TESTID_PREFIX = 'features.entityListView.entity';
 

--- a/app/cdap/components/EntityListView/JustAddedSection/index.js
+++ b/app/cdap/components/EntityListView/JustAddedSection/index.js
@@ -34,7 +34,7 @@ import SearchStoreActions from 'components/EntityListView/SearchStore/SearchStor
 import { SCOPES } from 'services/global-constants';
 import { MyAppApi } from 'api/app';
 require('./JustAddedSection.scss');
-import { getDataTestid } from '../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 const TESTID_PREFIX = 'features.entityListView.justAdded';
 

--- a/app/cdap/components/EntityListView/ListView/index.js
+++ b/app/cdap/components/EntityListView/ListView/index.js
@@ -33,7 +33,7 @@ import {
 import isNil from 'lodash/isNil';
 import { getCurrentNamespace } from 'services/NamespaceStore';
 import { MyAppApi } from 'api/app';
-import { getDataTestid } from '../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 const TESTID_PREFIX = 'features.entityListView';
 

--- a/app/cdap/components/Home/HomeActions/ActionConfig.ts
+++ b/app/cdap/components/Home/HomeActions/ActionConfig.ts
@@ -16,7 +16,7 @@
 
 import T from 'i18n-react';
 import { Theme } from 'services/ThemeHelper';
-import { getDataTestid } from '../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 const PREFIX = 'features.Home';
 const TESTID_PREFIX = 'features.home';
 

--- a/app/cdap/components/shared/ScrollableList/index.js
+++ b/app/cdap/components/shared/ScrollableList/index.js
@@ -20,7 +20,7 @@ import React, { Component } from 'react';
 import IconSVG from 'components/shared/IconSVG';
 import findIndex from 'lodash/findIndex';
 import classnames from 'classnames';
-import { getDataTestid } from '../../../testids/TestidsProvider';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 require('./ScrollableList.scss');
 const TESTID_PREFIX = 'common.components.scrollableList';

--- a/app/cdap/main.js
+++ b/app/cdap/main.js
@@ -65,7 +65,7 @@ import history from 'services/history';
 import { CookieBanner } from 'components/CookieBanner';
 // See ./graphql/fragements/README.md
 import introspectionQueryResultData from '../../graphql/fragments/fragmentTypes.json';
-import { TestidProvider } from './testids/TestidsProvider';
+import { TestidProvider } from '@cdap-ui/testids/TestidsProvider';
 
 require('../ui-utils/url-generator');
 require('font-awesome-sass-loader!./styles/font-awesome.config.js');

--- a/app/cdap/testids/TestidsProvider.tsx
+++ b/app/cdap/testids/TestidsProvider.tsx
@@ -67,7 +67,7 @@ export function getDataTestid(prefixPath: string, siblingKey?: string | number):
   const testidValue = getDataTestidInternal(prefixPath, siblingKey);
 
   // runs only in development
-  if (window.CDAP_CONFIG.uiValidateTestids) {
+  if (window && _get(window, 'CDAP_CONFIG.uiValidateTestids', false)) {
     if (!testidValue) {
       throw new Error(
         `Using a data-testid that is not defined in testids.yaml: 

--- a/app/cdap/testids/testids.yaml
+++ b/app/cdap/testids/testids.yaml
@@ -26,16 +26,197 @@ features:
     tethering:
       tab: ~
   dataprep:
+    columnTextSelection:
+      cell: ~
+      column: ~
+      header: ~
     directives:
+      calculate:
+        option: ~
+        submenu:
+          applyButton: ~
+          cancelButton: ~
+          copyToNewColumn: ~
+          destinationColumnNameInput: ~
+          operandInput: ~
+        title: ~
+      changeDataType:
+        option: ~
+        submenu:
+          decimal:
+            applyButton: ~
+            cancelButton: ~
+            precisionInput: ~
+            roundingOption: ~
+            roundingSelector: ~
+            scaleInput: ~
+        title: ~
+      copyColumn:
+        applyButton: ~
+        cancelButton: ~
+        newColumnNameInput: ~
+        title: ~
+      customTransform:
+        applyButton: ~
+        cancelButton: ~
+        expressionTextarea: ~
+        title: ~
+      defineVariable:
+        applyButton: ~
+        cancelButton: ~
+        columnOption: ~
+        columnSelector: ~
+        conditionOption: ~
+        conditionSelector: ~
+        conditionTextInput: ~
+        customConditionInput: ~
+        summaryText: ~
+        title: ~
+        variableNameInput: ~
+      dropColumn:
+        title: ~
+      encodeDecode:
+        options: ~
+        title: ~
+      explode:
+        options:
+          arrayFlattening: ~
+          delimited: ~
+          recordFlattening: ~
+        title: ~
+      extractFields:
+        modal:
+          delimiters:
+            applyButton: ~
+            cancelButton: ~
+            closeButton: ~
+            customDelimiterInput: ~
+            delimiterOption: ~
+            title: ~
+          patterns:
+            applyButton: ~
+            cancelButton: ~
+            closeButton: ~
+            customPatternInput: ~
+            editPatternInput: ~
+            numDigitsPatternInput: ~
+            patternEndInput: ~
+            patternStartInput: ~
+            patternsOption: ~
+            patternsSelector: ~
+            title: ~
+            togglePatternEdit: ~
+          positions:
+            applyButton: ~
+            cancelButton: ~
+            destinationColumnNameInput: ~
+            modalTrigger: ~
+            selectionRangeText: ~
+        options:
+          delimiters: ~
+          patterns: ~
+          positions: ~
+        title: ~
+      fillNullOrEmpty:
+        applyButton: ~
+        cancelButton: ~
+        fillerValueInput: ~
+        title: ~
+      filter:
+        applyButton: ~
+        cancelButton: ~
+        conditionOption: ~
+        conditionSelector: ~
+        customFilterTextarea: ~
+        ignoreCase: ~
+        keepRows: ~
+        removeRows: ~
+        textFilterInput: ~
+        title: ~
+      findAndReplace:
+        applyButton: ~
+        cancelButton: ~
+        exactMatch: ~
+        ignoreCase: ~
+        newValueInput: ~
+        oldValueInput: ~
+        title: ~
+      format:
+        option: ~
+        submenu:
+          concat:
+            applyButton: ~
+            cancelButton: ~
+            copyToNewColumn: ~
+            newColumnNameInput: ~
+            option: ~
+            optionSelector: ~
+            stringInput: ~
+        title: ~
+      hash:
+        applyButton: ~
+        cancelButton: ~
+        encode: ~
+        hashOptions: ~
+        hashSelector: ~
+        title: ~
+      keepColumn:
+        title: ~
+      markAsError:
+        applyButton: ~
+        cancelButton: ~
+        conditionOption: ~
+        conditionSelector: ~
+        customConditionInput: ~
+        ignoreCase: ~
+        textConditionInput: ~
+        title: ~
+      maskData:
+        customSelectionApplyButton: ~
+        customSelectionCancelButton: ~
+        options:
+          customSelection: ~
+          last2Chars: ~
+          last4Chars: ~
+          shuffling: ~
+        title: ~
+      mergeColumns:
+        applyButton: ~
+        cancelButton: ~
+        changeOrder: ~
+        customDelimiterInput: ~
+        delimiterOption: ~
+        delimiterSelector: ~
+        firstColumnName: ~
+        newColumnNameInput: ~
+        secondColumnName: ~
+        title: ~
       parse:
         modal:
           csv:
             applyButton: ~
             cancelButton: ~
             closeButton: ~
-            customDelimeterInput: ~
+            customDelimiterInput: ~
             firstRowAsHeaderToggle: ~
             option: ~
+            title: ~
+          dateFormats:
+            applyButton: ~
+            cancelButton: ~
+            closeButton: ~
+            customFormatInput: ~
+            option: ~
+            title: ~
+          excel:
+            applyButton: ~
+            cancelButton: ~
+            closeButton: ~
+            setFirstRowAsHeader: ~
+            sheetNameInput: ~
+            sheetNameRadio: ~
+            sheetNumberInput: ~
+            sheetNumberRadio: ~
             title: ~
           log:
             applyButton: ~
@@ -43,6 +224,13 @@ features:
             closeButton: ~
             customLogFormatInput: ~
             option: ~
+            title: ~
+          singleField:
+            applyButton: ~
+            cancelButton: ~
+            closeButton: ~
+            mainFieldInput: ~
+            optionalFieldInput: ~
             title: ~
           xmlToJson:
             applyButton: ~
@@ -52,6 +240,17 @@ features:
             keepStringsToggle: ~
             title: ~
         option: ~
+        title: ~
+      setCounter:
+        applyButton: ~
+        cancelButton: ~
+        conditionOption: ~
+        conditionSelector: ~
+        counterIncrementInput: ~
+        counterNameInput: ~
+        customConditionInput: ~
+        title: ~
+      swapColumns:
         title: ~
     workspace:
       cli:

--- a/jest.config.js
+++ b/jest.config.js
@@ -30,6 +30,7 @@ module.exports = {
     },
   },
   moduleDirectories: ['node_modules', 'jest', __dirname],
+  moduleFileExtensions: [ 'js', 'jsx', 'ts', 'tsx',  'yaml' ],
   moduleNameMapper: {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
       '<rootDir>/__mocks__/fileMock.js',
@@ -52,6 +53,7 @@ module.exports = {
   transform: {
     '.+\\.(css|styl|less|sass|scss)$': 'jest-css-modules-transform',
     '\\.[jt]sx?$': 'babel-jest',
+    '\\.yaml$': 'yaml-jest',
   },
   transformIgnorePatterns: ['<rootDir>/node_modules/?!(@material)/'],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -38,6 +38,7 @@ module.exports = {
     '/^components/': '<rootDir>/app/cdap/components',
     '/^services/': '<rootDir>/app/cdap/services',
     '/^api/': '<rootDir>/app/cdap/api',
+    '^@cdap-ui/(.*)': '<rootDir>/app/cdap/$1',
     '^lib': '<rootDir>/../lib',
     '^mocks': '<rootDir>/__mocks__',
   },

--- a/package.json
+++ b/package.json
@@ -154,7 +154,8 @@
     "url-loader": "3.0.0",
     "webpack": "4.41.2",
     "webpack-cli": "3.3.10",
-    "webpack-livereload-plugin": "2.2.0"
+    "webpack-livereload-plugin": "2.2.0",
+    "yaml-jest": "^1.2.0"
   },
   "dependencies": {
     "@ajainarayanan/react-pan-zoom": "0.0.4",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,6 +40,9 @@
       ],
       "test-utils": [
         "./jest/test-utils"
+      ],
+      "@cdap-ui/*": [
+        "./app/cdap/*"
       ]
     }
   },

--- a/webpack.config.cdap.dev.js
+++ b/webpack.config.cdap.dev.js
@@ -259,6 +259,7 @@ var webpackConfig = {
       api: __dirname + '/app/cdap/api',
       lib: __dirname + '/app/lib',
       styles: __dirname + '/app/cdap/styles',
+      '@cdap-ui': __dirname + '/app/cdap',
       'react-dom': '@hot-loader/react-dom',
     },
   },

--- a/webpack.config.cdap.js
+++ b/webpack.config.cdap.js
@@ -257,6 +257,7 @@ var webpackConfig = {
       api: __dirname + '/app/cdap/api',
       lib: __dirname + '/app/lib',
       styles: __dirname + '/app/cdap/styles',
+      '@cdap-ui': __dirname + '/app/cdap',
     },
   },
   resolveLoader: {

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -201,6 +201,7 @@ var webpackConfig = {
       api: __dirname + '/app/cdap/api',
       wrangler: __dirname + '/app/wrangler',
       styles: __dirname + '/app/cdap/styles',
+      '@cdap-ui': __dirname + '/app/cdap',
     },
   },
   plugins,

--- a/webpack.config.login.js
+++ b/webpack.config.login.js
@@ -192,6 +192,7 @@ var webpackConfig = {
       services: __dirname + '/app/cdap/services',
       styles: __dirname + '/app/cdap/styles',
       api: __dirname + '/app/cdap/api',
+      '@cdap-ui': __dirname + '/app/cdap',
     },
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -23313,6 +23313,13 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
+yaml-jest@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/yaml-jest/-/yaml-jest-1.2.0.tgz#5e863a8c3ce5aa7b9f63e12f8bffd6e2e47b4bf7"
+  integrity sha512-rrUNn3ovs5J8td7i3k6rJfh3leBydnM+3YqKJcVyTFRiSiEAdKMy7uhqBxJfsJ+w1le5AGCkMTldNEMY8oqbPg==
+  dependencies:
+    js-yaml "^4.1.0"
+
 yaml@^1.10.0:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"


### PR DESCRIPTION
# Add data-testids for wrangler directives

## Description
Adds `data-testid` attributes for all of the wrangler column directives.

Also adds the dev-dependency `yaml-jest`. It's required by jest (unit test runner) to be able to import the `testids.yaml` file. `yaml-jest` is a transformer that takes a yaml file and transforms it into a js module consumable by jest.

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [x] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-21039](https://cdap.atlassian.net/browse/CDAP-21039)

## Test Plan
NA

## Screenshots
NA



[CDAP-21039]: https://cdap.atlassian.net/browse/CDAP-21039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ