### PR TITLE
Allowlist request options forwarded from the WebSocket handler

### DIFF
--- a/server/aggregator.js
+++ b/server/aggregator.js
@@ -91,6 +91,47 @@ Aggregator.prototype.validateSession = function(message) {
   return true;
 };
 
+// Fields that the WebSocket client is allowed to forward into the
+// request library's options object. The resource received from the
+// client is otherwise attacker-controllable, and the request library
+// recognises a number of fields (proxy, tunnel, auth, cert, key, ca,
+// pfx, agent, agentOptions, baseUrl, strictSSL, rejectUnauthorized,
+// pool, localAddress, har, aws, oauth, hawk, httpSignature, ...) that
+// we do not want the client to be able to set — especially not after
+// the server has already injected its own Authorization header into
+// resource.headers.
+var REQUEST_OPTION_ALLOWLIST = [
+  'method',
+  'url',
+  'uri',
+  'headers',
+  'body',
+  'json',
+  'form',
+  'formData',
+  'multipart',
+  'qs',
+  'qsStringifyOptions',
+  'useQuerystring',
+  'encoding',
+  'gzip',
+  'timeout',
+  'followRedirect',
+  'followAllRedirects',
+  'maxRedirects',
+];
+
+function buildSafeRequestOptions(resource) {
+  var safe = {};
+  for (var i = 0; i < REQUEST_OPTION_ALLOWLIST.length; i++) {
+    var key = REQUEST_OPTION_ALLOWLIST[i];
+    if (Object.prototype.hasOwnProperty.call(resource, key)) {
+      safe[key] = resource[key];
+    }
+  }
+  return safe;
+}
+
 /**
  * Pushes the ETL Application configuration for templates and plugins to the
  * FE. These configurations are UI specific and hences need to be supported
@@ -333,7 +374,7 @@ function onSocketData(message) {
           r.headers[this.cdapConfig['security.authentication.proxy.user.identity.header']] = this.connection.userid;
         }
         log.debug('[REQUEST]: (method: ' + r.method + ', id: ' + r.id + ', url: ' + r.url + ')');
-        request(r, emitResponse.bind(this, r)).on('error', function(err) {
+        request(buildSafeRequestOptions(r), emitResponse.bind(this, r)).on('error', function(err) {
           log.error('[ERROR]: (url: ' + r.url + ') ' + err.message);
         });
         break;


### PR DESCRIPTION
## Summary

The `'request'` action inside `Aggregator#onSocketData` currently forwards the entire client-supplied `resource` object straight into the `request` HTTP library:

```js
r.headers.Authorization = this.connection.authToken;
r.headers[this.cdapConfig['security.authentication.proxy.user.identity.header']] = this.connection.userid;
...
request(r, emitResponse.bind(this, r))
```

Because the server first injects its own `Authorization` header (and, in proxy mode, a user-identity header) into `r.headers`, every field that happens to sit on `r` becomes a client-controllable option on an outbound request that is already carrying server credentials. The `request` library recognises several options the WebSocket client has no business setting:

- `proxy`, `tunnel`
- `auth`
- `cert`, `key`, `ca`, `pfx`
- `agent`, `agentOptions`
- `baseUrl`
- `strictSSL`, `rejectUnauthorized`
- `pool`, `localAddress`
- `har`, `aws`, `oauth`, `hawk`, `httpSignature`

## Changes

- Add `REQUEST_OPTION_ALLOWLIST` and `buildSafeRequestOptions(resource)` in `server/aggregator.js`. The helper copies only a fixed set of fields — `method`, `url`/`uri`, `headers`, `body`/`json`/`form`/`formData`/`multipart`, `qs`/`qsStringifyOptions`/`useQuerystring`, `encoding`, `gzip`, `timeout`, `followRedirect`/`followAllRedirects`/`maxRedirects` — onto a fresh object, so unknown/dangerous fields are dropped before they reach `request()`.
- The `'request'` case now calls `request(buildSafeRequestOptions(r), ...)`. The original `r` continues to be bound into `emitResponse`, so fields consumed on the response side (`id`, `requestOrigin`, `startTs`, etc.) are unaffected.

## Testing

Exercised `buildSafeRequestOptions` in isolation against an input that mixes legitimate fields with the full list of disallowed options. The resulting object contained only `method`, `url`, `headers`, and `body`; `proxy`, `auth`, `cert`, `agent`, `strictSSL`, `baseUrl`, `har`, `aws`, `oauth`, `hawk`, and the metadata fields (`id`, `requestOrigin`, `startTs`, `templateid`, `pluginid`) were all dropped.