### PR TITLE
Fix the case where runtime args for a trigger can be nullish

### DIFF
--- a/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/ScheduleRuntimeArgsActions.js
+++ b/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/ScheduleRuntimeArgsActions.js
@@ -141,6 +141,9 @@ function bulkSetArgMapping(argsArray) {
  * @returns all the args that belong to the triggering pipeline.
  */
 function filterPropertyMapping(args, triggeringPipelineInfo) {
+  if (!args) {
+    return [];
+  }
   return args.filter(
     (arg) =>
       !arg.pipeline ||


### PR DESCRIPTION
# Cherrypick of #1360 from 6.10 where it was fixed first

## Description
Summary of changes

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [x] Cherry Pick

## Links
Jira: [Jira issue #](fill-in.org)

## Test Plan

## Screenshots


