### PR TITLE
fix error stage prop propagation in legacy code

### DIFF
--- a/app/hydrator/controllers/detail/canvas-ctrl.js
+++ b/app/hydrator/controllers/detail/canvas-ctrl.js
@@ -192,6 +192,9 @@ angular.module(PKG.name + '.feature.hydrator')
         this.totalRuns = runs.length;
         this.errorStages = (this.PipelineDetailStore.getState().runErrorDetails[this.runId] || [])
           .map((err) => err.stageName);
+
+        $scope.errorStages = this.errorStages;
+        $scope.$apply();
       }
     });
 


### PR DESCRIPTION
# fix error stage prop propagation in legacy code

The errorStages from the error classification API were not updated in the angularjs DAG view as soon as the errorStages value was available. This was caused by how angularjs propagates values in scope. To update the view as soon as a value is available, we need to force evaluate the scope.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-21100](https://cdap.atlassian.net/browse/CDAP-21100)

## Test Plan
To be added in the e2e tests in a subsequent PR

## Screenshots
NA



[CDAP-21100]: https://cdap.atlassian.net/browse/CDAP-21100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ