### PR TITLE
Restrict /updateTheme to the configured theme file and harden market host verification

### DIFF
--- a/server/express.js
+++ b/server/express.js
@@ -704,6 +704,13 @@ function makeApp(authAddress, cdapConfig, uiSettings) {
     if (!uiThemePath) {
       return res.status(500).send('UnKnown theme file. Please make sure the path is valid');
     }
+    // Only allow (re)loading the theme file configured by the operator. Without
+    // this check, extractUITheme() would __non_webpack_require__() an arbitrary
+    // absolute path taken from the request body, letting a caller load any file
+    // on the server as a Node module.
+    if (uiThemePath !== cdapConfig['ui.theme.file']) {
+      return res.status(400).send('Invalid theme file path');
+    }
     try {
       uiThemeConfig = uiThemeWrapper.extractUITheme(cdapConfig, uiThemePath);
     } catch (e) {

--- a/server/url-helper.js
+++ b/server/url-helper.js
@@ -56,7 +56,30 @@ function extractMarketUrls(cdapConfig) {
 export const getMarketUrls = memoize(extractMarketUrls);
 
 export function isVerifiedMarketHost(cdapConfig, url) {
-  return !!getMarketUrls(cdapConfig).find((element) => url.startsWith(element));
+  // A naive `url.startsWith(element)` lets an attacker bypass the allowlist with
+  // origins such as `https://market.cdap.io.evil.com/...` or
+  // `https://market.cdap.io@evil.com/...`, turning the market proxy into an
+  // SSRF. Parse both URLs and require an exact origin match plus a path that is
+  // contained within the configured market base path.
+  let requested;
+  try {
+    requested = new URL(url);
+  } catch (e) {
+    return false;
+  }
+  return !!getMarketUrls(cdapConfig).find((element) => {
+    let base;
+    try {
+      base = new URL(element);
+    } catch (e) {
+      return false;
+    }
+    if (requested.origin !== base.origin) {
+      return false;
+    }
+    const basePath = base.pathname.endsWith('/') ? base.pathname : `${base.pathname}/`;
+    return requested.pathname === base.pathname || requested.pathname.startsWith(basePath);
+  });
 }
 
 export function constructUrl(cdapConfig, path, origin = REQUEST_ORIGIN_ROUTER) {

--- a/server/url-helper.js
+++ b/server/url-helper.js
@@ -55,6 +55,29 @@ function extractMarketUrls(cdapConfig) {
 
 export const getMarketUrls = memoize(extractMarketUrls);
 
+// Cache of parsed market base URLs, keyed by the (memoized) array returned by
+// getMarketUrls so the configured URLs are only parsed once per config rather
+// than on every request.
+const parsedMarketUrlsCache = new WeakMap();
+
+function getParsedMarketUrls(cdapConfig) {
+  const marketUrls = getMarketUrls(cdapConfig);
+  let parsed = parsedMarketUrlsCache.get(marketUrls);
+  if (!parsed) {
+    parsed = marketUrls
+      .map((element) => {
+        try {
+          return new URL(element);
+        } catch (e) {
+          return null;
+        }
+      })
+      .filter((parsedUrl) => parsedUrl !== null);
+    parsedMarketUrlsCache.set(marketUrls, parsed);
+  }
+  return parsed;
+}
+
 export function isVerifiedMarketHost(cdapConfig, url) {
   // A naive `url.startsWith(element)` lets an attacker bypass the allowlist with
   // origins such as `https://market.cdap.io.evil.com/...` or
@@ -67,13 +90,7 @@ export function isVerifiedMarketHost(cdapConfig, url) {
   } catch (e) {
     return false;
   }
-  return !!getMarketUrls(cdapConfig).find((element) => {
-    let base;
-    try {
-      base = new URL(element);
-    } catch (e) {
-      return false;
-    }
+  return getParsedMarketUrls(cdapConfig).some((base) => {
     if (requested.origin !== base.origin) {
       return false;
     }


### PR DESCRIPTION
## 1. `/updateTheme`: arbitrary file load via `uiThemePath`

The `/updateTheme` handler reads `req.body.uiThemePath` and passes it to `uiThemeWrapper.extractUITheme()`, which for an absolute path calls `__non_webpack_require__(uiThemePath)` — loading any absolute path on the server as a Node module. The endpoint's only legitimate use is reloading the operator-configured theme.

**Fix:** reject any `uiThemePath` that does not exactly match the configured `ui.theme.file`. This preserves the reload-theme behavior while removing the arbitrary-`require` primitive.

## 2. `isVerifiedMarketHost`: allowlist bypass via `startsWith`

`isVerifiedMarketHost` validates a market URL with `url.startsWith(configuredMarketUrl)`. A prefix check is bypassable: with a host-only configured market URL, `https://market.example.com.evil.com/...` and `https://market.example.com@evil.com/...` both pass, letting the market proxy (`/market`, `/forwardMarketToCdap`) fetch an attacker-controlled host (server-side request forgery).

**Fix:** parse both the requested and configured URLs with `URL`, require an exact `origin` match, and require the requested path to be contained within the configured base path.
