### PR TITLE
[CDAP-21230] fetch triggers count as soon as the triggers panel loads

### DIFF
--- a/app/cdap/components/PipelineTriggers/index.tsx
+++ b/app/cdap/components/PipelineTriggers/index.tsx
@@ -82,6 +82,7 @@ const PipelineTriggers = ({
         lifecycleManagementEditEnabled,
       },
     });
+    fetchTriggersAndApps(pipelineName, GLOBALS.programId[pipelineType], namespace, true);
 
     return () => {
       if (sub) {
@@ -91,9 +92,9 @@ const PipelineTriggers = ({
   }, []);
 
   const onToggleSidebar = (isExpanded) => {
-    const enabledTriggers = PipelineTriggersStore.getState().triggers.enabledTriggers;
+    const { enabledTriggers, lastRefreshTime } = PipelineTriggersStore.getState().triggers;
 
-    if (isExpanded && enabledTriggers.length === 0) {
+    if (isExpanded && (enabledTriggers.length === 0 || !lastRefreshTime)) {
       fetchTriggersAndApps(pipelineName, GLOBALS.programId[pipelineType], namespace);
     }
     setTabText(isExpanded ? `${PREFIX}.expandedTabLabel` : `${PREFIX}.collapsedTabLabel`);

--- a/app/cdap/components/PipelineTriggers/store/PipelineTriggersActionCreator.ts
+++ b/app/cdap/components/PipelineTriggers/store/PipelineTriggersActionCreator.ts
@@ -496,7 +496,8 @@ export function validateTriggerMappping(
 export function fetchTriggersAndApps(
   pipeline: string,
   workflowName: string,
-  activeNamespace = null
+  activeNamespace = null,
+  skipFetchingPipelinesList = false
 ) {
   const namespace = NamespaceStore.getState().selectedNamespace;
   const activeNamespaceView =
@@ -521,8 +522,10 @@ export function fetchTriggersAndApps(
     });
 
     const lastRefreshTime = moment().format('DD/MM/YYYY HH:mm A');
-    setLastRefreshTime(lastRefreshTime);
-    fetchPipelinesList();
+    if (!skipFetchingPipelinesList) {
+      fetchPipelinesList();
+      setLastRefreshTime(lastRefreshTime);
+    }
   });
 }
 

--- a/src/e2e-test/features/pipeline.triggers.feature
+++ b/src/e2e-test/features/pipeline.triggers.feature
@@ -21,6 +21,22 @@ Feature: Pipeline Triggers
     Given No pipelines are deployed
 
   @PIPELINE_TRIGGERS_TEST
+  Scenario: Enabled triggers count in the inbound triggers panel should be correct
+    When Deploy pipeline "trigger_test_pipeline_1" with pipeline JSON file "pipeline_with_macros.json"
+    When Deploy pipeline "trigger_test_pipeline_2" with pipeline JSON file "pipeline_with_macros.json"
+    Then Verify inbound triggers count to be 0
+    Then Open inbound triggers and add a simple trigger with name "test_trigger_1" when pipeline "trigger_test_pipeline_1" succeeds
+    Then Verify inbound triggers count to be 1
+    Then Reload the page
+    Then Verify inbound triggers count to be 1
+    Then Open inbound triggers and delete trigger "test_trigger_1"
+    Then Verify inbound triggers count to be 0
+    Then Reload the page
+    Then Verify inbound triggers count to be 0
+    Then Cleanup pipeline "trigger_test_pipeline_1"
+    Then Cleanup pipeline "trigger_test_pipeline_2"
+
+  @PIPELINE_TRIGGERS_TEST
   Scenario: Deploy two pipelines and enable trigger for pipeline2 when pipeline1 succeeds with a simple trigger and disabling it
     When Deploy pipeline "trigger_test_pipeline_1" with pipeline JSON file "pipeline_with_macros.json"
     When Deploy pipeline "trigger_test_pipeline_2" with pipeline JSON file "pipeline_with_macros.json"

--- a/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/PipelineTriggers.java
+++ b/src/e2e-test/java/io/cdap/cdap/ui/stepsdesign/PipelineTriggers.java
@@ -27,7 +27,8 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.Select;
 
 import java.util.List;
-
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class PipelineTriggers {
   public static String simpleTriggerName = "simple_trigger_test";
@@ -63,6 +64,61 @@ public class PipelineTriggers {
     ElementHelper.clickOnElement(Helper.locateElementByTestId("Delete"));
     Assert.assertFalse(Helper.isElementExists(Helper.getCssSelectorByDataTestId(simpleTriggerName + "-collapsed")));
     ElementHelper.clickOnElement(Helper.locateElementByTestId("inbound-triggers-toggle"));
+  }
+
+  @Then("Open inbound triggers and add a simple trigger with name {string} when pipeline {string} succeeds")
+  public void openInboundTriggersAndAddASimpleTrigger(String triggerName, String sourcePipeline) {
+    ElementHelper.clickOnElement(Helper.locateElementByTestId("inbound-triggers-toggle"));
+    WebElement triggerNameInputField = Helper.locateElementByCssSelector(
+        Helper.getCssSelectorByDataTestId("trigger-name-text-field") + " input"
+    );
+    ElementHelper.clearElementValue(triggerNameInputField);
+    ElementHelper.sendKeys(triggerNameInputField, triggerName);
+    ElementHelper.clickOnElement(Helper.locateElementByTestId(sourcePipeline + "-enable-trigger-btn"));
+    ElementHelper.clickOnElement(Helper.locateElementByTestId("enable-group-trigger-btn"));
+    Helper.isElementExists(Helper.getCssSelectorByDataTestId(triggerName + "-collapsed"));
+    ElementHelper.clickOnElement(Helper.locateElementByTestId(triggerName + "-collapsed"));
+    Helper.isElementExists(Helper.getCssSelectorByDataTestId(triggerName + "-expanded"));
+    ElementHelper.clickOnElement(Helper.locateElementByTestId("inbound-triggers-toggle"));
+  }
+
+  @Then("Open inbound triggers and delete trigger {string}")
+  public void openInboundTriggersAndDeleteTrigger(String triggerName) {
+    ElementHelper.clickOnElement(Helper.locateElementByTestId("inbound-triggers-toggle"));
+    Helper.isElementExists(Helper.getCssSelectorByDataTestId(triggerName + "-collapsed"));
+    ElementHelper.clickOnElement(Helper.locateElementByTestId(triggerName + "-collapsed"));
+    Helper.isElementExists(Helper.getCssSelectorByDataTestId(triggerName + "-expanded"));
+    ElementHelper.clickOnElement(Helper.locateElementByTestId(triggerName + "-disable-trigger-btn"));
+    ElementHelper.clickOnElement(Helper.locateElementByTestId("Delete"));
+    Assert.assertFalse(Helper.isElementExists(Helper.getCssSelectorByDataTestId(triggerName + "-collapsed")));
+    ElementHelper.clickOnElement(Helper.locateElementByTestId("inbound-triggers-toggle"));
+  }
+
+  @Then("Verify inbound triggers count to be {int}")
+  public void verifyInboundTriggersCount(int count) throws InterruptedException {
+    Thread.sleep(3000);
+    WebElement triggersToggle = Helper.locateElementByTestId("inbound-triggers-toggle");
+    String toggleText = triggersToggle.getAttribute("innerText");
+    int actualCount = extractTriggersCount(toggleText);
+    Assert.assertEquals(count, actualCount);
+  }
+
+  private int extractTriggersCount(String toggleText) {
+    String regex = "Inbound triggers \\((\\d+)\\)";
+    Pattern pattern = Pattern.compile(regex);
+    Matcher matcher = pattern.matcher(toggleText);
+
+    if (matcher.find()) {
+      String extracted = matcher.group(1);
+      try {
+        int extractedNum = Integer.parseInt(extracted);
+        return extractedNum;
+      } catch (Exception e) {
+        return 0;
+      }
+    }
+    
+    return 0;
   }
 
   private WebElement getSourceRuntimeArgElement(int index) {


### PR DESCRIPTION
# fetch actual triggers count as soon as the triggers panel loads

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [CDAP-21230](https://cdap.atlassian.net/browse/CDAP-21230)

## Test Plan
Updated e2e-tests to check the initial load of triggers panel

## Screenshots
<img width="1920" height="955" alt="Screenshot 2026-02-17 at 11 15 10 AM" src="https://github.com/user-attachments/assets/f5eee04d-6c9c-4e56-a6fb-4a56e9d8936b" />




[CDAP-21230]: https://cdap.atlassian.net/browse/CDAP-21230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ