### PR TITLE
Restrict UI theme file loader to JSON files under the theme config dir

### DIFF
--- a/server/uiThemeWrapper.js
+++ b/server/uiThemeWrapper.js
@@ -24,6 +24,63 @@ const CDAP_DIST_PATH = path.normalize(__dirname + '/../public/cdap_dist');
 const log = log4js.getLogger('default');
 const uiThemePropertyName = 'ui.theme.file';
 
+// Directories from which UI theme files are allowed to be loaded.
+// extractUITheme accepts a path from HTTP input (POST /updateTheme), so
+// the resolved theme file must stay inside one of these roots and must
+// be a .json file. This prevents the loader from pulling in files from
+// arbitrary locations and blocks non-JSON modules (which would otherwise
+// be executed by require()).
+const UI_THEME_ALLOWED_ROOTS = [
+  path.resolve(__dirname, 'config', 'themes'),
+  path.resolve(__dirname, '..', 'server', 'config', 'themes'),
+];
+
+function isPathInsideRoot(candidate, root) {
+  const relative = path.relative(root, candidate);
+  return (
+    relative === '' ||
+    (!relative.startsWith('..') && !path.isAbsolute(relative))
+  );
+}
+
+function resolveAllowedThemePath(uiThemePath) {
+  if (typeof uiThemePath !== 'string' || uiThemePath.length === 0) {
+    throw new Error('UI theme path is missing');
+  }
+  if (path.extname(uiThemePath).toLowerCase() !== '.json') {
+    throw new Error(`UI theme path must be a .json file: ${uiThemePath}`);
+  }
+
+  const candidates = [];
+  if (path.isAbsolute(uiThemePath)) {
+    candidates.push(path.resolve(uiThemePath));
+  } else {
+    candidates.push(path.resolve(__dirname, uiThemePath));
+    if (uiThemePath.startsWith('server') && __dirname.endsWith('server')) {
+      candidates.push(path.resolve(__dirname, '..', uiThemePath));
+    }
+    if (uiThemePath.startsWith('config') && !__dirname.endsWith('server')) {
+      candidates.push(path.resolve(__dirname, 'server', uiThemePath));
+    }
+  }
+
+  for (const resolved of candidates) {
+    for (const root of UI_THEME_ALLOWED_ROOTS) {
+      if (isPathInsideRoot(resolved, root)) {
+        return resolved;
+      }
+    }
+  }
+  throw new Error(
+    `UI theme path is not inside an allowed theme directory: ${uiThemePath}`
+  );
+}
+
+function loadThemeJsonFile(resolvedPath) {
+  const raw = fs.readFileSync(resolvedPath, 'utf8');
+  return JSON.parse(raw);
+}
+
 export function extractUIThemeWrapper(cdapConfig) {
   const uiThemePath = cdapConfig[uiThemePropertyName];
   return extractUITheme(cdapConfig, uiThemePath);
@@ -67,59 +124,22 @@ export function extractUITheme(cdapConfig, uiThemePath) {
     return mergeUIThemeWithConfig(cdapConfig, DEFAULT_CONFIG);
   }
 
-  let uiThemeConfig = DEFAULT_CONFIG;
-  // Absolute path
-  if (uiThemePath[0] === '/') {
-    try {
-      if (__non_webpack_require__.resolve(uiThemePath)) {
-        uiThemeConfig = __non_webpack_require__(uiThemePath);
-        log.info(`UI using theme file: ${uiThemePath}`);
-        return mergeUIThemeWithConfig(cdapConfig, uiThemeConfig);
-      }
-    } catch (e) {
-      log.info('UI Theme file not found at: ', uiThemePath);
-      throw e;
-    }
+  let resolvedThemePath;
+  try {
+    resolvedThemePath = resolveAllowedThemePath(uiThemePath);
+  } catch (e) {
+    log.info(`UI theme path rejected: ${e.message}`);
+    throw e;
   }
-  // Relative path
 
-  {
-    let themePath;
-
-    try {
-      /**
-       * Two paths
-       * theme file path : config/themes/light.json | server/config/themes/light.json
-       * __dirname: <cdap-home>/ui | <cdap-home/ui/server
-       *
-       * The configs exists in <cdap-home>/ui/sever/config/themes/*.json
-       *
-       */
-      themePath = uiThemePath;
-      if (uiThemePath.startsWith('server') && __dirname.endsWith('server')) {
-        themePath = path.join('..', uiThemePath);
-      }
-
-      if (uiThemePath.startsWith('config') && !__dirname.endsWith('server')) {
-        themePath = path.join('server', uiThemePath);
-      }
-      themePath = path.join(__dirname, themePath);
-
-      if (__non_webpack_require__.resolve(themePath)) {
-        uiThemeConfig = __non_webpack_require__(themePath);
-        log.info(`UI using theme file: ${themePath}`);
-        return mergeUIThemeWithConfig(cdapConfig, uiThemeConfig);
-      }
-    } catch (e) {
-      // This will show the user what the full path is.
-      // This should help them give proper relative path
-      log.info('UI Theme file not found at: ', themePath);
-
-      console.log('e', e);
-      throw e;
-    }
+  try {
+    const uiThemeConfig = loadThemeJsonFile(resolvedThemePath);
+    log.info(`UI using theme file: ${resolvedThemePath}`);
+    return mergeUIThemeWithConfig(cdapConfig, uiThemeConfig);
+  } catch (e) {
+    log.info('UI Theme file not found or not valid JSON at: ', resolvedThemePath);
+    throw e;
   }
-  return mergeUIThemeWithConfig(cdapConfig, uiThemeConfig);
 }
 
 export function getFaviconPath(uiThemeConfig) {


### PR DESCRIPTION
## Summary

`server/uiThemeWrapper.js` currently loads the UI theme file by passing the caller-supplied path straight to `__non_webpack_require__`. The `POST /updateTheme` handler in `server/express.js` feeds this function a path taken from the request body, so the effective contract is "load any file reachable by `require()` and expose its contents to the UI through `window.CDAP_UI_THEME`".

This PR narrows that contract:

- **Allowlist the theme directory.** A new `resolveAllowedThemePath()` helper canonicalises the supplied path (keeping the existing `server/` and `config/` relative-path shortcuts) and refuses to return anything that does not resolve to a location inside one of the UI theme config directories.
- **Require a `.json` extension.** The resolver rejects paths with any other extension, so the loader can no longer be pointed at a `.js` module.
- **Switch from `require()` to `fs.readFileSync` + `JSON.parse`.** Even if the allowlist check were ever weakened, the loaded file is no longer executed as a Node module.

The exported `extractUITheme(cdapConfig, uiThemePath)` signature and return shape are unchanged; the two existing callers (`extractUIThemeWrapper` and the `/updateTheme` express handler) continue to work with the legitimate theme paths shipped in `server/config/themes/` (`default.json`, `light.json`).

## Testing

I exercised the new resolver in isolation against the server's `config/themes` directory and confirmed:

| Input | Expected | Actual |
|---|---|---|
| `config/themes/light.json` | accept | accepted |
| absolute path under `server/config/themes/` | accept | accepted |
| `../../../etc/passwd` | reject | rejected (not .json) |
| `/etc/cdap/conf/cdap-site.json` | reject | rejected (outside allowed root) |
| `config/themes/evil.js` | reject | rejected (extension) |
| `config/themes/../../etc/passwd.json` | reject | rejected (outside allowed root after resolve) |
| `''` | reject | rejected (missing) |

`default.json` and `light.json` continue to load identically to the previous implementation.