### PR TITLE
[CDAP-21074] remove calls to list apps api during pipeline deployment

### DIFF
--- a/src/e2e-test/java/io/cdap/cdap/ui/utils/Commands.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/utils/Commands.java
@@ -30,6 +30,7 @@ import io.cdap.e2e.utils.WaitHelper;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.openqa.selenium.By;
+import org.openqa.selenium.ElementClickInterceptedException;
 import org.openqa.selenium.NoAlertPresentException;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.OutputType;
@@ -363,8 +364,8 @@ public class Commands implements CdfHelper {
           "//div[@data-testid='valium-banner-hydrator']//button[@class='close ng-scope']");
       WaitHelper.waitForElementToBeClickable(bannerCloseButton, 180L);
       ElementHelper.clickOnElement(bannerCloseButton);
-    } catch (NoSuchElementException e) {
-      // pass
+    } catch (NoSuchElementException | ElementClickInterceptedException e) {
+      // pass and just wait for the banner to disappear
     }
     WaitHelper.waitForElementToBeHidden(Helper.locateElementByTestId("valium-banner-hydrator"));
   }


### PR DESCRIPTION
# remove calls to list apps api during pipeline deployment

## Description
The list apps (`GET /apps`) call is made before deploying a pipeline to ensure that a pipeline of the same name does not already exist. This check is necessary, because the deployment path in the backend (`PUT /apps/{app-id}`) creates a new version of the application when an existing pipelineName / appId is given.

In the UI, we do not want to call the deploy method before ensuring that the pipeline name does not already exist, in the case where the intent of the user is to create a new pipeline. (If the intent of the user is to edit and create a new version, we do not perform this check, nor call the list apps API).

However, this is not an efficient method of checking the existence of the pipeline name, as in case of instances with large number of pipelines the network overhead and the load on the backend service are high. A better way to check if a pipeline name is available, is to use the `GET /apps/{app-id}` API. This would return a 404 response if the name is available.

**Solution**

Use the `GET /apps/{app-id}` API to ensure that the pipeline name is available.

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [x] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-21074](https://cdap.atlassian.net/browse/CDAP-21074)

## Test Plan
Existing e2e-tests must pass

## Screenshots
NA



[CDAP-21074]: https://cdap.atlassian.net/browse/CDAP-21074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ