### PR TITLE
upgrade nodejs to v22.22.3 and yarn to v1.22.22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,7 @@ jobs:
       with:
         repository: cdapio/cdap
         path: cdap
+        ref: ${{ github.event.inputs.branch || github.base_ref || github.ref_name }}
 
     - name: Get Secrets from GCP Secret Manager
       id: secrets

--- a/pom.xml
+++ b/pom.xml
@@ -242,8 +242,8 @@
                   <goal>install-node-and-yarn</goal>
                 </goals>
                 <configuration>
-                  <nodeVersion>v22.12.0</nodeVersion>
-                  <yarnVersion>v1.22.19</yarnVersion>
+                  <nodeVersion>v22.22.3</nodeVersion>
+                  <yarnVersion>v1.22.22</yarnVersion>
                 </configuration>
               </execution>
               <execution>
@@ -350,8 +350,8 @@
                   <goal>install-node-and-yarn</goal>
                 </goals>
                 <configuration>
-                  <nodeVersion>v22.12.0</nodeVersion>
-                  <yarnVersion>v1.7.0</yarnVersion>
+                  <nodeVersion>v22.22.3</nodeVersion>
+                  <yarnVersion>v1.22.22</yarnVersion>
                 </configuration>
               </execution>
               <execution>


### PR DESCRIPTION
# upgrade nodejs to v22.22.3 and yarn to v1.22.22

## Description
Summary of changes

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [x] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [Jira issue #](fill-in.org)

## Test Plan

## Screenshots


