### PR TITLE
build: skip GCP secret retrieval and e2e tests for fork PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,7 @@ jobs:
 
     - name: Get Secrets from GCP Secret Manager
       id: secrets
+      if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
       uses: 'google-github-actions/get-secretmanager-secrets@v2'
       with:
         secrets: |-
@@ -99,6 +100,7 @@ jobs:
         yarn run bower-root # Install Bower dependencies (deprecated in develop branch, will be removed in a future version)
 
     - name: Start CDAP-UI and run the tests
+      if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
       env:
         GCP_PROJECTID: ${{ steps.secrets.outputs.GCP_PROJECTID }}
         GCP_SERVICE_ACCOUNT_CONTENTS: ${{ steps.secrets.outputs.GCP_SERVICE_ACCOUNT_CONTENTS }}


### PR DESCRIPTION
The build workflow uses a self-hosted k8s runner that has ambient GCP workload identity. When a fork PR receives the `build` label, the workflow checks out the fork's code, then calls `get-secretmanager-secrets` to retrieve `CDAP_UI_E2E_GCP_SERVICE_ACCOUNT_CONTENTS` and `SCM_TEST_REPO_PAT` from Secret Manager — using the runner's ambient credentials, not a GitHub secret. The service account key is then written to `key_file.json` on disk before the fork-controlled build script runs.

This means a fork contributor whose PR gets labeled `build` can read GCP credentials and the SCM PAT from their own build script. Run `#22436281006` (head: `GnsP/cdap-ui`, a fork) shows the secret retrieval step completing successfully for an external contributor.

Fix: gate both the secret retrieval step and the test step on `head.repo.full_name == github.repository`. Fork PRs still run the build and unit test steps — only the GCP-backed e2e tests are skipped, since those require credentials that should not be accessible to unreviewed fork code.