### PR TITLE
[CDAP-21195] Implement Pagination on Inbound Triggers Sidebar Pipelines List

### DIFF
--- a/app/cdap/components/PipelineTriggers/PipelineListCompositeTab/PipelineCompositeTriggerRow.tsx
+++ b/app/cdap/components/PipelineTriggers/PipelineListCompositeTab/PipelineCompositeTriggerRow.tsx
@@ -69,6 +69,7 @@ interface IPipelineTriggersRowViewProps {
   pipelineName: string;
   triggersGroupToAdd: IProgramStatusTrigger[];
   triggersGroupRunArgsToAdd: ICompositeTriggerRunArgsWithTargets;
+  isEnabledForTriggers?: boolean;
 }
 
 const PipelineCompositeTriggerRow = ({
@@ -82,6 +83,7 @@ const PipelineCompositeTriggerRow = ({
   pipelineName,
   triggersGroupToAdd,
   triggersGroupRunArgsToAdd,
+  isEnabledForTriggers = false,
 }: IPipelineTriggersRowViewProps) => {
   const currentPipelineSelected = () => {
     return triggersGroupToAdd.filter(
@@ -159,6 +161,24 @@ const PipelineCompositeTriggerRow = ({
     dispatch({ type: 'TOGGLE_PAYLOAD' });
   };
 
+  const handleSucceedsCheckboxClick = () => {
+    if (!state.selected) {
+      dispatch({ type: 'COMPLETED' });
+    }
+  };
+
+  const handleKilledCheckboxClick = () => {
+    if (!state.selected) {
+      dispatch({ type: 'KILLED' });
+    }
+  };
+
+  const handleFailedCheckboxClick = () => {
+    if (!state.selected) {
+      dispatch({ type: 'FAILED' });
+    }
+  };
+
   const enabledButtonDisabled = !state.completed && !state.killed && !state.failed;
 
   return (
@@ -175,7 +195,7 @@ const PipelineCompositeTriggerRow = ({
         <AccordionCheckBox
           checked={state.selected}
           color="primary"
-          disabled={enabledButtonDisabled}
+          disabled={!isEnabledForTriggers || enabledButtonDisabled}
           onClick={(e) => handlePipelineCheckClick(e)}
           data-cy={`${pipelineRow}-enable-trigger-btn`}
           data-testid={`${pipelineRow}-enable-trigger-btn`}
@@ -191,10 +211,10 @@ const PipelineCompositeTriggerRow = ({
             <HelperText>{T.translate(`${TRIGGER_PREFIX}.helperText`, { pipelineName })}</HelperText>
             <CheckboxContainer>
               <CheckboxItemContainer
-                onClick={() => !state.selected && dispatch({ type: 'COMPLETED' })}
+                onClick={isEnabledForTriggers ? handleSucceedsCheckboxClick : undefined}
               >
                 <Checkbox
-                  disabled={state.selected}
+                  disabled={!isEnabledForTriggers || state.selected}
                   checked={state.completed}
                   color="primary"
                   size="small"
@@ -202,10 +222,10 @@ const PipelineCompositeTriggerRow = ({
                 <span>{T.translate(`${TRIGGER_PREFIX}.Events.COMPLETED`)}</span>
               </CheckboxItemContainer>
               <CheckboxItemContainer
-                onClick={() => !state.selected && dispatch({ type: 'KILLED' })}
+                onClick={isEnabledForTriggers ? handleKilledCheckboxClick : undefined}
               >
                 <Checkbox
-                  disabled={state.selected}
+                  disabled={!isEnabledForTriggers || state.selected}
                   checked={state.killed}
                   color="primary"
                   size="small"
@@ -214,10 +234,10 @@ const PipelineCompositeTriggerRow = ({
               </CheckboxItemContainer>
 
               <CheckboxItemContainer
-                onClick={() => !state.selected && dispatch({ type: 'FAILED' })}
+                onClick={isEnabledForTriggers ? handleFailedCheckboxClick : undefined}
               >
                 <Checkbox
-                  disabled={state.selected}
+                  disabled={!isEnabledForTriggers || state.selected}
                   checked={state.failed}
                   color="primary"
                   size="small"
@@ -239,7 +259,7 @@ const PipelineCompositeTriggerRow = ({
           </CardContent>
           <CardActions>
             <TriggerCardButton
-              disabled={state.selected}
+              disabled={!isEnabledForTriggers || state.selected}
               onClick={handlePayloadToggleClick}
               data-cy={`${triggeringPipelineInfo.id}-trigger-config-btn`}
               data-testid={`${triggeringPipelineInfo.id}-trigger-config-btn`}

--- a/app/cdap/components/PipelineTriggers/PipelineListCompositeTab/index.tsx
+++ b/app/cdap/components/PipelineTriggers/PipelineListCompositeTab/index.tsx
@@ -14,15 +14,21 @@
  * the License.
  */
 
-import React, { useEffect, useReducer } from 'react';
+import React, { useEffect, useReducer, useState } from 'react';
 import styled from 'styled-components';
 import {
   changeMaxConcurrentRuns,
   changeNamespace,
   changeTriggersType,
   enableGroupTrigger,
+  fetchTriggersAndApps,
+  isLastPipelinesPage,
+  fetchPipelinesList,
+  setNameFilter,
+  updateCurrentPage,
+  updatePageSize,
 } from 'components/PipelineTriggers/store/PipelineTriggersActionCreator';
-import { connect } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 import PipelineTriggersActions from 'components/PipelineTriggers/store/PipelineTriggersActions';
 import PipelineTriggersTypes from 'components/PipelineTriggers/store/PipelineTriggersTypes';
 import T from 'i18n-react';
@@ -39,15 +45,16 @@ import {
 } from 'components/PipelineTriggers/store/ScheduleTypes';
 import ConfigTabs from 'components/PipelineTriggers/ScheduleRuntimeArgs/Tabs/TabConfig';
 import {
-  PipelineCount,
   PipelineListContainer,
   PipelineListHeader,
-  PipelineName,
+  PipelineNameHeading,
   PipelineTriggerButton,
   PipelineTriggerHeader,
+  RefreshTimeLabel,
   SearchTriggerTextField,
+  StyledRefreshIcon,
 } from 'components/PipelineTriggers/shared.styles';
-import { InputAdornment, TextField, Tooltip, withStyles } from '@material-ui/core';
+import { InputAdornment, TablePagination, TextField, Tooltip, withStyles } from '@material-ui/core';
 import SearchIcon from '@material-ui/icons/Search';
 import {
   initialAvailablePipelineListState,
@@ -56,9 +63,11 @@ import {
 import PayloadConfigModal from 'components/PipelineTriggers/PayloadConfigModal';
 import PipelineCompositeTriggerRow from './PipelineCompositeTriggerRow';
 import { DEFAULT_TRIGGER_MAX_CONCURRENT_RUNS } from '../store/PipelineTriggersStore';
+import { getDataTestid } from '@cdap-ui/testids/TestidsProvider';
 
 const TRIGGER_PREFIX = 'features.PipelineTriggers';
 const PREFIX = `${TRIGGER_PREFIX}.SetTriggers`;
+const TESTID_PREFIX = 'features.pipelineTriggers.setTriggers';
 
 const CloseTabIconButton = styled(IconButton)`
   float: right;
@@ -87,7 +96,7 @@ const PipelineListTabDiv = styled.div`
 `;
 
 const SelectedGroupPipelinesContainer = styled.div`
-  margin: 20px 0;
+  margin: 10px 0;
   font-weight: bold;
 `;
 
@@ -137,12 +146,13 @@ const CustomTooltip = withStyles(() => {
 
 interface IPipelineListCompositeTabViewProps {
   existingTriggers: ISchedule[];
-  pipelineList: IPipelineInfo[];
+  paginatedPipelineList: IPipelineInfo[][];
   triggersGroupToAdd: IProgramStatusTrigger[];
   triggersGroupRunArgsToAdd: ICompositeTriggerRunArgsWithTargets;
   selectedNamespace: string;
   selectedTriggersType: string;
   pipelineName: string;
+  pipelineType: string;
   expandedPipeline: string;
   toggleExpandPipeline: (pipeline: string) => void;
   configureError: string;
@@ -153,10 +163,11 @@ interface IPipelineListCompositeTabViewProps {
 
 const PipelineListCompositeTabView = ({
   existingTriggers,
-  pipelineList,
+  paginatedPipelineList,
   triggersGroupToAdd,
   triggersGroupRunArgsToAdd,
   pipelineName,
+  pipelineType,
   selectedNamespace,
   selectedTriggersType,
   expandedPipeline,
@@ -166,12 +177,22 @@ const PipelineListCompositeTabView = ({
   maxConcurrentRuns = DEFAULT_TRIGGER_MAX_CONCURRENT_RUNS,
 }: IPipelineListCompositeTabViewProps) => {
   const [state, dispatch] = useReducer(triggerNameReducer, initialAvailablePipelineListState);
+  const [isReloading, setIsReloading] = useState(false);
+  const { ready, pageSize, currentPage, lastRefreshTime, nameFilter } = useSelector(
+    ({ triggers }) => triggers
+  );
   const emptyTriggerErrorMsg =
     triggersGroupToAdd.length === 0 ? T.translate(`${PREFIX}.emptyCompositeTriggerError`) : '';
 
   useEffect(() => {
     dispatch({ type: 'SET_NAMESPACE' });
   }, []);
+
+  useEffect(() => {
+    if (!ready && state.namespace) {
+      fetchPipelinesList();
+    }
+  }, [ready]);
 
   const triggeredPipelineInfo = {
     id: pipelineName,
@@ -201,19 +222,7 @@ const PipelineListCompositeTabView = ({
 
   const onSearchPipelineChange = (e) => {
     const searchInput = e.target.value;
-    dispatch({ type: 'SET_SEARCH_INPUT', searchInput });
-  };
-
-  const getFilteredPipelines = () => {
-    if (!state.searchInput) {
-      return pipelineList;
-    }
-    const newFilteredPipelines = pipelineList.filter(
-      (pipeline) =>
-        pipeline.name.toLowerCase().includes(state.searchInput) ||
-        (pipeline.description && pipeline.description.toLowerCase().includes(state.searchInput))
-    );
-    return newFilteredPipelines;
+    setNameFilter(searchInput);
   };
 
   const changeNamespaceEvent = (e) => {
@@ -239,6 +248,25 @@ const PipelineListCompositeTabView = ({
   const configureComputeProfile = (mapping, propertiesConfig = {}) => {
     dispatch({ type: 'COMPUTE_PROFILE', computeProfile: propertiesConfig });
   };
+
+  const handlePageChange = (event: React.MouseEvent | null, page: number) => {
+    updateCurrentPage(page);
+  };
+
+  const handlePageSizeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = event.target;
+    updatePageSize(parseInt(value, 10));
+  };
+
+  const handleRefeshTriggersClick = (event: React.MouseEvent | null) => {
+    setIsReloading(true);
+    setTimeout(() => {
+      setIsReloading(false);
+    }, 500);
+    fetchTriggersAndApps(pipelineName, GLOBALS.programId[pipelineType]);
+  };
+
+  const pipelineList = paginatedPipelineList[currentPage] || [];
 
   return (
     <PipelineListTabDiv>
@@ -322,13 +350,10 @@ const PipelineListCompositeTabView = ({
           <span>{T.translate(`${PREFIX}.selectPipelineInstruction`)}</span>
         </SelectedGroupPipelinesContainer>
       </div>
-      <PipelineCount>
-        {T.translate(`${PREFIX}.pipelineCount`, { count: pipelineList.length })}
-      </PipelineCount>
-
       <SearchTriggerTextField
         onChange={onSearchPipelineChange}
         placeholder="Search available pipelines"
+        value={nameFilter}
         InputProps={{
           startAdornment: (
             <InputAdornment position="start">
@@ -340,36 +365,77 @@ const PipelineListCompositeTabView = ({
         }}
       />
 
-      {pipelineList.length === 0 ? null : (
-        <PipelineListContainer>
-          <PipelineListHeader>
-            <PipelineName>{T.translate(`${TRIGGER_PREFIX}.pipelineName`)}</PipelineName>
-          </PipelineListHeader>
-          {getFilteredPipelines().map((pipeline) => {
-            const triggeringPipelineInfo: ITriggeringPipelineInfo = {
-              id: pipeline.name,
-              namespace: selectedNamespace,
-              description: pipeline.description,
-              workflowName: GLOBALS.programId[pipeline.artifact.name],
-            };
-            return (
-              <PipelineCompositeTriggerRow
-                key={pipeline.name}
-                pipelineRow={pipeline.name}
-                isExpanded={expandedPipeline === pipeline.name}
-                onToggle={toggleExpandPipeline}
-                triggeringPipelineInfo={triggeringPipelineInfo}
-                triggeredPipelineInfo={triggeredPipelineInfo}
-                selectedNamespace={selectedNamespace}
-                configureError={configureError}
-                pipelineName={pipelineName}
-                triggersGroupToAdd={triggersGroupToAdd}
-                triggersGroupRunArgsToAdd={triggersGroupRunArgsToAdd}
-              />
-            );
-          })}
-        </PipelineListContainer>
-      )}
+      <PipelineListContainer>
+        <PipelineListHeader>
+          <PipelineNameHeading>{T.translate(`${TRIGGER_PREFIX}.pipelineName`)}</PipelineNameHeading>
+          <RefreshTimeLabel>
+            {T.translate(`${PREFIX}.lastRefreshedAtLabel`, {
+              datetime: lastRefreshTime,
+            })}
+            <StyledRefreshIcon rotated={isReloading} onClick={handleRefeshTriggersClick} />
+          </RefreshTimeLabel>
+        </PipelineListHeader>
+        {pipelineList.length === 0 ? null : (
+          <div data-testid={getDataTestid(`${TESTID_PREFIX}.pipelines-container`)}>
+            {pipelineList.map((pipeline) => {
+              const triggeringPipelineInfo: ITriggeringPipelineInfo = {
+                id: pipeline.name,
+                namespace: selectedNamespace,
+                description: pipeline.description,
+                workflowName: GLOBALS.programId[pipeline.artifact.name],
+              };
+              return (
+                <PipelineCompositeTriggerRow
+                  key={pipeline.name}
+                  pipelineRow={pipeline.name}
+                  isExpanded={expandedPipeline === pipeline.name}
+                  onToggle={toggleExpandPipeline}
+                  triggeringPipelineInfo={triggeringPipelineInfo}
+                  triggeredPipelineInfo={triggeredPipelineInfo}
+                  selectedNamespace={selectedNamespace}
+                  configureError={configureError}
+                  pipelineName={pipelineName}
+                  triggersGroupToAdd={triggersGroupToAdd}
+                  triggersGroupRunArgsToAdd={triggersGroupRunArgsToAdd}
+                  isEnabledForTriggers={pipeline.isEnabledForTriggers}
+                />
+              );
+            })}
+            <TablePagination
+              rowsPerPageOptions={[5, 10, 25, 50]}
+              component="span"
+              count={-1}
+              rowsPerPage={pageSize}
+              page={currentPage}
+              onPageChange={handlePageChange}
+              onRowsPerPageChange={handlePageSizeChange}
+              labelDisplayedRows={({ from, to }) =>
+                T.translate(`${PREFIX}.pipelinesPaginationLabel`, {
+                  from: Math.min(from, currentPage * pageSize + pipelineList.length),
+                  to: Math.min(to, currentPage * pageSize + pipelineList.length),
+                })
+              }
+              nextIconButtonProps={
+                {
+                  disabled: isLastPipelinesPage(),
+                  'data-testid': getDataTestid(`${TESTID_PREFIX}.pagination-next-btn`),
+                } as any
+              }
+              backIconButtonProps={
+                {
+                  'data-testid': getDataTestid(`${TESTID_PREFIX}.pagination-back-btn`),
+                } as any
+              }
+              SelectProps={{
+                native: true,
+                inputProps: {
+                  'data-testid': getDataTestid(`${TESTID_PREFIX}.pagination-select`),
+                },
+              }}
+            />
+          </div>
+        )}
+      </PipelineListContainer>
       <SelectedGroupPipelinesContainer>
         <ButtonsWrap>
           <PipelineTriggerComputeProfileButton
@@ -415,7 +481,7 @@ const PipelineListCompositeTabView = ({
 const mapStateToProps = (state) => {
   return {
     existingTriggers: state.triggers.enabledTriggers,
-    pipelineList: state.triggers.pipelineList,
+    paginatedPipelineList: state.triggers.paginatedPipelineList,
     triggersGroupToAdd: state.triggers.triggersGroupToAdd,
     triggersGroupRunArgsToAdd: state.triggers.triggersGroupRunArgsToAdd,
     selectedNamespace: state.triggers.selectedNamespace,

--- a/app/cdap/components/PipelineTriggers/PipelineListTab/PipelineTriggersRow.tsx
+++ b/app/cdap/components/PipelineTriggers/PipelineListTab/PipelineTriggersRow.tsx
@@ -65,6 +65,7 @@ interface IPipelineTriggersRowViewProps {
   configureError: string;
   pipelineName: string;
   workflowName: string;
+  isEnabledForTriggers?: boolean;
 }
 
 const PipelineTriggersRow = ({
@@ -77,6 +78,7 @@ const PipelineTriggersRow = ({
   configureError,
   pipelineName,
   workflowName,
+  isEnabledForTriggers = false,
 }: IPipelineTriggersRowViewProps) => {
   const [state, dispatch] = useReducer(triggerConditionReducer, initialInlineTriggerState);
 
@@ -125,6 +127,24 @@ const PipelineTriggersRow = ({
     dispatch({ type: 'TOGGLE_PAYLOAD' });
   };
 
+  const handleSucceedsCheckboxClick = () => {
+    if (!state.selected) {
+      dispatch({ type: 'COMPLETED' });
+    }
+  };
+
+  const handleKilledCheckboxClick = () => {
+    if (!state.selected) {
+      dispatch({ type: 'KILLED' });
+    }
+  };
+
+  const handleFailedCheckboxClick = () => {
+    if (!state.selected) {
+      dispatch({ type: 'FAILED' });
+    }
+  };
+
   const enabledButtonDisabled = !state.completed && !state.killed && !state.failed;
 
   return (
@@ -156,16 +176,37 @@ const PipelineTriggersRow = ({
         </PipelineDescription>
         <HelperText>{T.translate(`${TRIGGER_PREFIX}.helperText`, { pipelineName })}</HelperText>
         <EventsList>
-          <CheckboxItemContainer onClick={() => dispatch({ type: 'COMPLETED' })}>
-            <Checkbox checked={state.completed} color="primary" size="small" />
+          <CheckboxItemContainer
+            onClick={isEnabledForTriggers ? handleSucceedsCheckboxClick : undefined}
+          >
+            <Checkbox
+              disabled={!isEnabledForTriggers}
+              checked={state.completed}
+              color="primary"
+              size="small"
+            />
             <span>{T.translate(`${TRIGGER_PREFIX}.Events.COMPLETED`)}</span>
           </CheckboxItemContainer>
-          <CheckboxItemContainer onClick={() => dispatch({ type: 'KILLED' })}>
-            <Checkbox checked={state.killed} color="primary" size="small" />
+          <CheckboxItemContainer
+            onClick={isEnabledForTriggers ? handleKilledCheckboxClick : undefined}
+          >
+            <Checkbox
+              disabled={!isEnabledForTriggers}
+              checked={state.killed}
+              color="primary"
+              size="small"
+            />
             <span>{T.translate(`${TRIGGER_PREFIX}.Events.KILLED`)}</span>
           </CheckboxItemContainer>
-          <CheckboxItemContainer onClick={() => dispatch({ type: 'FAILED' })}>
-            <Checkbox checked={state.failed} color="primary" size="small" />
+          <CheckboxItemContainer
+            onClick={isEnabledForTriggers ? handleFailedCheckboxClick : undefined}
+          >
+            <Checkbox
+              disabled={!isEnabledForTriggers}
+              checked={state.failed}
+              color="primary"
+              size="small"
+            />
             <span>{T.translate(`${TRIGGER_PREFIX}.Events.FAILED`)}</span>
           </CheckboxItemContainer>
         </EventsList>
@@ -174,7 +215,7 @@ const PipelineTriggersRow = ({
 
         <ActionButtonsContainer>
           <PipelineTriggerButton
-            disabled={enabledButtonDisabled}
+            disabled={!isEnabledForTriggers || enabledButtonDisabled}
             onClick={() => enableScheduleClick()}
             data-cy={`${pipelineRow}-enable-trigger-btn`}
             data-testid={`${pipelineRow}-enable-trigger-btn`}
@@ -182,6 +223,7 @@ const PipelineTriggersRow = ({
             {T.translate(`${PREFIX}.buttonLabel`)}
           </PipelineTriggerButton>
           <PipelineTriggerButton
+            disabled={!isEnabledForTriggers}
             onClick={handlePayloadToggleClick}
             data-cy={`${triggeringPipelineInfo.id}-trigger-config-btn`}
             data-testid={`${triggeringPipelineInfo.id}-trigger-config-btn`}

--- a/app/cdap/components/PipelineTriggers/PipelineListTab/index.tsx
+++ b/app/cdap/components/PipelineTriggers/PipelineListTab/index.tsx
@@ -14,10 +14,17 @@
  * the License.
  */
 
-import React, { useEffect, useReducer } from 'react';
+import React, { useEffect, useReducer, useState } from 'react';
 import styled from 'styled-components';
-import { changeNamespace } from 'components/PipelineTriggers/store/PipelineTriggersActionCreator';
-import { connect } from 'react-redux';
+import {
+  changeNamespace,
+  fetchTriggersAndApps,
+  isLastPipelinesPage,
+  fetchPipelinesList,
+  updateCurrentPage,
+  updatePageSize,
+} from 'components/PipelineTriggers/store/PipelineTriggersActionCreator';
+import { connect, useSelector } from 'react-redux';
 import PipelineTriggersActions from 'components/PipelineTriggers/store/PipelineTriggersActions';
 import PipelineTriggersRow from 'components/PipelineTriggers/PipelineListTab/PipelineTriggersRow';
 import T from 'i18n-react';
@@ -27,16 +34,18 @@ import {
   ITriggeringPipelineInfo,
 } from 'components/PipelineTriggers/store/ScheduleTypes';
 import {
-  PipelineCount,
   PipelineListContainer,
   PipelineListHeader,
-  PipelineName,
+  PipelineNameHeading,
   PipelineTriggerHeader,
+  RefreshTimeLabel,
+  StyledRefreshIcon,
 } from 'components/PipelineTriggers/shared.styles';
 import {
   initialAvailablePipelineListState,
   triggerNameReducer,
 } from 'components/PipelineTriggers/reducer';
+import { TablePagination } from '@material-ui/core';
 
 const TRIGGER_PREFIX = 'features.PipelineTriggers';
 const PREFIX = `${TRIGGER_PREFIX}.SetTriggers`;
@@ -61,9 +70,10 @@ const PipelineListTabDiv = styled.div`
 `;
 
 interface IPipelineListTabViewProps {
-  pipelineList: IPipelineInfo[];
+  paginatedPipelineList: IPipelineInfo[][];
   selectedNamespace: string;
   pipelineName: string;
+  pipelineType: string;
   expandedPipeline: string;
   toggleExpandPipeline: (pipeline: string) => void;
   workflowName: string;
@@ -71,8 +81,9 @@ interface IPipelineListTabViewProps {
 }
 
 const PipelineListTabView = ({
-  pipelineList,
+  paginatedPipelineList,
   pipelineName,
+  pipelineType,
   selectedNamespace,
   expandedPipeline,
   toggleExpandPipeline,
@@ -80,10 +91,18 @@ const PipelineListTabView = ({
   configureError,
 }: IPipelineListTabViewProps) => {
   const [state, dispatch] = useReducer(triggerNameReducer, initialAvailablePipelineListState);
+  const [isReloading, setIsReloading] = useState(false);
+  const { ready, pageSize, currentPage, lastRefreshTime } = useSelector(({ triggers }) => triggers);
 
   useEffect(() => {
     dispatch({ type: 'SET_NAMESPACE' });
   }, []);
+
+  useEffect(() => {
+    if (!ready && state.namespace) {
+      fetchPipelinesList();
+    }
+  }, [ready]);
 
   const triggeredPipelineInfo = {
     id: pipelineName,
@@ -93,6 +112,25 @@ const PipelineListTabView = ({
   const changeNamespaceEvent = (e) => {
     changeNamespace(e.target.value);
   };
+
+  const handlePageChange = (event: React.MouseEvent | null, page: number) => {
+    updateCurrentPage(page);
+  };
+
+  const handlePageSizeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = event.target;
+    updatePageSize(parseInt(value, 10));
+  };
+
+  const handleRefeshTriggersClick = (event: React.MouseEvent | null) => {
+    setIsReloading(true);
+    setTimeout(() => {
+      setIsReloading(false);
+    }, 500);
+    fetchTriggersAndApps(pipelineName, GLOBALS.programId[pipelineType]);
+  };
+
+  const pipelineList = paginatedPipelineList[currentPage] || [];
 
   return (
     <PipelineListTabDiv>
@@ -118,45 +156,67 @@ const PipelineListTabView = ({
           </select>
         </NamespaceSelectorDropdown>
       </div>
-      <PipelineCount>
-        {T.translate(`${PREFIX}.pipelineCount`, { count: pipelineList.length })}
-      </PipelineCount>
-      {pipelineList.length === 0 ? null : (
-        <PipelineListContainer>
-          <PipelineListHeader>
-            <PipelineName>{T.translate(`${TRIGGER_PREFIX}.pipelineName`)}</PipelineName>
-          </PipelineListHeader>
-          {pipelineList.map((pipeline) => {
-            const triggeringPipelineInfo: ITriggeringPipelineInfo = {
-              id: pipeline.name,
-              namespace: selectedNamespace,
-              description: pipeline.description,
-              workflowName: GLOBALS.programId[pipeline.artifact.name],
-            };
-            return (
-              <PipelineTriggersRow
-                key={pipeline.name}
-                pipelineRow={pipeline.name}
-                isExpanded={expandedPipeline === pipeline.name}
-                onToggle={toggleExpandPipeline}
-                triggeringPipelineInfo={triggeringPipelineInfo}
-                triggeredPipelineInfo={triggeredPipelineInfo}
-                selectedNamespace={selectedNamespace}
-                configureError={configureError}
-                pipelineName={pipelineName}
-                workflowName={workflowName}
-              />
-            );
-          })}
-        </PipelineListContainer>
-      )}
+      <PipelineListContainer>
+        <PipelineListHeader>
+          <PipelineNameHeading>{T.translate(`${TRIGGER_PREFIX}.pipelineName`)}</PipelineNameHeading>
+          <RefreshTimeLabel>
+            {T.translate(`${PREFIX}.lastRefreshedAtLabel`, {
+              datetime: lastRefreshTime,
+            })}
+            <StyledRefreshIcon rotated={isReloading} onClick={handleRefeshTriggersClick} />
+          </RefreshTimeLabel>
+        </PipelineListHeader>
+        {pipelineList.length === 0 ? null : (
+          <div>
+            {pipelineList.map((pipeline) => {
+              const triggeringPipelineInfo: ITriggeringPipelineInfo = {
+                id: pipeline.name,
+                namespace: selectedNamespace,
+                description: pipeline.description,
+                workflowName: GLOBALS.programId[pipeline.artifact.name],
+              };
+              return (
+                <PipelineTriggersRow
+                  key={pipeline.name}
+                  pipelineRow={pipeline.name}
+                  isExpanded={expandedPipeline === pipeline.name}
+                  onToggle={toggleExpandPipeline}
+                  triggeringPipelineInfo={triggeringPipelineInfo}
+                  triggeredPipelineInfo={triggeredPipelineInfo}
+                  selectedNamespace={selectedNamespace}
+                  configureError={configureError}
+                  pipelineName={pipelineName}
+                  workflowName={workflowName}
+                  isEnabledForTriggers={pipeline.isEnabledForTriggers}
+                />
+              );
+            })}
+            <TablePagination
+              rowsPerPageOptions={[5, 10, 25, 50]}
+              component="span"
+              count={-1}
+              rowsPerPage={pageSize}
+              page={currentPage}
+              onPageChange={handlePageChange}
+              onRowsPerPageChange={handlePageSizeChange}
+              labelDisplayedRows={({ from, to }) =>
+                T.translate(`${PREFIX}.pipelinesPaginationLabel`, {
+                  from,
+                  to: Math.min(to, currentPage * pageSize + pipelineList.length),
+                })
+              }
+              nextIconButtonProps={{ disabled: isLastPipelinesPage() }}
+            />
+          </div>
+        )}
+      </PipelineListContainer>
     </PipelineListTabDiv>
   );
 };
 
 const mapStateToProps = (state) => {
   return {
-    pipelineList: state.triggers.pipelineList,
+    paginatedPipelineList: state.triggers.paginatedPipelineList,
     selectedNamespace: state.triggers.selectedNamespace,
     pipelineName: state.triggers.pipelineName,
     expandedPipeline: state.triggers.expandedPipeline,

--- a/app/cdap/components/PipelineTriggers/index.tsx
+++ b/app/cdap/components/PipelineTriggers/index.tsx
@@ -108,9 +108,9 @@ const PipelineTriggers = ({
       return <EnabledTriggersTab setTab={setTab} />;
     } else if (activeTab === 1) {
       return pipelineCompositeTriggersEnabled ? (
-        <PipelineListCompositeTab setTab={setTab} />
+        <PipelineListCompositeTab setTab={setTab} pipelineType={pipelineType} />
       ) : (
-        <PipelineListTab />
+        <PipelineListTab pipelineType={pipelineType} />
       );
     }
   };

--- a/app/cdap/components/PipelineTriggers/reducer.ts
+++ b/app/cdap/components/PipelineTriggers/reducer.ts
@@ -68,11 +68,6 @@ export function triggerNameReducer(oldstate, action) {
         namespaceList: nsList,
         namespace: ns,
       };
-    case 'SET_SEARCH_INPUT':
-      return {
-        ...oldstate,
-        searchInput: action.searchInput,
-      };
     case 'NO_TRIGGER_NAME_ERROR':
       return {
         ...oldstate,
@@ -115,7 +110,6 @@ export function triggerNameReducer(oldstate, action) {
 }
 
 export const initialAvailablePipelineListState = {
-  searchInput: '',
   namespaceList: [],
   namespace: '',
   triggerName: '',

--- a/app/cdap/components/PipelineTriggers/shared.styles.tsx
+++ b/app/cdap/components/PipelineTriggers/shared.styles.tsx
@@ -18,6 +18,7 @@ import styled from 'styled-components';
 import AccordionSummary, { AccordionSummaryProps } from '@material-ui/core/AccordionSummary';
 import AccordionDetails from '@material-ui/core/AccordionDetails';
 import ArrowRightIcon from '@material-ui/icons/ArrowRight';
+import RefreshIcon from '@material-ui/icons/Refresh';
 import React from 'react';
 
 export const CaretContainer = styled.div`
@@ -52,6 +53,10 @@ export const PipelineName = styled.div`
   vertical-align: middle;
 `;
 
+export const PipelineNameHeading = styled(PipelineName)`
+  text-decoration: underline;
+`;
+
 export const HelperText = styled.div`
   margin: 5px 0;
 `;
@@ -79,7 +84,8 @@ export const PipelineListHeader = styled.div`
   border-bottom: 1px solid #dedede;
   padding: 5px 0;
   margin: 5px 0 0 23px;
-  text-decoration: underline;
+  display: flex;
+  justify-content: space-between;
 `;
 
 export const PipelineTriggerHeader = styled.div`
@@ -186,4 +192,21 @@ export const SearchTriggerTextField = styled(TextField)`
       border-bottom: 2px solid black;
     }
   }
+`;
+
+export const RefreshTimeLabel = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  font-style: italic;
+  font-size: 0.7rem;
+  color: #666666;
+`;
+
+export const StyledRefreshIcon = styled(RefreshIcon)`
+  cursor: pointer;
+  display: inline-block;
+  transition: ${(props) => (props.rotated ? 'transform 0.5s ease-in-out' : 'transform 0s')};
+
+  transform: ${(props) => (props.rotated ? 'rotate(360deg)' : 'rotate(0deg)')};
 `;

--- a/app/cdap/components/PipelineTriggers/store/PipelineTriggersActionCreator.ts
+++ b/app/cdap/components/PipelineTriggers/store/PipelineTriggersActionCreator.ts
@@ -13,10 +13,12 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
+import debounce from 'lodash/debounce';
 import PipelineTriggersActions from 'components/PipelineTriggers/store/PipelineTriggersActions';
 import PipelineTriggersTypes from 'components/PipelineTriggers/store/PipelineTriggersTypes';
-import PipelineTriggersStore from 'components/PipelineTriggers/store/PipelineTriggersStore';
+import PipelineTriggersStore, {
+  DEFAULT_PAGE_SIZE,
+} from 'components/PipelineTriggers/store/PipelineTriggersStore';
 import NamespaceStore from 'services/NamespaceStore';
 import { MyAppApi } from 'api/app';
 import { MyScheduleApi } from 'api/schedule';
@@ -32,35 +34,79 @@ import {
   ITriggerPropertyMapping,
   ICompositeTriggerRunArgsWithTargets,
   ITriggeringPipelineId,
+  IPipelineListResponse,
 } from 'components/PipelineTriggers/store/ScheduleTypes';
+import moment from 'moment';
 
 const WORKFLOW_TYPE = 'workflows';
 
 export function changeNamespace(namespace: string) {
+  PipelineTriggersStore.dispatch({
+    type: PipelineTriggersActions.changeNamespace,
+    payload: {
+      selectedNamespace: namespace,
+    },
+  });
+  updateCurrentPage(0);
+}
+
+async function fetchPipelines(pageNo: number): Promise<void> {
   const currentNamespace = NamespaceStore.getState().selectedNamespace;
   const state = PipelineTriggersStore.getState().triggers;
-  const pipelineName = state.pipelineName;
   const existingTriggers = state.enabledTriggers;
+  const activeNamespaceView = state.selectedNamespace;
+  const { pipelineName, pageSize, nextPageTokensList, nameFilter } = state;
+  const paginatedPipelineList = [...state.paginatedPipelineList];
+  const nextPageToken = getPageToken(nextPageTokensList, pageNo);
+  if (!paginatedPipelineList[pageNo]) {
+    const listParam = {
+      namespace: activeNamespaceView,
+      pageSize,
+      pageToken: nextPageToken,
+      nameFilter,
+    };
+    try {
+      const res: IPipelineListResponse = await MyAppApi.list(listParam).toPromise();
 
-  MyAppApi.list({
-    namespace,
-  }).subscribe((res: IPipelineInfo[]) => {
-    const pipelineList = _filterPipelineList(
-      existingTriggers,
-      res,
-      currentNamespace,
-      namespace,
-      pipelineName
-    );
+      const pipelineList = _filterPipelineList(
+        existingTriggers,
+        res.applications,
+        currentNamespace,
+        activeNamespaceView,
+        pipelineName
+      );
 
-    PipelineTriggersStore.dispatch({
-      type: PipelineTriggersActions.changeNamespace,
-      payload: {
-        pipelineList,
-        selectedNamespace: namespace,
-      },
-    });
-  });
+      paginatedPipelineList[pageNo] = pipelineList;
+      PipelineTriggersStore.dispatch({
+        type: PipelineTriggersActions.setPaginatedPipelineList,
+        payload: {
+          paginatedPipelineList,
+        },
+      });
+      setNextPageToken(pageNo, res.nextPageToken);
+    } catch (err) {
+      markViewReady();
+    }
+  } else {
+    markViewReady();
+  }
+}
+
+export async function fetchPipelinesList() {
+  const currentPage = PipelineTriggersStore.getState().triggers.currentPage;
+  if (currentPage === 0) {
+    await fetchPipelines(currentPage);
+  }
+
+  if (!isLastPipelinesPage()) {
+    await fetchPipelines(currentPage + 1);
+    const paginatedPipelineList = PipelineTriggersStore.getState().triggers.paginatedPipelineList;
+    if (paginatedPipelineList[currentPage + 1].length === 0) {
+      setNextPageToken(currentPage, undefined);
+    }
+  } else {
+    markViewReady();
+  }
 }
 
 export function changeTriggersType(selectedTriggersType: string) {
@@ -463,35 +509,21 @@ export function fetchTriggersAndApps(
     'schedule-status': 'SCHEDULED',
   };
 
-  const lifecycleManagementEditEnabled = PipelineTriggersStore.getState().triggers
-    .lifecycleManagementEditEnabled;
-  const listParam: any = { namespace: activeNamespaceView };
-  if (lifecycleManagementEditEnabled) {
-    listParam.latestOnly = 'true';
-  }
-  MyScheduleApi.getTriggers(params)
-    .combineLatest(MyAppApi.list(listParam))
-    .subscribe((res) => {
-      const existingTriggers = _transformSchedule(res[0]);
-      const appsList = res[1];
+  MyScheduleApi.getTriggers(params).subscribe((res) => {
+    const existingTriggers = _transformSchedule(res);
 
-      const pipelineList = _filterPipelineList(
-        existingTriggers,
-        appsList,
-        namespace,
-        activeNamespaceView,
-        pipeline
-      );
-
-      PipelineTriggersStore.dispatch({
-        type: PipelineTriggersActions.setTriggersAndPipelineList,
-        payload: {
-          pipelineList,
-          enabledTriggers: existingTriggers,
-          selectedNamespace: activeNamespaceView,
-        },
-      });
+    PipelineTriggersStore.dispatch({
+      type: PipelineTriggersActions.resetTriggers,
+      payload: {
+        enabledTriggers: existingTriggers,
+        selectedNamespace: activeNamespaceView,
+      },
     });
+
+    const lastRefreshTime = moment().format('DD/MM/YYYY HH:mm A');
+    setLastRefreshTime(lastRefreshTime);
+    fetchPipelinesList();
+  });
 }
 
 export function disableSchedule(schedule: ISchedule, activePipeline: string, workflowName: string) {
@@ -602,7 +634,7 @@ function _filterPipelineList(
   const pipelineCompositeTriggersEnabled = PipelineTriggersStore.getState().triggers
     .pipelineCompositeTriggersEnabled;
 
-  const pipelineList = appsList.filter((app) => {
+  const pipelineList = appsList.map((app) => {
     const isWorkflow = GLOBALS.programType[app.artifact.name] === WORKFLOW_TYPE;
 
     const isCurrentNamespace =
@@ -610,9 +642,13 @@ function _filterPipelineList(
 
     const isNotExistingTrigger = triggersPipelineName.indexOf(app.name) === -1;
 
-    return (
-      isWorkflow && isCurrentNamespace && (pipelineCompositeTriggersEnabled || isNotExistingTrigger)
-    );
+    return {
+      ...app,
+      isEnabledForTriggers:
+        isWorkflow &&
+        isCurrentNamespace &&
+        (pipelineCompositeTriggersEnabled || isNotExistingTrigger),
+    };
   });
 
   return pipelineList;
@@ -659,3 +695,85 @@ function _transformSchedule(existingSchedules: ISchedule[]) {
 
   return [...transformedSchedules, ...enabledCompositeTriggers];
 }
+
+export const updatePageSize = (payload: number = DEFAULT_PAGE_SIZE) => {
+  PipelineTriggersStore.dispatch({
+    type: PipelineTriggersActions.setPageSize,
+    payload,
+  });
+  // if pageSize changes move to the first page,
+  // to preserve consistency of pagination
+  updateCurrentPage(0);
+};
+
+export const updateCurrentPage = (payload: number) => {
+  PipelineTriggersStore.dispatch({
+    type: PipelineTriggersActions.setCurrentPage,
+    payload,
+  });
+  markViewStale();
+};
+
+const setNextPageToken = (currentPage: number, nextPageToken?: string) => {
+  PipelineTriggersStore.dispatch({
+    type: PipelineTriggersActions.setPageToken,
+    payload: {
+      currentPage,
+      nextPageToken,
+    },
+  });
+};
+
+const getPageToken = (nextPageTokens: string[], pageNo: number = 0) => {
+  if (pageNo === 0) {
+    return undefined;
+  }
+
+  // as the pageToken for the current page is the nextPageToken of the previous
+  return nextPageTokens[pageNo - 1];
+};
+
+export const setLastRefreshTime = (payload?: string) => {
+  PipelineTriggersStore.dispatch({
+    type: PipelineTriggersActions.setLastRefreshTime,
+    payload,
+  });
+};
+
+export const markViewStale = () => {
+  PipelineTriggersStore.dispatch({
+    type: PipelineTriggersActions.markStale,
+  });
+};
+
+export const markViewReady = () => {
+  PipelineTriggersStore.dispatch({
+    type: PipelineTriggersActions.markReady,
+  });
+};
+
+export const isLastPipelinesPage = () => {
+  const { nextPageTokensList, currentPage } = PipelineTriggersStore.getState().triggers;
+  return !nextPageTokensList[currentPage];
+};
+
+const applySearch = () => {
+  PipelineTriggersStore.dispatch({
+    type: PipelineTriggersActions.applySearch,
+  });
+
+  updateCurrentPage(0);
+};
+
+const debouncedApplySearch = debounce(applySearch, 300);
+
+export const setNameFilter = (nameFilter: string) => {
+  PipelineTriggersStore.dispatch({
+    type: PipelineTriggersActions.setNameFilter,
+    payload: {
+      nameFilter,
+    },
+  });
+
+  debouncedApplySearch();
+};

--- a/app/cdap/components/PipelineTriggers/store/PipelineTriggersActions.ts
+++ b/app/cdap/components/PipelineTriggers/store/PipelineTriggersActions.ts
@@ -23,7 +23,8 @@ const PipelineTriggersActions = {
   setExpandedPipeline: 'TRIGGERS_SET_EXPANDED_PIPELINE',
   setExpandedSchedule: 'TRIGGERS_SET_EXPANDED_SCHEDULE',
   setExpandedInlineTrigger: 'TRIGGERS_SET_EXPANDED_INLINE_TRIGGER',
-  setTriggersAndPipelineList: 'TRIGGERS_SET_TRIGGERS_PIPELINE',
+  resetTriggers: 'TRIGGERS_RESET_TRIGGERS',
+  setPaginatedPipelineList: 'TRIGGERS_SET_PAGINATED_PIPELINE_LIST',
   setEnabledTriggerPipelineInfo: 'TRIGGERS_SET_PIPELINE_INFO',
   setEnabledTriggerInlinePipelineInfo: 'TRIGGERS_SET_INLINE_PIPELINE_INFO',
   setConfigureTriggerError: 'TRIGGERS_SET_CONFIGURE_ERROR',
@@ -32,6 +33,14 @@ const PipelineTriggersActions = {
   setTriggerType: 'TRIGGERS_SET_TYPE',
   reset: 'TRIGGERS_RESET',
   setMaxConcurrentRuns: 'TRIGGERS_SET_MAX_CONCURRENT_RUNS',
+  setPageSize: 'TRIGGERS_SET_PAGE_SIZE',
+  setCurrentPage: 'TRIGGERS_SET_CURRENT_PAGE',
+  setPageToken: 'TRIGGERS_SET_PAGE_TOKEN',
+  markStale: 'TRIGGERS_MARK_STATE',
+  setLastRefreshTime: 'TRIGGERS_SET_LAST_REFRESH_TIME',
+  setNameFilter: 'TRIGGERS_SET_NAME_FILTER',
+  applySearch: 'TRIGGERS_APPLY_SERACH',
+  markReady: 'TRIGGERS_MARK_READY',
 };
 
 export default PipelineTriggersActions;

--- a/app/cdap/components/PipelineTriggers/store/PipelineTriggersStore.ts
+++ b/app/cdap/components/PipelineTriggers/store/PipelineTriggersStore.ts
@@ -26,13 +26,14 @@ import {
 import PipelineTriggersTypes from 'components/PipelineTriggers/store/PipelineTriggersTypes';
 
 export const DEFAULT_TRIGGER_MAX_CONCURRENT_RUNS = 3;
+export const DEFAULT_PAGE_SIZE = 10;
 
 interface IPayLoad {
   pipelineName?: string;
   workflowName?: string;
   pipelineCompositeTriggersEnabled?: boolean;
   lifecycleManagementEditEnabled?: boolean;
-  pipelineList?: IPipelineInfo[];
+  paginatedPipelineList?: IPipelineInfo[][];
   selectedNamespace?: string;
   selectedTriggersType?: string;
   triggersGroupToAdd?: IProgramStatusTrigger[];
@@ -44,6 +45,12 @@ interface IPayLoad {
   expandedSchedule?: string;
   pipelineInfo?: IPipelineInfo;
   maxConcurrentRuns?: number;
+  pageSize?: number;
+  nextPageToken?: string;
+  currentPage?: number;
+  ready?: boolean;
+  lastRefreshTime?: string;
+  nameFilter?: string;
 }
 
 interface IAction {
@@ -57,7 +64,7 @@ const defaultAction: IAction = {
 };
 
 const defaultInitialState = {
-  pipelineList: [],
+  paginatedPipelineList: [],
   triggersGroupToAdd: [],
   selectedNamespace: '',
   selectedTriggersType: PipelineTriggersTypes.orType,
@@ -75,6 +82,11 @@ const defaultInitialState = {
   pipelineCompositeTriggersEnabled: false,
   lifecycleManagementEditEnabled: false,
   maxConcurrentRuns: DEFAULT_TRIGGER_MAX_CONCURRENT_RUNS,
+  currentPage: 0,
+  pageSize: DEFAULT_PAGE_SIZE,
+  nextPageTokensList: [],
+  ready: false,
+  nameFilter: '',
 };
 
 const defaultInitialEnabledTriggersState = {
@@ -82,6 +94,16 @@ const defaultInitialEnabledTriggersState = {
   pipelineInfo: null,
   disableError: null,
 };
+
+function updateNextPageToken(
+  nextPageTokensList: string[],
+  currentPage: number,
+  nextPageToken?: string
+): string[] {
+  const tokensDraft = [...nextPageTokensList];
+  tokensDraft[currentPage] = nextPageToken;
+  return tokensDraft;
+}
 
 const triggers = (state = defaultInitialState, action = defaultAction) => {
   let stateCopy;
@@ -99,10 +121,12 @@ const triggers = (state = defaultInitialState, action = defaultAction) => {
     case PipelineTriggersActions.changeNamespace:
       stateCopy = {
         ...state,
-        pipelineList: action.payload.pipelineList,
         selectedNamespace: action.payload.selectedNamespace,
         expandedPipeline: null,
         configureError: null,
+        nameFilter: '',
+        paginatedPipelineList: [],
+        nextPageTokensList: [],
       };
       break;
     case PipelineTriggersActions.setTriggerType:
@@ -133,12 +157,24 @@ const triggers = (state = defaultInitialState, action = defaultAction) => {
         configureError: null,
       };
       break;
-    case PipelineTriggersActions.setTriggersAndPipelineList:
+    case PipelineTriggersActions.resetTriggers:
       stateCopy = {
         ...state,
-        pipelineList: action.payload.pipelineList,
         enabledTriggers: action.payload.enabledTriggers,
         selectedNamespace: action.payload.selectedNamespace,
+        paginatedPipelineList: [],
+        expandedPipeline: null,
+        configureError: null,
+        ready: true,
+        currentPage: 0,
+        nextPageTokensList: [],
+      };
+      break;
+    case PipelineTriggersActions.setPaginatedPipelineList:
+      stateCopy = {
+        ...state,
+        paginatedPipelineList: action.payload.paginatedPipelineList,
+        ready: true,
         expandedPipeline: null,
         configureError: null,
       };
@@ -169,6 +205,60 @@ const triggers = (state = defaultInitialState, action = defaultAction) => {
         maxConcurrentRuns: action.payload.maxConcurrentRuns,
       };
       break;
+    case PipelineTriggersActions.setPageSize:
+      stateCopy = {
+        ...state,
+        pageSize: action.payload,
+        nextPageTokensList: [],
+        paginatedPipelineList: [],
+      };
+      break;
+    case PipelineTriggersActions.setCurrentPage:
+      stateCopy = {
+        ...state,
+        currentPage: action.payload,
+      };
+      break;
+    case PipelineTriggersActions.setPageToken:
+      stateCopy = {
+        ...state,
+        nextPageTokensList: updateNextPageToken(
+          state.nextPageTokensList,
+          action.payload.currentPage,
+          action.payload.nextPageToken
+        ),
+      };
+      break;
+    case PipelineTriggersActions.markStale:
+      stateCopy = {
+        ...state,
+        ready: false,
+      };
+      break;
+    case PipelineTriggersActions.markReady:
+      stateCopy = {
+        ...state,
+        ready: true,
+      };
+      break;
+    case PipelineTriggersActions.setNameFilter:
+      stateCopy = {
+        ...state,
+        nameFilter: action.payload.nameFilter,
+      };
+      break;
+    case PipelineTriggersActions.applySearch:
+      return {
+        ...state,
+        paginatedPipelineList: [],
+        nextPageTokensList: [],
+      };
+    case PipelineTriggersActions.setLastRefreshTime:
+      stateCopy = {
+        ...state,
+        lastRefreshTime: action.payload,
+      };
+      break;
     case PipelineTriggersActions.reset:
       return defaultInitialState;
     default:
@@ -189,7 +279,7 @@ const enabledTriggers = (state = defaultInitialEnabledTriggersState, action = de
         disableError: null,
       };
       break;
-    case PipelineTriggersActions.setTriggersAndPipelineList:
+    case PipelineTriggersActions.resetTriggers:
       stateCopy = {
         ...state,
         disableError: null,

--- a/app/cdap/components/PipelineTriggers/store/ScheduleTypes.ts
+++ b/app/cdap/components/PipelineTriggers/store/ScheduleTypes.ts
@@ -60,6 +60,11 @@ export interface ISchedule {
   isTransformed?: boolean;
 }
 
+export interface IPipelineListResponse {
+  applications: IPipelineInfo[];
+  nextPageToken?: string;
+}
+
 export interface IPipelineInfo {
   appVersion: string;
   artifact: IArtifactObj;
@@ -69,6 +74,7 @@ export interface IPipelineInfo {
   name: string;
   plugins: IPlugin[];
   programs: IProgramInfo[];
+  isEnabledForTriggers?: boolean;
 }
 
 interface IProgram {

--- a/app/cdap/testids/testids.yaml
+++ b/app/cdap/testids/testids.yaml
@@ -343,3 +343,9 @@ features:
       viewStageErrorButton: ~
     runLevel:
       currentRunIndex: ~
+  pipelineTriggers:
+    setTriggers:
+      pagination-back-btn: ~
+      pagination-next-btn: ~
+      pagination-select: ~
+      pipelines-container: ~

--- a/app/cdap/text/text-en.yaml
+++ b/app/cdap/text/text-en.yaml
@@ -2899,6 +2899,8 @@ features:
       triggerAndType: "Wait for all events (AND)"
       triggerOrType: "Trigger on any selected event (OR)"
       viewNamespace: View pipelines in namespace
+      pipelinesPaginationLabel: "Results {from} - {to}"
+      lastRefreshedAtLabel: Last refreshed at {datetime}
     viewPipeline: View Pipeline
     viewPipelineCapitalized: VIEW PIPELINE
   PreviewData:

--- a/src/e2e-test/features/pipeline.triggers.feature
+++ b/src/e2e-test/features/pipeline.triggers.feature
@@ -79,3 +79,30 @@ Feature: Pipeline Triggers
     Then Cleanup pipeline "trigger_test_pipeline_1"
     Then Cleanup pipeline "trigger_test_pipeline_2"
     Then Cleanup pipeline "trigger_test_pipeline_3"
+
+    @PIPELINE_TRIGGERS_TEST
+    Scenario: Deploy seven pipelines and check pagination on inbound triggers tab
+      When Deploy pipelines list with pipeline JSON file "pipeline_with_macros.json":
+        |trigger_test_pipeline_1|
+        |trigger_test_pipeline_2|
+        |trigger_test_pipeline_3|
+        |trigger_test_pipeline_4|
+        |trigger_test_pipeline_5|
+        |trigger_test_pipeline_6|
+        |trigger_test_pipeline_7|
+      Then Open inbound triggers and check pagination with pipelines:
+        |trigger_test_pipeline_1|
+        |trigger_test_pipeline_2|
+        |trigger_test_pipeline_3|
+        |trigger_test_pipeline_4|
+        |trigger_test_pipeline_5|
+        |trigger_test_pipeline_6|
+        |trigger_test_pipeline_7|
+      Then Cleanup pipelines list:
+        |trigger_test_pipeline_1|
+        |trigger_test_pipeline_2|
+        |trigger_test_pipeline_3|
+        |trigger_test_pipeline_4|
+        |trigger_test_pipeline_5|
+        |trigger_test_pipeline_6|
+        |trigger_test_pipeline_7|

--- a/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/CommonSteps.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/CommonSteps.java
@@ -38,6 +38,7 @@ import org.openqa.selenium.WindowType;
 import org.openqa.selenium.support.ui.Select;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.UUID;
 
 public class CommonSteps {
@@ -240,6 +241,13 @@ public class CommonSteps {
   @Then("Cleanup pipeline {string}")
   public void cleanupPipeline(String pipelineName) {
     Helper.cleanupPipelines(pipelineName);
+  }
+
+  @Then("Cleanup pipelines list:")
+  public void cleanupMultiplePipelines(List<String> pipelineNames) {
+    for (String pipelineName : pipelineNames) {
+      cleanupPipeline(pipelineName);
+    }
   }
 
   @Then("Visit pipeline {string}")

--- a/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/PipelineTriggers.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/PipelineTriggers.java
@@ -21,9 +21,12 @@ import io.cdap.e2e.utils.ElementHelper;
 import io.cdap.e2e.utils.SeleniumDriver;
 import io.cucumber.java.en.Then;
 import org.junit.Assert;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.Select;
+
+import java.util.List;
 
 
 public class PipelineTriggers {
@@ -34,6 +37,13 @@ public class PipelineTriggers {
   @Then("Deploy pipeline {string} with pipeline JSON file {string}")
   public void deployPipelineFromJson(String pipelineName, String pipelineJSONfile) {
     Helper.deployAndTestPipeline(pipelineJSONfile, pipelineName);
+  }
+
+  @Then("Deploy pipelines list with pipeline JSON file {string}:")
+  public void deployMultiplePipelineFromJson(String pipelineJSONfile, List<String> pipelineNames) {
+    for (String pipelineName : pipelineNames) {
+      deployPipelineFromJson(pipelineName, pipelineJSONfile);
+    }
   }
 
   @Then("Open inbound trigger and set and delete a simple trigger when {string} succeeds")
@@ -193,5 +203,63 @@ public class PipelineTriggers {
     Assert.assertFalse(Helper.isElementExists(
       Helper.getCssSelectorByDataTestId(crossArgMappingTriggerName + "-collapsed")));
     ElementHelper.clickOnElement(Helper.locateElementByTestId("inbound-triggers-toggle"));
+  }
+
+  @Then("Open inbound triggers and check pagination with pipelines:")
+  public void openInboundTriggerAndCheckPagination(List<String> totalPipelinesList) {
+    ElementHelper.clickOnElement(Helper.locateElementByTestId("inbound-triggers-toggle"));
+
+    changePageSizeAndVerify("25", totalPipelinesList.size());
+    changePageSizeAndVerify("5", totalPipelinesList.size());
+
+    if (totalPipelinesList.size() <= 5) {
+      return;
+    }
+    WebElement nextPageButtonIcon = Helper.locateElementByTestId(
+            "features-pipelineTriggers-setTriggers-pagination-next-btn");
+    if (nextPageButtonIcon.isEnabled()) {
+      nextPageButtonIcon.click();
+    }
+    checkFirstPipelineDisplayed(totalPipelinesList.get(5));
+
+    WebElement previousPageButtonIcon = Helper.locateElementByTestId(
+            "features-pipelineTriggers-setTriggers-pagination-back-btn");
+    if (previousPageButtonIcon.isEnabled()) {
+      previousPageButtonIcon.click();
+    }
+    checkFirstPipelineDisplayed(totalPipelinesList.get(0));
+  }
+
+  private void checkFirstPipelineDisplayed(String firstPipeline) {
+    String pipelinesContainerTestId = "features-pipelineTriggers-setTriggers-pipelines-container";
+    SeleniumDriver.getWaitDriver(3)
+            .until(ExpectedConditions.textToBePresentInElementLocated(
+                    By.xpath("//div[@data-testid='" + pipelinesContainerTestId + "']/div[1]"),
+                    firstPipeline
+            ));
+  }
+
+  private void changePageSizeAndVerify(String desiredPageSize, int totalPipelinesCount) {
+    WebElement rowsPerPageDropdown = Helper.locateElementByTestId(
+            "features-pipelineTriggers-setTriggers-pagination-select");
+    Select rowsPerPageSelect = new Select(rowsPerPageDropdown);
+    rowsPerPageSelect.selectByValue(desiredPageSize);
+
+    int expectedPipelinesCount = Math.min(Integer.parseInt(desiredPageSize), totalPipelinesCount);
+
+    String pipelinesContainerTestId = "features-pipelineTriggers-setTriggers-pipelines-container";
+    SeleniumDriver.getWaitDriver(3)
+            .until(ExpectedConditions.numberOfElementsToBe(
+                    By.xpath("//div[@data-testid='" + pipelinesContainerTestId + "']/div"),
+                    expectedPipelinesCount
+            ));
+
+    WebElement nextPageButtonIcon = Helper.locateElementByTestId(
+            "features-pipelineTriggers-setTriggers-pagination-next-btn");
+    if (expectedPipelinesCount < totalPipelinesCount) {
+      Assert.assertTrue(nextPageButtonIcon.isEnabled());
+    } else {
+      Assert.assertFalse(nextPageButtonIcon.isEnabled());
+    }
   }
 }


### PR DESCRIPTION
# Implement Pagination on Inbound Triggers Sidebar Pipelines List

## Description
Summary of changes

- Implemented MUI Pagination for the pipelines list in the inbound triggers sidebar of the pipeline details page. This feature internally invoke the getAllApps() function with pagination parameters, facilitating lazy and conditional loading of data onto the UI.
- Written a E2E test to check and verify whether the  UI and features such as pageSize, nextPage and previousPage of pagination are in sync with the api calls.

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [x] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-21195](https://cdap.atlassian.net/browse/CDAP-21195)

## Test Plan
- Should not cause regression on existing tests. 
- pipeline.triggers.feature > Scenario:  Deploy seven pipelines and check pagination on inbound triggers tab should pass.

## Screenshots
<img width="720" height="914" alt="Screenshot 2025-07-24 at 4 16 12 PM" src="https://github.com/user-attachments/assets/6d28358d-a00c-4ebd-a39e-a2ddbe4bb0c2" />




[CDAP-21195]: https://cdap.atlassian.net/browse/CDAP-21195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ