### PR TITLE
[🍒 - 6.10][CDAP-21182] Update polling logic in PipelineDetails/runLevelInfo

### DIFF
--- a/app/cdap/components/PipelineDetails/RunLevelInfo/CurrentRunIndex.tsx
+++ b/app/cdap/components/PipelineDetails/RunLevelInfo/CurrentRunIndex.tsx
@@ -33,6 +33,7 @@ import Popover from 'components/shared/Popover';
 import { GLOBALS } from 'services/global-constants';
 
 const PREFIX = 'features.PipelineDetails.RunLevel';
+const DEFAULT_POLL_RUNS_INTERVAL_MS = 10000; // 10s
 
 const StyledNoRunsHeader = styled.div`
   display: flex;
@@ -108,13 +109,26 @@ const CurrentRunIndex = ({
       versionId: version,
       programType: GLOBALS.programInfo[artifactName].programType,
       programName: GLOBALS.programInfo[artifactName].programName,
+      limit: 1,
     };
-    getRunsForVersion(params);
     const interval = setInterval(() => {
-      getRunsForVersion(params);
-    }, 2000);
-    return () => clearInterval(interval);
-  }, []);
+      getRunsForVersion(params, clearPollInterval);
+    }, DEFAULT_POLL_RUNS_INTERVAL_MS);
+
+    function clearPollInterval() {
+      if (interval) {
+        clearInterval(interval);
+      }
+    }
+
+    // Avoid the delay caused by the interval by calling the API early
+    // if this succeeds, we clear the interval and avoid further polling
+    getRunsForVersion(params, clearPollInterval);
+
+    // if the version changes, clear the old interval before running this
+    // effect again
+    return clearPollInterval;
+  }, [version]);
 
   if (!reversedRuns || currentRunIndex === -1) {
     return (

--- a/app/cdap/components/PipelineDetails/store/ActionCreator.js
+++ b/app/cdap/components/PipelineDetails/store/ActionCreator.js
@@ -225,9 +225,12 @@ const getRuns = (params) => {
   return runsFetch;
 };
 
-const getRunsForVersion = (params) => {
+const getRunsForVersion = (params, clearPollIntervalCb = () => {}) => {
   MyPipelineApi.getVersionedRuns(params).subscribe((runs) => {
     setVersionHasRun(runs.length > 0);
+    if (runs.length > 0 && typeof clearPollIntervalCb === 'function') {
+      clearPollIntervalCb();
+    }
   });
 };
 


### PR DESCRIPTION
# Cherrypick of #1330 

## Description
Short-term fix for decreasing pipeline runs call. The UI used to poll a complete set of run ids every 2s. We have increased the poll interval to 10s and updated the polling logic to stop polling once we have a successful retrieval of at least one run for a pipeline version.


## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [x] Cherry Pick

## Links
Jira: [CDAP-21182](https://cdap.atlassian.net/browse/CDAP-21182)

## Test Plan

## Screenshots




[CDAP-21182]: https://cdap.atlassian.net/browse/CDAP-21182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ