### PR TITLE
[CDAP-21161] use appsCount API in the NamespaceAdmin page

### DIFF
--- a/app/cdap/api/pipeline.js
+++ b/app/cdap/api/pipeline.js
@@ -41,6 +41,7 @@ var pipelineV1AppContextPath = `${pipelineV1AppPath}/contexts/:context`;
 
 export const MyPipelineApi = {
   list: apiCreator(dataSrc, 'GET', 'REQUEST', '/namespaces/:namespace/apps'),
+  pipelinesCount: apiCreator(dataSrc, 'GET', 'REQUEST', '/namespaces/:namespace/apps/count'),
   publish: apiCreator(dataSrc, 'PUT', 'REQUEST', basepath),
 
   schedule: apiCreator(dataSrc, 'POST', 'REQUEST', `${schedulePath}/resume`),

--- a/app/cdap/components/NamespaceAdmin/store/ActionCreator.ts
+++ b/app/cdap/components/NamespaceAdmin/store/ActionCreator.ts
@@ -53,16 +53,14 @@ export function getNamespaceDetail(namespace) {
     });
   });
 
-  MyPipelineApi.list({ namespace, artifactName: PIPELINE_ARTIFACTS, latestOnly: true }).subscribe(
-    (pipelines) => {
-      Store.dispatch({
-        type: NamespaceAdminActions.setPipelinesCount,
-        payload: {
-          pipelinesCount: pipelines && Array.isArray(pipelines) ? pipelines.length : 0,
-        },
-      });
-    }
-  );
+  MyPipelineApi.pipelinesCount({ namespace }).subscribe((pipelinesCount) => {
+    Store.dispatch({
+      type: NamespaceAdminActions.setPipelinesCount,
+      payload: {
+        pipelinesCount,
+      },
+    });
+  });
 
   MyDatasetApi.list({ namespace }).subscribe((datasets) => {
     Store.dispatch({


### PR DESCRIPTION
# use appsCount API in the NamespaceAdmin page

## Description
Remove the listApps API call in NamespaceAdmin page and use countApps API instead.

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [x] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-21161](https://cdap.atlassian.net/browse/CDAP-21161)

## Test Plan
Existing tests should pass.

## Screenshots
<img width="1511" alt="Screenshot 2025-06-24 at 9 09 34 AM" src="https://github.com/user-attachments/assets/b155a7aa-58ef-4b9d-a04a-dde3ac06cb00" />




[CDAP-21161]: https://cdap.atlassian.net/browse/CDAP-21161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ