### PR TITLE
[CDAP-21096] Add App Fabric Processor service name

### DIFF
--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -292,6 +292,7 @@ features:
         requested: Requested
         status: Status
       appfabric: App Fabric
+      appfabric_processor: App Fabric Processor
       dataset_executor: Dataset Executor
       explore_service: Explore Service
       log_saver: Log Saver


### PR DESCRIPTION
# Add App Fabric Processor service name

## Description

As part of [CDAP-21096](https://cdap.atlassian.net/browse/CDAP-21096) Appfabric will be split into server and processor. Adding a new service `App Fabric Processor` in the CDAP UI.

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-21096](https://cdap.atlassian.net/browse/CDAP-21096)

## Test Plan

Verified by building CDAP sandbox and local image of CDAP UI. See screenshot below.

## Screenshots

<img width="1764" alt="image" src="https://github.com/user-attachments/assets/22f02acd-9bee-47e5-ba72-93250efa5391" />



[CDAP-21096]: https://cdap.atlassian.net/browse/CDAP-21096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-21096]: https://cdap.atlassian.net/browse/CDAP-21096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ