### PR TITLE
Making agent: false for post calls in grapql

### DIFF
--- a/graphql/resolvers-common.js
+++ b/graphql/resolvers-common.js
@@ -28,6 +28,7 @@ export function getPOSTRequestOptions() {
   return {
     method: 'POST',
     json: true,
+    agent: false,
   };
 }
 


### PR DESCRIPTION
# TITLE

## Description
Summary of changes

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [Jira issue #](fill-in.org)

## Test Plan

Did 1000 calls to graphql for pipeline list page. = 100 % success 

## Screenshots

1. agent: false (Client-Side Socket Pool Override)
Default Behavior: By default, Node.js uses a global connection pool (http.globalAgent). When an HTTP request completes, the underlying TCP socket is kept open in memory and placed into a "free pool" so subsequent requests can reuse it.
What agent: false does: It instructs Node.js to completely bypass the Keep-Alive connection pool.
Every time a query (POST /runs) is dispatched, Node.js instantiates a brand-new net.Socket instance.
