### PR TITLE
Defer pipeline size check to pre-upgrade validation after import

### DIFF
--- a/app/hydrator/controllers/create/toppanel-ctrl.js
+++ b/app/hydrator/controllers/create/toppanel-ctrl.js
@@ -1457,23 +1457,6 @@ class HydratorPlusPlusTopPanelCtrl {
     }
 
     let uploadedFile = files[0];
-
-    try {
-      const pipelineSizeLimit = this.GLOBALS.MIN_PIPELINE_SIZE_FOR_WARNING_BYTES;
-      const pipelineSizeLimitMB = pipelineSizeLimit / this.GLOBALS.MemoryUnits.MB;
-      const pipelineSizeLimitMBRounded = pipelineSizeLimitMB.toFixed(2);
-
-      if (files[0].size > pipelineSizeLimit) {
-        const fileSizeInMB = (files[0].size || 1) / this.GLOBALS.MemoryUnits.MB;
-        const fileSizeInMBRounded = fileSizeInMB.toFixed(2);
-        this.myAlertOnValium.show({
-          type: "warning",
-          content: `File size is ${fileSizeInMBRounded}MB. Pipelines larger than ${pipelineSizeLimitMBRounded}MB may fail during deployment.`,
-        });
-      }
-    } catch (e) {
-      console.error("Unable to check pipeline size.");
-    }
     this.HydratorUpgradeService.validateAndUpgradeConfigFile(uploadedFile, this.getParentVersion());
   }
 

--- a/app/hydrator/services/hydrator-upgrade-service.js
+++ b/app/hydrator/services/hydrator-upgrade-service.js
@@ -15,7 +15,7 @@
  */
 
 class HydratorUpgradeService {
-  constructor($rootScope, myPipelineApi, HydratorPlusPlusLeftPanelStore, $state, $uibModal, HydratorPlusPlusConfigStore, $q, PipelineAvailablePluginsActions, myAlertOnValium, NonStorePipelineErrorFactory) {
+  constructor($rootScope, myPipelineApi, HydratorPlusPlusLeftPanelStore, $state, $uibModal, HydratorPlusPlusConfigStore, $q, PipelineAvailablePluginsActions, myAlertOnValium, NonStorePipelineErrorFactory, GLOBALS) {
     this.$rootScope = $rootScope;
     this.myPipelineApi = myPipelineApi;
     this.$state = $state;
@@ -30,6 +30,7 @@ class HydratorUpgradeService {
     this.PipelineAvailablePluginsActions = PipelineAvailablePluginsActions;
     this.myAlertOnValium = myAlertOnValium;
     this.NonStorePipelineErrorFactory = NonStorePipelineErrorFactory;
+    this.GLOBALS = GLOBALS;
   }
 
   _checkVersionIsInRange(range, version) {
@@ -289,6 +290,27 @@ class HydratorUpgradeService {
       } catch (e) {
         return;
       }
+    }
+
+    // validate that the imported pipeline json is less than 2MB. Otherwise throw a warning.
+    try {
+      const pipelineSizeLimit = this.GLOBALS.MIN_PIPELINE_SIZE_FOR_WARNING_BYTES;
+      const pipelineSizeLimitMB = pipelineSizeLimit / this.GLOBALS.MemoryUnits.MB;
+      const pipelineSizeLimitMBRounded = pipelineSizeLimitMB.toFixed(2);
+
+      const jsonBlob = new Blob([JSON.stringify(jsonData, null, 4)], { type: 'application/json' });
+      const blobSize = jsonBlob.size || 1;
+
+      if (blobSize > pipelineSizeLimit) {
+        const blobSizeInMB = blobSize / this.GLOBALS.MemoryUnits.MB;
+        const blobSizeInMBRounded = blobSizeInMB.toFixed(2);
+        this.myAlertOnValium.show({
+          type: "warning",
+          content: `File size is ${blobSizeInMBRounded}MB. Pipelines larger than ${pipelineSizeLimitMBRounded}MB may fail during deployment.`,
+        });
+      }
+    } catch (e) {
+      console.error("Unable to check pipeline size.");
     }
 
     /**


### PR DESCRIPTION
# Defer pipeline size check to pre-upgrade validation after import

## Description
So that the check also applies for pipeline imports from the resource center modal.

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-21148](https://cdap.atlassian.net/browse/CDAP-21148)

## Test Plan

## Screenshots
![image](https://github.com/user-attachments/assets/94f66e63-fafd-4f6b-b92b-6595563e7b51)




[CDAP-21148]: https://cdap.atlassian.net/browse/CDAP-21148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ