### PR TITLE
Fix the case where runtime args for a trigger can be nullish

### DIFF
--- a/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/ScheduleRuntimeArgsActions.js
+++ b/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/ScheduleRuntimeArgsActions.js
@@ -141,6 +141,9 @@ function bulkSetArgMapping(argsArray) {
  * @returns all the args that belong to the triggering pipeline.
  */
 function filterPropertyMapping(args, triggeringPipelineInfo) {
+  if (!args) {
+    return [];
+  }
   return args.filter(
     (arg) =>
       !arg.pipeline ||


### PR DESCRIPTION
# Fix triggers runtimeargs modal, when args can be nullish

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: NA

## Test Plan
NA

## Screenshots
NA

