### PR TITLE
[CDAP-21185] uptake mui table in compute profiles tab of namespace admin page

### DIFF
--- a/app/cdap/components/Cloud/Profiles/ListView/index.js
+++ b/app/cdap/components/Cloud/Profiles/ListView/index.js
@@ -19,14 +19,12 @@ import PropTypes from 'prop-types';
 import { getCurrentNamespace } from 'services/NamespaceStore';
 import { Link } from 'react-router-dom';
 import T from 'i18n-react';
-import classnames from 'classnames';
 import IconSVG from 'components/shared/IconSVG';
 import LoadingSVG from 'components/shared/LoadingSVG';
 import orderBy from 'lodash/orderBy';
 import ConfirmationModal from 'components/shared/ConfirmationModal';
 import AutoScaleBadge from 'components/Cloud/Profiles/AutoScaleBadge';
 import ProfilesStore, { PROFILE_STATUSES } from 'components/Cloud/Profiles/Store';
-import { alpha, Box, Button } from '@material-ui/core';
 import {
   getProfiles,
   deleteProfile,
@@ -47,19 +45,17 @@ import { CLOUD, SYSTEM_NAMESPACE } from 'services/global-constants';
 import { preventPropagation } from 'services/helpers';
 import findIndex from 'lodash/findIndex';
 import { SCOPES } from 'services/global-constants';
-import {
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  TableSortLabel,
-} from '@material-ui/core';
-require('./ListView.scss');
-import styled from 'styled-components';
+import { Box, Table, TableBody, TableHead, TableSortLabel } from '@material-ui/core';
 import history from 'services/history';
+import {
+  StyledStarIcon,
+  StyledTableCell,
+  StyledTableContainer,
+  StyledTableRow,
+  StyledViewAllButton,
+} from './styles';
+
+require('./ListView.scss');
 
 const PREFIX = 'features.Cloud.Profiles';
 
@@ -118,75 +114,6 @@ const SORT_METHODS = {
 };
 
 const NUM_PROFILES_TO_SHOW = 5;
-
-const StyledTableContainer = styled(TableContainer).attrs(() => ({
-  component: Paper,
-  elevation: 10,
-}))`
-  margin-top: 1.3rem;
-`;
-
-const StyledTableCell = styled(TableCell)`
-  font-size: 1rem;
-
-  &.default-star {
-    cursor: pointer;
-  }
-
-  &.default-star {
-    .default-profile {
-      color: var(--brand-primary-color);
-    }
-
-    .not-default-profile {
-      display: none;
-    }
-  }
-
-  &.enabled-label {
-    color: ${(props) => {
-      return props.theme.palette.green[100];
-    }};
-  }
-
-  &.disabled-label {
-    color: ${(props) => {
-      return props.theme.palette.red[100];
-    }};
-  }
-`;
-
-const StyledTableRow = styled(TableRow)`
-  &.highlighted {
-    border: 2px solid
-      ${(props) => {
-        return props.theme.palette.green[200];
-      }};
-    background-color: ${(props) => {
-      return alpha(props.theme.palette.green[200], 0.1);
-    }};
-  }
-
-  & {
-    cursor: pointer;
-  }
-
-  &.native-profile {
-    cursor: not-allowed;
-  }
-
-  &:hover {
-    .default-star {
-      .not-default-profile {
-        display: inline-block;
-      }
-    }
-  }
-`;
-
-const StyledViewAllButton = styled(Button)`
-  margin: 10px 0;
-`;
 
 class ProfilesListView extends Component {
   state = {
@@ -412,13 +339,8 @@ class ProfilesListView extends Component {
     };
     return (
       <StyledTableRow
-        className={
-          ('highlighted',
-          classnames({
-            'native-profile': isNativeProfile,
-            highlighted: profileName === this.props.newProfile,
-          }))
-        }
+        isNativeProfile={isNativeProfile}
+        isNewProfile={profileName === this.props.newProfile}
         onClick={
           !isNativeProfile
             ? () => history.push(`/ns/${namespace}/profiles/details/${profile.name}`)
@@ -428,13 +350,13 @@ class ProfilesListView extends Component {
         key={uuidV4()}
       >
         <StyledTableCell
-          className="default-star"
+          defaultStar={true}
           onClick={this.setProfileAsDefault.bind(this, profileName)}
         >
           {profileIsDefault ? (
-            <IconSVG name="icon-star" className="default-profile" />
+            <StyledStarIcon name="icon-star" profileIsDefault={profileIsDefault} />
           ) : (
-            <IconSVG name="icon-star-o" className="not-default-profile" />
+            <StyledStarIcon name="icon-star-o" />
           )}
         </StyledTableCell>
         <StyledTableCell
@@ -465,7 +387,7 @@ class ProfilesListView extends Component {
         <StyledTableCell>{getNodeHours(profile.overAllMetrics.minutes || '--')}</StyledTableCell>
         <StyledTableCell>{profile.schedulesCount}</StyledTableCell>
         <StyledTableCell>{profile.triggersCount}</StyledTableCell>
-        <StyledTableCell className={`${profileStatus}-label`}>
+        <StyledTableCell profileStatus={profileStatus}>
           {T.translate(`${PREFIX}.common.${profileStatus}`)}
         </StyledTableCell>
         <StyledTableCell>

--- a/app/cdap/components/Cloud/Profiles/ListView/index.js
+++ b/app/cdap/components/Cloud/Profiles/ListView/index.js
@@ -23,11 +23,10 @@ import classnames from 'classnames';
 import IconSVG from 'components/shared/IconSVG';
 import LoadingSVG from 'components/shared/LoadingSVG';
 import orderBy from 'lodash/orderBy';
-import ViewAllLabel from 'components/shared/ViewAllLabel';
 import ConfirmationModal from 'components/shared/ConfirmationModal';
 import AutoScaleBadge from 'components/Cloud/Profiles/AutoScaleBadge';
 import ProfilesStore, { PROFILE_STATUSES } from 'components/Cloud/Profiles/Store';
-import { alpha } from '@material-ui/core';
+import { alpha, Box, Button } from '@material-ui/core';
 import {
   getProfiles,
   deleteProfile,
@@ -183,6 +182,10 @@ const StyledTableRow = styled(TableRow)`
       }
     }
   }
+`;
+
+const StyledViewAllButton = styled(Button)`
+  margin: 10px 0;
 `;
 
 class ProfilesListView extends Component {
@@ -533,12 +536,15 @@ class ProfilesListView extends Component {
     return (
       <div className="profiles-list-view">
         {this.renderProfilesTable()}
-        <ViewAllLabel
-          arrayToLimit={this.state.profiles}
-          limit={NUM_PROFILES_TO_SHOW}
-          viewAllState={this.state.viewAll}
-          toggleViewAll={this.toggleViewAll}
-        />
+        {this.state.profiles.length > NUM_PROFILES_TO_SHOW && (
+          <Box display="flex" flexDirection="row-reverse">
+            <StyledViewAllButton variant="outlined" color="primary" onClick={this.toggleViewAll}>
+              {this.state.viewAll
+                ? T.translate(`${PREFIX}.ListView.viewLess`)
+                : T.translate(`${PREFIX}.ListView.viewAll`)}
+            </StyledViewAllButton>
+          </Box>
+        )}
         {this.renderDeleteConfirmationModal()}
         {this.renderError()}
       </div>

--- a/app/cdap/components/Cloud/Profiles/ListView/index.js
+++ b/app/cdap/components/Cloud/Profiles/ListView/index.js
@@ -27,6 +27,7 @@ import ViewAllLabel from 'components/shared/ViewAllLabel';
 import ConfirmationModal from 'components/shared/ConfirmationModal';
 import AutoScaleBadge from 'components/Cloud/Profiles/AutoScaleBadge';
 import ProfilesStore, { PROFILE_STATUSES } from 'components/Cloud/Profiles/Store';
+import { alpha } from '@material-ui/core';
 import {
   getProfiles,
   deleteProfile,
@@ -47,7 +48,19 @@ import { CLOUD, SYSTEM_NAMESPACE } from 'services/global-constants';
 import { preventPropagation } from 'services/helpers';
 import findIndex from 'lodash/findIndex';
 import { SCOPES } from 'services/global-constants';
+import {
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TableSortLabel,
+} from '@material-ui/core';
 require('./ListView.scss');
+import styled from 'styled-components';
+import history from 'services/history';
 
 const PREFIX = 'features.Cloud.Profiles';
 
@@ -106,6 +119,71 @@ const SORT_METHODS = {
 };
 
 const NUM_PROFILES_TO_SHOW = 5;
+
+const StyledTableContainer = styled(TableContainer).attrs(() => ({
+  component: Paper,
+  elevation: 10,
+}))`
+  margin-top: 1.3rem;
+`;
+
+const StyledTableCell = styled(TableCell)`
+  font-size: 1rem;
+
+  &.default-star {
+    cursor: pointer;
+  }
+
+  &.default-star {
+    .default-profile {
+      color: var(--brand-primary-color);
+    }
+
+    .not-default-profile {
+      display: none;
+    }
+  }
+
+  &.enabled-label {
+    color: ${(props) => {
+      return props.theme.palette.green[100];
+    }};
+  }
+
+  &.disabled-label {
+    color: ${(props) => {
+      return props.theme.palette.red[100];
+    }};
+  }
+`;
+
+const StyledTableRow = styled(TableRow)`
+  &.highlighted {
+    border: 2px solid
+      ${(props) => {
+        return props.theme.palette.green[200];
+      }};
+    background-color: ${(props) => {
+      return alpha(props.theme.palette.green[200], 0.1);
+    }};
+  }
+
+  & {
+    cursor: pointer;
+  }
+
+  &.native-profile {
+    cursor: not-allowed;
+  }
+
+  &:hover {
+    .default-star {
+      .not-default-profile {
+        display: inline-block;
+      }
+    }
+  }
+`;
 
 class ProfilesListView extends Component {
   state = {
@@ -245,12 +323,12 @@ class ProfilesListView extends Component {
     }
 
     return (
-      <div className="grid-wrapper">
-        <div className="grid grid-container">
+      <StyledTableContainer>
+        <Table>
           {this.renderProfilesTableHeader()}
           {this.renderProfilesTableBody()}
-        </div>
-      </div>
+        </Table>
+      </StyledTableContainer>
     );
   }
 
@@ -268,40 +346,35 @@ class ProfilesListView extends Component {
 
   renderProfilesTableHeader() {
     return (
-      <div className="grid-header">
-        <div className="grid-row sub-header">
-          <div />
-          <div />
-          <div />
-          <div />
-          <div />
-          <div className="sub-title">{T.translate(`${PREFIX}.ListView.pipelineUsage`)}</div>
-          <div />
-          <div />
-          <div />
-          <div />
-          <div />
-        </div>
-        <div className="grid-row">
+      <TableHead>
+        <StyledTableRow>
           {PROFILES_TABLE_HEADERS.map((header, i) => {
             if (header.property) {
               return (
-                <strong
-                  className={classnames('sortable-header', {
-                    active: this.state.sortColumn === header.property,
-                  })}
+                <StyledTableCell
                   key={i}
-                  onClick={this.handleProfilesSort.bind(this, header.property)}
+                  sortDirection={
+                    this.state.sortColumn === header.property ? this.state.sortMethod : false
+                  }
                 >
-                  <span>{header.label}</span>
-                  {this.renderSortIcon(header.property)}
-                </strong>
+                  <TableSortLabel
+                    active={this.state.sortColumn === header.property}
+                    direction={
+                      this.state.sortColumn === header.property
+                        ? this.state.sortMethod
+                        : SORT_METHODS.asc
+                    }
+                    onClick={this.handleProfilesSort.bind(this, header.property)}
+                  >
+                    {header.label}
+                  </TableSortLabel>
+                </StyledTableCell>
               );
             }
-            return <strong key={i}>{header.label}</strong>;
+            return <StyledTableCell key={i}>{header.label}</StyledTableCell>;
           })}
-        </div>
-      </div>
+        </StyledTableRow>
+      </TableHead>
     );
   }
 
@@ -317,7 +390,6 @@ class ProfilesListView extends Component {
     let provisionerName = profile.provisioner.name;
     profile.provisioner.label = this.state.provisionersMap[provisionerName] || provisionerName;
     let profileStatus = PROFILE_STATUSES[profile.status];
-    let Tag = Link;
     const profileName = getProfileNameWithScope(profile.name, profile.scope);
     const isNativeProfile = profileName === CLOUD.DEFAULT_PROFILE_NAME;
     const profileIsDefault = profileName === this.props.defaultProfile;
@@ -335,39 +407,46 @@ class ProfilesListView extends Component {
       }
       return <IconSVG name="icon-more" />;
     };
-    if (isNativeProfile) {
-      Tag = 'div';
-    }
     return (
-      <Tag
-        to={`/ns/${namespace}/profiles/details/${profile.name}`}
-        className={classnames('grid-row grid-link', {
-          'native-profile': isNativeProfile,
-          highlighted: profileName === this.props.newProfile,
-        })}
+      <StyledTableRow
+        className={
+          ('highlighted',
+          classnames({
+            'native-profile': isNativeProfile,
+            highlighted: profileName === this.props.newProfile,
+          }))
+        }
+        onClick={
+          !isNativeProfile
+            ? () => history.push(`/ns/${namespace}/profiles/details/${profile.name}`)
+            : undefined
+        }
+        hover
         key={uuidV4()}
       >
-        <div className="default-star" onClick={this.setProfileAsDefault.bind(this, profileName)}>
+        <StyledTableCell
+          className="default-star"
+          onClick={this.setProfileAsDefault.bind(this, profileName)}
+        >
           {profileIsDefault ? (
             <IconSVG name="icon-star" className="default-profile" />
           ) : (
             <IconSVG name="icon-star-o" className="not-default-profile" />
           )}
-        </div>
-        <div
-          className="profile-label"
+        </StyledTableCell>
+        <StyledTableCell
           title={profile.label || profile.name}
           data-cy={`profile-list-${profile.name}`}
           data-testid={`profile-list-${profile.name}`}
         >
           {profile.label || profile.name}
-        </div>
-        <div>{profile.provisioner.label}</div>
-        <div>
+        </StyledTableCell>
+        <StyledTableCell>{profile.provisioner.label}</StyledTableCell>
+        <StyledTableCell>
           {profile.provisioner.totalProcessingCpusLabel || '--'}
           <AutoScaleBadge properties={profile.provisioner.properties} />
-        </div>
-        <div>{profile.scope}</div>
+        </StyledTableCell>
+        <StyledTableCell>{profile.scope}</StyledTableCell>
         {/*
           We should set the defaults in the metrics call but since it is not certain that we get metrics
           for all the profiles all the time I have added the defaults here in the view
@@ -378,15 +457,15 @@ class ProfilesListView extends Component {
           Also, need to make these properties sortable, using SortableStickyGrid.
           JIRA: CDAP-13895
         */}
-        <div>{profile.oneDayMetrics.runs || '--'}</div>
-        <div>{getNodeHours(profile.oneDayMetrics.minutes || '--')}</div>
-        <div>{getNodeHours(profile.overAllMetrics.minutes || '--')}</div>
-        <div>{profile.schedulesCount}</div>
-        <div>{profile.triggersCount}</div>
-        <div className={`${profileStatus}-label`}>
+        <StyledTableCell>{profile.oneDayMetrics.runs || '--'}</StyledTableCell>
+        <StyledTableCell>{getNodeHours(profile.oneDayMetrics.minutes || '--')}</StyledTableCell>
+        <StyledTableCell>{getNodeHours(profile.overAllMetrics.minutes || '--')}</StyledTableCell>
+        <StyledTableCell>{profile.schedulesCount}</StyledTableCell>
+        <StyledTableCell>{profile.triggersCount}</StyledTableCell>
+        <StyledTableCell className={`${profileStatus}-label`}>
           {T.translate(`${PREFIX}.common.${profileStatus}`)}
-        </div>
-        <div className="grid-item-sm">
+        </StyledTableCell>
+        <StyledTableCell>
           <ActionsPopover
             target={actionsElem}
             namespace={this.props.namespace}
@@ -394,8 +473,8 @@ class ProfilesListView extends Component {
             disabled={isNativeProfile}
             onDeleteClick={this.toggleDeleteConfirmationModal.bind(this, profile)}
           />
-        </div>
-      </Tag>
+        </StyledTableCell>
+      </StyledTableRow>
     );
   };
 
@@ -406,7 +485,7 @@ class ProfilesListView extends Component {
       profiles = profiles.slice(0, NUM_PROFILES_TO_SHOW);
     }
 
-    return <div className="grid-body">{profiles.map(this.renderProfilerow)}</div>;
+    return <TableBody>{profiles.map(this.renderProfilerow)}</TableBody>;
   }
 
   renderDeleteConfirmationModal() {

--- a/app/cdap/components/Cloud/Profiles/ListView/styles.js
+++ b/app/cdap/components/Cloud/Profiles/ListView/styles.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+import { alpha, Button, Paper, TableCell, TableContainer, TableRow } from '@material-ui/core';
+import IconSVG from 'components/shared/IconSVG';
+import styled, { css } from 'styled-components';
+
+export const StyledTableContainer = styled(TableContainer).attrs(() => ({
+  component: Paper,
+  elevation: 10,
+}))`
+  margin-top: 1.3rem;
+`;
+
+export const StyledTableCell = styled(TableCell)`
+  font-size: 1rem;
+
+  ${(props) => css`
+    ${props.defaultStar &&
+      `
+      cursor: pointer;
+    `}
+
+    ${props.profileStatus === 'enabled' &&
+      `
+        color: ${props.theme.palette.green[100]};
+      `}
+
+    ${props.profileStatus === 'disabled' &&
+      `
+        color: ${props.theme.palette.red[100]};
+      `}
+  `}
+`;
+
+export const StyledStarIcon = styled(IconSVG)`
+  color: var(--brand-primary-color);
+  ${(props) =>
+    !props.profileIsDefault &&
+    `
+    display: none;
+  `}
+`;
+
+export const StyledTableRow = styled(TableRow)`
+  cursor: pointer;
+
+  ${(props) => css`
+    ${props.isNativeProfile &&
+      `
+    cursor: not-allowed;
+  `}
+
+    ${props.isNewProfile &&
+      `
+    border: 2px solid ${props.theme.palette.green[200]};
+    background-color: ${alpha(props.theme.palette.green[200], 0.1)};
+  `}
+
+  &:hover {
+      ${StyledStarIcon} {
+        display: inline-block;
+      }
+    }
+  `}
+`;
+
+export const StyledViewAllButton = styled(Button)`
+  margin: 10px 0;
+`;

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -403,6 +403,8 @@ features:
         profileUsage: Profile usage
         schedules: Schedules
         triggers: Triggers
+        viewAll: View all
+        viewLess: View less
   ConfirmationModal:
     cancelDefaultText: Cancel
     confirmDefaultText: OK


### PR DESCRIPTION
# uptake mui table in compute profiles tab of namespace admin page
## Description
Changed to grid based list view  to MUI Table component on compute profiles tab of namespace admin page 

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [x] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-21185](https://cdap.atlassian.net/jira/software/c/projects/CDAP/issues/CDAP-21185)
## Test Plan
Existing tests should pass.
## Screenshots
<img width="1725" alt="Screenshot 2025-07-09 at 11 15 54 AM" src="https://github.com/user-attachments/assets/5b4d1391-f308-4fbd-b54e-297be382e041" />





[CDAP-21185]: https://cdap.atlassian.net/browse/CDAP-21185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ