### PR TITLE
[CDAP-21194] Increase allowed pipeline size to 5MB

### DIFF
--- a/app/cdap/services/global-constants.js
+++ b/app/cdap/services/global-constants.js
@@ -32,7 +32,7 @@ MemoryUnits.KB = 1024 * MemoryUnits.Byte;
 MemoryUnits.MB = 1024 * MemoryUnits.KB;
 MemoryUnits.GB = 1024 * MemoryUnits.MB;
 
-const MIN_PIPELINE_SIZE_FOR_WARNING_BYTES = 2 * MemoryUnits.MB;
+const MIN_PIPELINE_SIZE_FOR_WARNING_BYTES = 5 * MemoryUnits.MB;
 
 const GLOBALS = {
   MemoryUnits,


### PR DESCRIPTION
# Increase allowed pipeline size to 5MB

## Description
Previously the limit to display a warning on pipeline size was 2MB, now we have updated it to 5MB.

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [x] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-21194](https://cdap.atlassian.net/browse/CDAP-21194)

## Test Plan
Existing tests should pass

## Screenshots
NA



[CDAP-21194]: https://cdap.atlassian.net/browse/CDAP-21194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ