### PR TITLE
fix yarn build server with node v22

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build-dev-common-w": "NODE_OPTIONS=\"--openssl-legacy-provider\" NODE_ENV=development parallel-webpack --config=webpack.config.common.js -d --watch",
     "build-prod-dlls": "NODE_OPTIONS=\"--openssl-legacy-provider\" NODE_ENV=production parallel-webpack --config=webpack.config.dlls.js",
     "build-dev-dlls": "NODE_OPTIONS=\"--openssl-legacy-provider\" NODE_ENV=development parallel-webpack --config=webpack.config.dlls.js",
-    "build-server": "webpack --config=webpack.config.server.js",
+    "build-server": "NODE_OPTIONS=\"--openssl-legacy-provider\" webpack --config=webpack.config.server.js",
     "jest": "jest --coverage",
     "jest-w": "jest --watch",
     "karma-test": "node ./node_modules/karma/bin/karma start test/karma-conf.js",


### PR DESCRIPTION
# CDAP UI builds are failing with incompatible node version error

## Description
Summary of changes

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [x] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-21088](https://cdap.atlassian.net/browse/CDAP-21088)

## Test Plan

## Screenshots

```
024-12-07T04:46:53.0953439Z [[1;34mINFO[m] Running 'yarn run build-server' in /runner/_work/cdap-build/cdap-build/cdap-build/cdap/cdap-ui
2024-12-07T04:46:53.0964471Z [[1;34mINFO[m] Changes detected - recompiling the module!
2024-12-07T04:46:53.0971130Z [[1;34mINFO[m] Compiling 7 source files to /runner/_work/cdap-build/cdap-build/cdap-build/cdap/cdap-app-templates/cdap-etl/hydrator-spark-core3_2.12/target/test-classes
2024-12-07T04:46:53.2585131Z [[1;34mINFO[m] yarn run v1.22.19
2024-12-07T04:46:53.3008489Z [[1;34mINFO[m] $ webpack --config=webpack.config.server.js
2024-12-07T04:46:53.3453209Z [[1;34mINFO[m] /runner/_work/cdap-build/cdap-build/cdap-build/cdap/cdap-app-templates/cdap-etl/hydrator-spark-core3_2.12/target/generated-test-sources/hydrator-spark-core-base/src/test/java/io/cdap/cdap/etl/spark/io/StageTrackingInputFormatTest.java: /runner/_work/cdap-build/cdap-build/cdap-build/cdap/cdap-app-templates/cdap-etl/hydrator-spark-core3_2.12/target/generated-test-sources/hydrator-spark-core-base/src/test/java/io/cdap/cdap/etl/spark/io/StageTrackingInputFormatTest.java uses unchecked or unsafe operations.
2024-12-07T04:46:53.3458812Z [[1;34mINFO[m] /runner/_work/cdap-build/cdap-build/cdap-build/cdap/cdap-app-templates/cdap-etl/hydrator-spark-core3_2.12/target/generated-test-sources/hydrator-spark-core-base/src/test/java/io/cdap/cdap/etl/spark/io/StageTrackingInputFormatTest.java: Recompile with -Xlint:unchecked for details.
2024-12-07T04:46:53.3460943Z [[1;34mINFO[m] 
2024-12-07T04:46:53.3462133Z [[1;34mINFO[m] [1m--- [0;32mmaven-checkstyle-plugin:3.1.2:check[m [1m(validate)[m @ [36mhydrator-spark-core3_2.12[0;1m ---[m
2024-12-07T04:46:54.3156114Z [[1;34mINFO[m] Browserslist: caniuse-lite is outdated. Please run:
2024-12-07T04:46:54.3158046Z [[1;34mINFO[m] npx browserslist@latest --update-db
2024-12-07T04:46:54.3159601Z [[1;34mINFO[m] 
2024-12-07T04:46:54.3160915Z [[1;34mINFO[m] Why you should do it regularly:
2024-12-07T04:46:54.3163107Z [[1;34mINFO[m] https://github.com/browserslist/browserslist#browsers-data-updating
2024-12-07T04:46:54.5892161Z [[1;34mINFO[m] node:internal/crypto/hash:79
2024-12-07T04:46:54.5894476Z [[1;34mINFO[m]   this[kHandle] = new _Hash(algorithm, xofLen, algorithmId, getHashCache());
2024-12-07T04:46:54.5896428Z [[1;34mINFO[m]                   ^
2024-12-07T04:46:54.5897820Z [[1;34mINFO[m] 
2024-12-07T04:46:54.5899671Z [[1;34mINFO[m] Error: error:0308010C:digital envelope routines::unsupported
2024-12-07T04:46:54.5901581Z [[1;34mINFO[m]     at new Hash (node:internal/crypto/hash:79:19)
2024-12-07T04:46:54.5903484Z [[1;34mINFO[m]     at Object.createHash (node:crypto:139:10)
2024-12-07T04:46:54.5906336Z [[1;34mINFO[m]     at module.exports (/runner/_work/cdap-build/cdap-build/cdap-build/cdap/cdap-ui/node_modules/webpack/lib/util/createHash.js:135:53)
2024-12-07T04:46:54.5909999Z [[1;34mINFO[m]     at NormalModule._initBuildHash (/runner/_work/cdap-build/cdap-build/cdap-build/cdap/cdap-ui/node_modules/webpack/lib/NormalModule.js:417:16)
2024-12-07T04:46:54.5913727Z [[1;34mINFO[m]     at handleParseError (/runner/_work/cdap-build/cdap-build/cdap-build/cdap/cdap-ui/node_modules/webpack/lib/NormalModule.js:471:10)
2024-12-07T04:46:54.5917096Z [[1;34mINFO[m]     at /runner/_work/cdap-build/cdap-build/cdap-build/cdap/cdap-ui/node_modules/webpack/lib/NormalModule.js:503:5
2024-12-07T04:46:54.5920512Z [[1;34mINFO[m]     at /runner/_work/cdap-build/cdap-build/cdap-build/cdap/cdap-ui/node_modules/webpack/lib/NormalModule.js:358:12
2024-12-07T04:46:54.5923815Z [[1;34mINFO[m]     at /runner/_work/cdap-build/cdap-build/cdap-build/cdap/cdap-ui/node_modules/loader-runner/lib/LoaderRunner.js:373:3
2024-12-07T04:46:54.5927320Z [[1;34mINFO[m]     at iterateNormalLoaders (/runner/_work/cdap-build/cdap-build/cdap-build/cdap/cdap-ui/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
2024-12-07T04:46:54.5930952Z [[1;34mINFO[m]     at iterateNormalLoaders (/runner/_work/cdap-build/cdap-build/cdap-build/cdap/cdap-ui/node_modules/loader-runner/lib/LoaderRunner.js:221:10)
2024-12-07T04:46:54.5941159Z [[1;34mINFO[m]     at /runner/_work/cdap-build/cdap-build/cdap-build/cdap/cdap-ui/node_modules/loader-runner/lib/LoaderRunner.js:236:3
2024-12-07T04:46:54.5943303Z [[1;34mINFO[m]     at context.callback (/runner/_work/cdap-build/cdap-build/cdap-build/cdap/cdap-ui/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
2024-12-07T04:46:54.5945113Z [[1;34mINFO[m]     at /runner/_work/cdap-build/cdap-build/cdap-build/cdap/cdap-ui/node_modules/babel-loader/lib/index.js:55:71
2024-12-07T04:46:54.5946639Z [[1;34mINFO[m]     at process.processTicksAndRejections (node:internal/process/task_queues:105:5) {
2024-12-07T04:46:54.5947734Z [[1;34mINFO[m]   opensslErrorStack: [
2024-12-07T04:46:54.5948904Z [[1;34mINFO[m]     'error:03000086:digital envelope routines::initialization error',
2024-12-07T04:46:54.5950153Z [[1;34mINFO[m]     'error:0308010C:digital envelope routines::unsupported'
2024-12-07T04:46:54.5951104Z [[1;34mINFO[m]   ],
2024-12-07T04:46:54.5952294Z [[1;34mINFO[m]   library: 'digital envelope routines',
2024-12-07T04:46:54.5953329Z [[1;34mINFO[m]   reason: 'unsupported',
2024-12-07T04:46:54.5954208Z [[1;34mINFO[m]   code: 'ERR_OSSL_EVP_UNSUPPORTED'
2024-12-07T04:46:54.5955204Z [[1;34mINFO[m] }
```




[CDAP-21088]: https://cdap.atlassian.net/browse/CDAP-21088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ