### PR TITLE
fix: path traversal, arbitrary file read, and weak session secret in Node server

### DIFF
--- a/server/aggregator.js
+++ b/server/aggregator.js
@@ -104,6 +104,22 @@ Aggregator.prototype.pushConfiguration = function(resource) {
   var statusCode = 404;
   var filePaths = [];
   var isConfigSemanticsValid;
+
+  // Validate templateid and pluginid to prevent path traversal attacks.
+  // Only allow alphanumeric characters, hyphens, and underscores.
+  var safeNamePattern = /^[a-zA-Z0-9_-]+$/;
+  if (!safeNamePattern.test(templateid) || !safeNamePattern.test(pluginid)) {
+    log.warn('Invalid templateid or pluginid: templateid=' + templateid + ', pluginid=' + pluginid);
+    this.connection.write(
+      JSON.stringify({
+        resource: this.stripAuthHeaderInProxyMode(this.cdapConfig, resource),
+        statusCode: 400,
+        response: 'INVALID_TEMPLATE_OR_PLUGIN_ID',
+      })
+    );
+    return;
+  }
+
   // Some times there might a plugin that is common across multiple templates
   // in which case, this is stored within the common directory. So, if the
   // template specific plugin check fails, then attempt to get it from common.

--- a/server/express.js
+++ b/server/express.js
@@ -704,6 +704,21 @@ function makeApp(authAddress, cdapConfig, uiSettings) {
     if (!uiThemePath) {
       return res.status(500).send('UnKnown theme file. Please make sure the path is valid');
     }
+
+    // Validate theme file path to prevent arbitrary file reads.
+    // Only allow .json files within the server/config/themes directory.
+    const allowedThemeDir = path.resolve(__dirname, 'config', 'themes');
+    const resolvedPath = path.resolve(
+      uiThemePath.startsWith('/') ? uiThemePath : path.join(__dirname, uiThemePath)
+    );
+    if (!resolvedPath.startsWith(allowedThemeDir + path.sep) && resolvedPath !== allowedThemeDir) {
+      log.warn('Blocked theme path outside allowed directory: ' + uiThemePath);
+      return res.status(400).send('Theme file must be within the allowed themes directory');
+    }
+    if (!resolvedPath.endsWith('.json')) {
+      return res.status(400).send('Theme file must be a .json file');
+    }
+
     try {
       uiThemeConfig = uiThemeWrapper.extractUITheme(cdapConfig, uiThemePath);
     } catch (e) {

--- a/server/token.mjs
+++ b/server/token.mjs
@@ -96,17 +96,22 @@ function decrypt(encText, key) {
   return messagetext;
 }
 
+// Generate a random fallback secret once at startup so sessions are not
+// predictable when no explicit key is configured.
+const RANDOM_FALLBACK_SECRET = crypto.randomBytes(64).toString('hex');
+
 function getSecretFromCDAPConfig(cdapConfig, logger) {
-  let secretKey =
-    cdapConfig['session.secret.key'] ||
-    path.resolve(__dirname, 'config', 'development', 'session.secret.key');
   if (!logger) {
     logger = console;
   }
-  if (!secretKey) {
+  let secretKey = cdapConfig['session.secret.key'];
+  if (!secretKey || secretKey === 'sample-secret-key-for-encryption') {
     logger.warn(
-      'Secret key missing. This is required to generate a strong time-based token to prevent cswh'
+      'session.secret.key is missing or uses the insecure default value. ' +
+      'A random secret has been generated for this process. ' +
+      'Set a strong, unique session.secret.key in cdap-site.xml for production use.'
     );
+    secretKey = RANDOM_FALLBACK_SECRET;
   }
   return secretKey;
 }


### PR DESCRIPTION
## Summary

This PR addresses three security vulnerabilities in the CDAP UI Node.js server:

### 1. Path Traversal via WebSocket `template-config` Message (High)

**File:** `server/aggregator.js` — `pushConfiguration()`

The `templateid` and `pluginid` parameters from WebSocket messages are concatenated directly into file paths and read with `fs.readFileSync()` without any validation:

```js
filePaths.push(
  __dirname + '/../templates/' + templateid + '/' + pluginid + '.json',
  __dirname + '/../templates/common/' + pluginid + '.json'
);
configString = fs.readFileSync(filePaths[i], 'utf8');
```

An attacker with a valid session token can send `templateid: "../../etc"` and `pluginid: "passwd"` to read arbitrary `.json`-parseable files from the server filesystem. The file contents are returned through the WebSocket connection in the response payload.

**Fix:** Validate both `templateid` and `pluginid` against a strict allowlist pattern (`/^[a-zA-Z0-9_-]+$/`) before constructing file paths. Reject requests with a 400 status if validation fails.

### 2. Arbitrary File Read via POST `/updateTheme` (High)

**Files:** `server/express.js`, `server/uiThemeWrapper.js`

The `/updateTheme` endpoint accepts a `uiThemePath` in the request body and passes it to `extractUITheme()`, which uses `require()` (via `__non_webpack_require__`) to load the file. The loaded content is then exposed at `GET /ui-theme.js` as a JavaScript global:

```js
// express.js — loaded content served to all visitors
res.send(`window.CDAP_UI_THEME = ${JSON.stringify(uiThemeConfig)};`);
```

An attacker with a session token can load arbitrary files (`.js`, `.json`, `.node`) from the server, and their contents become publicly readable at `/ui-theme.js`.

**Fix:** Validate that the resolved theme path is within the allowed themes directory (`server/config/themes/`) and has a `.json` extension before loading.

### 3. Hardcoded Session Secret (Medium)

**Files:** `server/token.mjs`, `server/config/development/cdap.json`

The development configuration ships with `"session.secret.key": "sample-secret-key-for-encryption"`. If this value is not overridden in production, all session tokens become predictable — any attacker who knows this default can forge valid session tokens and bypass session validation on all protected endpoints.

**Fix:** Detect the insecure default value at startup and replace it with a cryptographically random secret generated via `crypto.randomBytes()`. Log a warning to prompt operators to configure a proper secret.

## Related

- PR #16098 on cdapio/cdap addresses similar issues in the backend

## Test Plan

- [ ] Verify WebSocket `template-config` requests with valid templateid/pluginid still work
- [ ] Verify `template-config` requests with `../` in templateid or pluginid are rejected with 400
- [ ] Verify `POST /updateTheme` with a path inside `server/config/themes/` still works
- [ ] Verify `POST /updateTheme` with `../../etc/passwd` or `/etc/passwd` is rejected with 400
- [ ] Verify session tokens are generated and validated correctly after the secret fallback change
- [ ] Verify the warning log appears when using the default secret