### PR TITLE
[CDAP-21229] fix graphql latency

### DIFF
--- a/app/cdap/components/PipelineList/DeployedPipelineView/index.tsx
+++ b/app/cdap/components/PipelineList/DeployedPipelineView/index.tsx
@@ -94,7 +94,7 @@ const checkError = (error) => {
       } else {
         // Pick one of the leftover errors to show in the banner;
         const errs = Object.values(errorMap);
-        return errs ? errs[0][0] : 'Unknown error';
+        return errs?.[0]?.[0] ? errs[0][0] : 'Unknown error';
       }
     }
   }
@@ -156,7 +156,8 @@ const DeployedPipeline: React.FC = () => {
   );
   const { loading, error, data, refetch, networkStatus } = useQuery(QUERY, {
     errorPolicy: 'all',
-    fetchPolicy: 'no-cache',
+    fetchPolicy: 'cache-and-network',
+    nextFetchPolicy: 'cache-first',
     notifyOnNetworkStatusChange: true,
     variables: {
       nameFilter: search || undefined,

--- a/graphql/resolvers-common.js
+++ b/graphql/resolvers-common.js
@@ -43,6 +43,10 @@ export function requestPromiseWrapper(options, { auth: token, userIdProperty, us
     options.headers[userIdProperty] = userIdValue;
   }
 
+  if (!options.timeout) {
+    options.timeout = 5 * 60 * 1000; // 5mins
+  }
+
   return new Promise((resolve, reject) => {
     request(options, (err, response, body) => {
       const statusCode = response.statusCode;


### PR DESCRIPTION
# Improve perceived query latency in the Pipelines list page

## Description
+ Add 5min timeout for requests to the CDAP backends from the graphql server
+ Use `network-and-cache` fetch-policy and `cache-first` nextFetchPolicy in the Deployed Pipelines graphql query, this ensures that cache is used to load the page on subsequent navigations and then refresh the data in the background.
+ Fix an incorrect error handling in the deployed pipelines page, that used to cause errors like "can not read property of undefined, reading 0"

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-21229](https://cdap.atlassian.net/browse/CDAP-21229)

## Test Plan
N/A, it's an optimization, does not change any business logic

## Screenshots
N/A, no visible UI changes



[CDAP-21229]: https://cdap.atlassian.net/browse/CDAP-21229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ