### PR TITLE
Fix: inject the size limit constants into globals

### DIFF
--- a/app/cdap/services/global-constants.js
+++ b/app/cdap/services/global-constants.js
@@ -25,7 +25,19 @@ const pluginLabels = {
 };
 const NUMBER_TYPES = ['integer', 'int', 'short', 'long', 'float', 'double', 'bigdecimal'];
 const NATIVE_NUMBER_TYPES = ['integer', 'int', 'short', 'long', 'float', 'double'];
+
+const MemoryUnits = {};
+MemoryUnits.Byte = 1;
+MemoryUnits.KB = 1024 * MemoryUnits.Byte;
+MemoryUnits.MB = 1024 * MemoryUnits.KB;
+MemoryUnits.GB = 1024 * MemoryUnits.MB;
+
+const MIN_PIPELINE_SIZE_FOR_WARNING_BYTES = 2 * MemoryUnits.MB;
+
 const GLOBALS = {
+  MemoryUnits,
+  MIN_PIPELINE_SIZE_FOR_WARNING_BYTES,
+
   pageLevelErrors: {
     'UNKNOWN-NAMESPACE': (invalidNS) => { return `\'namespace:${invalidNS}' was not found.`},
     'UNAUTHORIZED-NAMESPACE': (invalidNS) => { return `You are not authorized to access '${invalidNS}' namespace`},
@@ -380,14 +392,6 @@ const PIPELINE_LOGS_FILTER =
 
 const SNAPSHOT_VERSION = '-SNAPSHOT';
 
-const MemoryUnits = {};
-MemoryUnits.Byte = 1;
-MemoryUnits.KB = 1024 * MemoryUnits.Byte;
-MemoryUnits.MB = 1024 * MemoryUnits.KB;
-MemoryUnits.GB = 1024 * MemoryUnits.MB;
-
-const MIN_PIPELINE_SIZE_FOR_WARNING_BYTES = 2 * MemoryUnits.MB;
-
 export {
   NUMBER_TYPES,
   NATIVE_NUMBER_TYPES,
@@ -403,6 +407,4 @@ export {
   PIPELINE_LOGS_FILTER,
   GENERATED_RUNTIMEARGS,
   SNAPSHOT_VERSION,
-  MemoryUnits,
-  MIN_PIPELINE_SIZE_FOR_WARNING_BYTES,
 };


### PR DESCRIPTION
# Fix: inject the size limit constants into globals

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-21148](https://cdap.atlassian.net/browse/CDAP-21148)

## Test Plan

## Screenshots
![image](https://github.com/user-attachments/assets/5f191974-bf89-4e36-838c-ba1cde05bfcc)




[CDAP-21148]: https://cdap.atlassian.net/browse/CDAP-21148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ